### PR TITLE
(Don't merge) DIV-3719 - don't set dueDate to null if AOS response is non-defended

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitAosCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitAosCaseTest.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.hmcts.reform.divorce.util.ResourceLoader.loadJson;
@@ -23,6 +22,7 @@ import static uk.gov.hmcts.reform.divorce.util.ResourceLoader.loadJson;
 public class SubmitAosCaseTest extends CcdSubmissionSupport {
     private static final String PAYLOAD_CONTEXT_PATH = "fixtures/maintenance/submit-aos/";
     private static final String TEST_AOS_STARTED_EVENT_ID = "testAosStarted";
+    private static final String AOS_INITIAL_DUE_DATE = "2018-10-30";
     private static final String AOS_RECEIVED_DATE = "2018-10-22";
     private static final String CCD_DATE_FORMAT = "yyyy-MM-dd";
     private static final String CCD_DUE_DATE = "dueDate";
@@ -139,7 +139,7 @@ public class SubmitAosCaseTest extends CcdSubmissionSupport {
             String dueDate = new LocalDate(AOS_RECEIVED_DATE).plusDays(daysToRespond).toString(CCD_DATE_FORMAT);
             assertEquals(dueDate, caseDetails.getData().get(CCD_DUE_DATE));
         } else {
-            assertNull(caseDetails.getData().get(CCD_DUE_DATE));
+            assertEquals(AOS_INITIAL_DUE_DATE, caseDetails.getData().get(CCD_DUE_DATE));
         }
     }
 }

--- a/src/integrationTest/resources/fixtures/issue-petition/submit-complete-case.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/submit-complete-case.json
@@ -96,5 +96,6 @@
   "D8InferredPetitionerGender":"female",
   "D8InferredRespondentGender":"male",
   "ReceivedAOSfromRespDate": "2018-10-22",
-  "ReceivedAOSfromResp": "YES"
+  "ReceivedAOSfromResp": "YES",
+  "dueDate": "2018-10-30"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCase.java
@@ -39,13 +39,11 @@ public class SubmitAosCase implements Task<Map<String, Object>> {
     public Map<String, Object> execute(TaskContext context, Map<String, Object> submissionData) {
         String authToken = (String) context.getTransientObject(AUTH_TOKEN_JSON_KEY);
         String eventId = getAosCompleteEventId(authToken, submissionData);
-        String dueDate = null;
 
         if (AWAITING_ANSWER_AOS_EVENT_ID.equals(eventId)) {
-            dueDate = getAosDueDate(authToken);
+            String dueDate = getAosDueDate(authToken);
+            submissionData.put(CCD_DUE_DATE, dueDate);
         }
-
-        submissionData.put(CCD_DUE_DATE, dueDate);
 
         Map<String, Object> updateCase = caseMaintenanceClient.updateCase(
             authToken,

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitAosCaseITest.java
@@ -63,16 +63,20 @@ public class SubmitAosCaseITest {
     private static final String UPDATE_CONTEXT_PATH = "/casemaintenance/version/1/updateCase/" + TEST_CASE_ID + "/";
     private static final String RETRIEVE_AOS_CASE_CONTEXT_PATH = "/casemaintenance/version/1/retrieveAosCase";
 
+    private static final String AOS_INITIAL_DUE_DATE = "2018-10-30";
     private static final String AOS_RESPONSE_DATE = "2018-10-22";
     private static final String AOS_DUE_DATE = "2018-11-12";
 
     private static final CaseDetails AOS_CASE_DETAILS =
         CaseDetails.builder()
             .caseData(
-                Collections.singletonMap(
-                    RECEIVED_AOS_FROM_RESP_DATE, AOS_RESPONSE_DATE
-                )
-            ).build();
+                Collections.unmodifiableMap(new HashMap<String, String>() {
+                    {
+                        put(RECEIVED_AOS_FROM_RESP_DATE, AOS_RESPONSE_DATE);
+                        put(CCD_DUE_DATE, AOS_INITIAL_DUE_DATE);
+                    }
+                }
+            )).build();
 
     @Autowired
     private MockMvc webClient;
@@ -240,7 +244,7 @@ public class SubmitAosCaseITest {
             caseData.put(CCD_DUE_DATE, AOS_DUE_DATE);
         } else {
             caseData.put(RESP_DEFENDS_DIVORCE_CCD_FIELD, NO_VALUE);
-            caseData.put(CCD_DUE_DATE, null);
+            caseData.put(CCD_DUE_DATE, AOS_INITIAL_DUE_DATE);
         }
 
         return caseData;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCaseUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCaseUTest.java
@@ -40,15 +40,19 @@ public class SubmitAosCaseUTest {
     private static final Map<String, Object> EXPECTED_OUTPUT = Collections.emptyMap();
     private static final Map<String, Object> CASE_UPDATE_RESPONSE = new HashMap<>();
     private static final TaskContext TASK_CONTEXT = new DefaultTaskContext();
+    private static final String AOS_INITIAL_DUE_DATE = "2018-10-30";
     private static final String AOS_RESPONSE_DATE = "2018-10-22";
     private static final String AOS_DUE_DATE = "2018-11-12";
 
     private static final CaseDetails AOS_CASE_DETAILS =
         CaseDetails.builder()
             .caseData(
-                Collections.singletonMap(
-                    RECEIVED_AOS_FROM_RESP_DATE, AOS_RESPONSE_DATE
-                )
+                Collections.unmodifiableMap(new HashMap<String, String>() {
+                    {
+                        put(RECEIVED_AOS_FROM_RESP_DATE, AOS_RESPONSE_DATE);
+                        put(CCD_DUE_DATE, AOS_INITIAL_DUE_DATE);
+                    }
+                })
             ).build();
 
     @Mock
@@ -152,7 +156,7 @@ public class SubmitAosCaseUTest {
             caseData.put(CCD_DUE_DATE, AOS_DUE_DATE);
         } else {
             caseData.put(RESP_DEFENDS_DIVORCE_CCD_FIELD, NO_VALUE);
-            caseData.put(CCD_DUE_DATE, null);
+            caseData.put(CCD_DUE_DATE, AOS_INITIAL_DUE_DATE);
         }
 
         return caseData;


### PR DESCRIPTION
# Description

dueDate should only be overridden when event is aosSubmittedDefended
Otherwise we leave it as it was

Fixes #DIV-3719

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
