### PR TITLE
Populate existing payments before updating

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
@@ -95,6 +95,14 @@ public interface CaseMaintenanceClient {
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken);
 
     @RequestMapping(
+            method = RequestMethod.GET,
+            value = "/casemaintenance/version/1/retrieveCaseById/{caseId}"
+    )
+    CaseDetails retrievePetitionById(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
+            @PathVariable("caseId") String caseId);
+
+    @RequestMapping(
             method = RequestMethod.DELETE,
             value = "/casemaintenance/version/1/drafts"
     )

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
@@ -96,7 +96,7 @@ public interface CaseMaintenanceClient {
 
     @RequestMapping(
             method = RequestMethod.GET,
-            value = "/casemaintenance/version/1/retrieveCaseById/{caseId}"
+            value = "/casemaintenance/version/1/case/{caseId}"
     )
     CaseDetails retrievePetitionById(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -59,6 +59,10 @@ public class OrchestrationConstants {
     public static final String CCD_DUE_DATE = "dueDate";
     public static final String D8_REASON_FOR_DIVORCE = "D8ReasonForDivorce";
     public static final String UNREASONABLE_BEHAVIOUR = "unreasonable-behaviour";
+    public static final String D_8_PAYMENTS = "Payments";
+
+    // Divorce Session
+    public static final String DIVORCE_SESSION_EXISTING_PAYMENTS = "existingPayments";
 
     public static final String ID = "id";
     public static final String PIN = "pin";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateExistingCollections.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateExistingCollections.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_EXISTING_PAYMENTS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PAYMENTS;
+
+@Component
+public class PopulateExistingCollections implements Task<Map<String, Object>> {
+
+    private final CaseMaintenanceClient caseMaintenanceClient;
+
+    @Autowired
+    public PopulateExistingCollections(CaseMaintenanceClient caseMaintenanceClient) {
+        this.caseMaintenanceClient = caseMaintenanceClient;
+    }
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> sessionData) {
+        CaseDetails cmsContent = caseMaintenanceClient
+                .retrievePetitionById(
+                        context.getTransientObject(AUTH_TOKEN_JSON_KEY).toString(),
+                        context.getTransientObject(CASE_ID_JSON_KEY).toString()
+                );
+
+        if (Objects.nonNull(cmsContent.getCaseData())) {
+            sessionData.put(DIVORCE_SESSION_EXISTING_PAYMENTS, cmsContent.getCaseData().get(D_8_PAYMENTS));
+        }
+
+        return sessionData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateToCCDWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateToCCDWorkflow.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkf
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToCaseData;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateExistingCollections;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
 import java.util.Map;
@@ -18,6 +19,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @Component
 public class UpdateToCCDWorkflow extends DefaultWorkflow<Map<String, Object>> {
+
+    @Autowired
+    private PopulateExistingCollections populateExistingCollections;
 
     @Autowired
     private FormatDivorceSessionToCaseData formatDivorceSessionToCaseData;
@@ -35,6 +39,7 @@ public class UpdateToCCDWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
         return this.execute(
             new Task[] {
+                populateExistingCollections,
                 formatDivorceSessionToCaseData,
                 updateCaseInCCD
             },

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateCaseTest.java
@@ -55,7 +55,7 @@ public class UpdateCaseTest {
     private static final String API_URL = String.format("/updateCase/%s", CASE_ID);
 
     private static final String RETRIEVE_CASE_CONTEXT_PATH = String.format(
-        "/casemaintenance/version/1/retrieveCaseById/%s",
+        "/casemaintenance/version/1/case/%s",
         CASE_ID
     );
     private static final String CCD_FORMAT_CONTEXT_PATH = "/caseformatter/version/1/to-ccd-format";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateCaseTest.java
@@ -54,6 +54,10 @@ public class UpdateCaseTest {
 
     private static final String API_URL = String.format("/updateCase/%s", CASE_ID);
 
+    private static final String RETRIEVE_CASE_CONTEXT_PATH = String.format(
+        "/casemaintenance/version/1/retrieveCaseById/%s",
+        CASE_ID
+    );
     private static final String CCD_FORMAT_CONTEXT_PATH = "/caseformatter/version/1/to-ccd-format";
     private static final String UPDATE_CONTEXT_PATH = String.format(
         "/casemaintenance/version/1/updateCase/%s/%s",
@@ -85,6 +89,7 @@ public class UpdateCaseTest {
     public void givenEventDataAndAuth_whenEventDataIsSubmitted_thenReturnSuccess() throws Exception {
         Map<String, Object> responseData = Collections.singletonMap(ID, TEST_CASE_ID);
 
+        stubMaintenanceServerEndpointForRetrieveCaseById();
         stubFormatterServerEndpoint();
         stubMaintenanceServerEndpointForUpdate(responseData);
 
@@ -118,6 +123,15 @@ public class UpdateCaseTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
+    }
+
+    private void stubMaintenanceServerEndpointForRetrieveCaseById() {
+        maintenanceServiceServer.stubFor(WireMock.get(RETRIEVE_CASE_CONTEXT_PATH)
+                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withBody(convertObjectToJsonString(caseData))));
     }
 
     private void stubFormatterServerEndpoint() {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateExistingCollectionsUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateExistingCollectionsUTest.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_EXISTING_PAYMENTS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PAYMENTS;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PopulateExistingCollectionsUTest {
+
+    @Mock
+    private CaseMaintenanceClient caseMaintenanceClient;
+
+    @InjectMocks
+    private PopulateExistingCollections target;
+
+    @Test
+    public void givenCaseIdWithCaseData_whenExecute_thenReturnUpdatedSession() {
+        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+
+        CollectionMember<Map<String, Object>> existingPayments = new CollectionMember<>();
+        existingPayments.setValue(Collections.EMPTY_MAP);
+
+        List<CollectionMember> payments = Collections.singletonList(existingPayments);
+
+        Map<String, Object> caseData = Collections.singletonMap(D_8_PAYMENTS, payments);
+
+        when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID))
+                .thenReturn(CaseDetails.builder().caseData(caseData).build());
+
+        Map<String, Object> session  = new HashMap<>();
+        Map<String, Object> expectedSession = Collections.singletonMap(DIVORCE_SESSION_EXISTING_PAYMENTS, payments);
+
+        assertEquals(expectedSession, target.execute(context, session));
+    }
+
+    @Test
+    public void givenCaseIdWithoutData_whenExecute_thenReturnSession() {
+        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+
+        when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID))
+                .thenReturn(CaseDetails.builder().caseId(TEST_CASE_ID).build());
+
+        Map<String, Object> session  = new HashMap<>();
+
+        assertEquals(session, target.execute(context, session));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateToCCDWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateToCCDWorkflowTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToCaseData;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateExistingCollections;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
 import java.util.Collections;
@@ -28,6 +29,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateToCCDWorkflowTest {
+
+    @Mock
+    private PopulateExistingCollections populateExistingCollections;
 
     @Mock
     private FormatDivorceSessionToCaseData formatDivorceSessionToCaseData;
@@ -59,11 +63,13 @@ public class UpdateToCCDWorkflowTest {
     public void runShouldExecuteTasksAndReturnPayload() throws Exception {
         Map<String, Object> resultData = Collections.singletonMap("Hello", "World");
 
+        when(populateExistingCollections.execute(context, testData)).thenReturn(testData);
         when(formatDivorceSessionToCaseData.execute(context, testData)).thenReturn(testData);
         when(updateCaseInCCD.execute(context, testData)).thenReturn(resultData);
 
         assertEquals(resultData, updateToCCDWorkflow.run(eventData, AUTH_TOKEN, TEST_CASE_ID));
 
+        verify(populateExistingCollections).execute(context, testData);
         verify(formatDivorceSessionToCaseData).execute(context, testData);
         verify(updateCaseInCCD).execute(context, testData);
     }


### PR DESCRIPTION
Adds a new task to the UpdateCcdCase workflow called PopulateExistingCollections.
Currently this retrieves a case from CCD with the passed in caseId and auth token. Then the existing payments list will be added to an existingPayments field on the divorceSession for the Mapper to handle when transforming the session.