### PR TITLE
DIV-3644 fix multiple cases exception handling (300)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/RetrieveCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/RetrieveCaseTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.divorce.util.RestUtil;
 import java.util.HashMap;
 import java.util.Map;
 
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static uk.gov.hmcts.reform.divorce.util.ResourceLoader.loadJsonToObject;
 
@@ -56,6 +57,20 @@ public class RetrieveCaseTest extends CcdSubmissionSupport {
         assertEquals("AwaitingPayment", cosResponse.path(STATE_KEY));
         assertEquals(loadJsonToObject(PAYLOAD_CONTEXT_PATH + "divorce-session.json", Map.class),
             cosResponse.path(DATA_KEY));
+    }
+
+
+    @Test
+    public void givenMultipleSubmittedCaseInCcd_whenGetCase_thenReturn300() {
+        UserDetails userDetails = createCitizenUser();
+
+        submitCase("submit-complete-case.json", userDetails);
+        submitCase("submit-complete-case.json", userDetails);
+
+        Response cosResponse = retrieveCase(userDetails.getAuthToken());
+
+        assertEquals(HttpStatus.MULTIPLE_CHOICES.value(), cosResponse.getStatusCode());
+        assertEquals(cosResponse.getBody().asString(), "");
     }
 
     private Response retrieveCase(String userToken) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
@@ -231,7 +231,7 @@ public class OrchestrationController {
         @ApiResponse(code = 200, message = "Case details fetched successfully",
             response = CaseDataResponse.class),
         @ApiResponse(code = 300, message = "Multiple Cases"),
-        @ApiResponse(code = 400, message = "No Case found"),
+        @ApiResponse(code = 404, message = "No Case found"),
         @ApiResponse(code = 400, message = "Bad Request")
         })
     public ResponseEntity<CaseDataResponse> retrieveCase(

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandler.java
@@ -56,6 +56,10 @@ class GlobalExceptionHandler {
     }
 
     private ResponseEntity<Object> handleFeignException(FeignException exception) {
+        int status = exception.status();
+        if (status == HttpStatus.MULTIPLE_CHOICES.value()) {
+            return ResponseEntity.status(exception.status()).body(null);
+        }
         return ResponseEntity.status(exception.status()).body(exception.getMessage());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandler.java
@@ -11,8 +11,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.exception.CaseNotF
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
-import java.util.Optional;
-
 @ControllerAdvice
 @Slf4j
 class GlobalExceptionHandler {
@@ -58,9 +56,10 @@ class GlobalExceptionHandler {
     }
 
     private ResponseEntity<Object> handleFeignException(FeignException exception) {
-        return Optional.of(exception.status())
-            .filter(i -> i == 300)
-            .map(status -> ResponseEntity.status(exception.status()).body(null))
-            .orElse(ResponseEntity.status(exception.status()).body(exception.getMessage()));
+        int status = exception.status();
+        if (status == HttpStatus.MULTIPLE_CHOICES.value()) {
+            return ResponseEntity.status(exception.status()).body(null);
+        }
+        return ResponseEntity.status(exception.status()).body(exception.getMessage());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.exception.CaseNotF
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
+import java.util.Optional;
+
 @ControllerAdvice
 @Slf4j
 class GlobalExceptionHandler {
@@ -56,10 +58,9 @@ class GlobalExceptionHandler {
     }
 
     private ResponseEntity<Object> handleFeignException(FeignException exception) {
-        int status = exception.status();
-        if (status == HttpStatus.MULTIPLE_CHOICES.value()) {
-            return ResponseEntity.status(exception.status()).body(null);
-        }
-        return ResponseEntity.status(exception.status()).body(exception.getMessage());
+        return Optional.of(exception.status())
+            .filter(i -> i == 300)
+            .map(status -> ResponseEntity.status(exception.status()).body(null))
+            .orElse(ResponseEntity.status(exception.status()).body(exception.getMessage()));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -280,10 +279,8 @@ public class OrchestrationControllerTest {
         when(caseOrchestrationService.getCase(AUTH_TOKEN))
             .thenThrow(new WorkflowException("error"));
 
-        ResponseEntity<CaseDataResponse> response = classUnderTest.retrieveCase(AUTH_TOKEN);
+        classUnderTest.retrieveCase(AUTH_TOKEN);
 
-        assertEquals(HttpStatus.MULTIPLE_CHOICES, response.getStatusCode());
-        assertNull(response.getBody());
         verify(caseOrchestrationService).getCase(AUTH_TOKEN);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
@@ -241,8 +241,6 @@ public class OrchestrationControllerTest {
             .thenThrow(new WorkflowException("error"));
 
         classUnderTest.retrieveAosCase(AUTH_TOKEN, TEST_CHECK_CCD);
-
-        verify(caseOrchestrationService).retrieveAosCase(TEST_CHECK_CCD, AUTH_TOKEN);
     }
 
     @Test
@@ -280,8 +278,6 @@ public class OrchestrationControllerTest {
             .thenThrow(new WorkflowException("error"));
 
         classUnderTest.retrieveCase(AUTH_TOKEN);
-
-        verify(caseOrchestrationService).getCase(AUTH_TOKEN);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DocumentLink;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.validation.ValidationResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.CaseOrchestrationService;
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -271,6 +273,18 @@ public class OrchestrationControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(caseDataResponse, response.getBody());
 
+        verify(caseOrchestrationService).getCase(AUTH_TOKEN);
+    }
+
+    @Test(expected = WorkflowException.class)
+    public void givenMultipleCases_whenGetCase_thenReturnExpectedResponse() throws WorkflowException {
+        when(caseOrchestrationService.getCase(AUTH_TOKEN))
+            .thenThrow(new WorkflowException("error"));
+
+        ResponseEntity<CaseDataResponse> response = classUnderTest.retrieveCase(AUTH_TOKEN);
+
+        assertEquals(HttpStatus.MULTIPLE_CHOICES, response.getStatusCode());
+        assertNull(response.getBody());
         verify(caseOrchestrationService).getCase(AUTH_TOKEN);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
@@ -273,7 +273,7 @@ public class OrchestrationControllerTest {
     }
 
     @Test(expected = WorkflowException.class)
-    public void givenMultipleCases_whenGetCase_thenReturnExpectedResponse() throws WorkflowException {
+    public void givenThrowsException_whenGetCase_thenReturnExpectedResponse() throws WorkflowException {
         when(caseOrchestrationService.getCase(AUTH_TOKEN))
             .thenThrow(new WorkflowException("error"));
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandlerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/helper/GlobalExceptionHandlerUTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -50,6 +51,18 @@ public class GlobalExceptionHandlerUTest {
 
         assertEquals(STATUS_CODE, actual.getStatusCodeValue());
         assertEquals(TEST_ERROR, actual.getBody());
+    }
+
+    @Test
+    public void givenCauseForMultiCases_whenHandleWorkFlowException_thenReturnFeignStatus() {
+        final FeignException feignException = getMultiFeignException();
+
+        final WorkflowException workflowException = new WorkflowException("", feignException);
+
+        ResponseEntity<Object> actual = classUnderTest.handleWorkFlowException(workflowException);
+
+        assertEquals(HttpStatus.MULTIPLE_CHOICES.value(), actual.getStatusCodeValue());
+        assertNull(actual.getBody());
     }
 
     @Test
@@ -126,6 +139,14 @@ public class GlobalExceptionHandlerUTest {
 
         when(feignException.status()).thenReturn(GlobalExceptionHandlerUTest.STATUS_CODE);
         when(feignException.getMessage()).thenReturn(TEST_ERROR);
+        return feignException;
+    }
+
+    private FeignException getMultiFeignException() {
+        final FeignException feignException = mock(FeignException.class);
+
+        when(feignException.status()).thenReturn(HttpStatus.MULTIPLE_CHOICES.value());
+        when(feignException.getMessage()).thenReturn("");
         return feignException;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrieveCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrieveCaseITest.java
@@ -113,6 +113,18 @@ public class RetrieveCaseITest {
     }
 
     @Test
+    public void givenMultipleCases_whenGetCase_thenPropagateException() throws Exception {
+        stubGetMultipleCaseFromCMS();
+
+        webClient.perform(get(API_URL)
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .param(CHECK_CCD, String.valueOf(TEST_CHECK_CCD))
+            .accept(APPLICATION_JSON))
+            .andExpect(status().isMultipleChoices())
+            .andExpect(content().string(""));
+    }
+
+    @Test
     public void givenAllGoesWellProceedAsExpected_whenGetCase_thenPropagateException() throws Exception {
         stubGetCaseFromCMS(CASE_DETAILS);
 
@@ -134,6 +146,10 @@ public class RetrieveCaseITest {
 
     private void stubGetCaseFromCMS(CaseDetails caseDetails) {
         stubGetCaseFromCMS(HttpStatus.OK, convertObjectToJsonString(caseDetails));
+    }
+
+    private void stubGetMultipleCaseFromCMS() {
+        stubGetCaseFromCMS(HttpStatus.MULTIPLE_CHOICES, "");
     }
 
     private void stubGetCaseFromCMS(HttpStatus status, String message) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrieveCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrieveCaseITest.java
@@ -148,17 +148,17 @@ public class RetrieveCaseITest {
         stubGetCaseFromCMS(HttpStatus.OK, convertObjectToJsonString(caseDetails));
     }
 
-    private void stubGetMultipleCaseFromCMS() {
-        stubGetCaseFromCMS(HttpStatus.MULTIPLE_CHOICES, "");
-    }
-
     private void stubGetCaseFromCMS(HttpStatus status, String message) {
         maintenanceServiceServer.stubFor(WireMock.get(GET_CASE_CONTEXT_PATH)
-            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-            .willReturn(aResponse()
-                .withStatus(status.value())
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                .withBody(message)));
+                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+                .willReturn(aResponse()
+                        .withStatus(status.value())
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withBody(message)));
+    }
+
+    private void stubGetMultipleCaseFromCMS() {
+        stubGetCaseFromCMS(HttpStatus.MULTIPLE_CHOICES, "");
     }
 
     private void stubFormatterServerEndpoint() {


### PR DESCRIPTION
# Description

Prevents an issue where raw string is appending to body of HTTP response when header is set to `application/json`. Added case for 300 (duplicates) HTTP status to ensure body is empty and doesn't cause issues for clients.

Fixes # DIV-3644

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Integration / unit tests

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
