### PR TITLE
Remove respondent permission in case update data fails

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
@@ -61,6 +61,15 @@ public interface CaseMaintenanceClient {
         @PathVariable("letterHolderId") String letterHolderId);
 
     @RequestMapping(
+            method = RequestMethod.DELETE,
+            value = "/casemaintenance/version/1/link-respondent/{caseId}",
+            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+    )
+    void unlinkRespondent(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
+            @PathVariable("caseId") String caseId);
+
+    @RequestMapping(
             method = RequestMethod.PUT,
             value = "/casemaintenance/version/1/drafts",
             headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -107,6 +107,7 @@ public class OrchestrationConstants {
     // Validation
     public static final String ERROR_STATUS = "error";
     public static final String FORM_ID = "case-progression";
+    public static final String UPDATE_REPONDENT_DATA_ERROR_KEY = "respondent.data.not.updated_Error";
     public static final String SOLICITOR_VALIDATION_ERROR_KEY
             = "uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateSolicitorCaseData_Error";
     public static final String VALIDATION_ERROR_KEY

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UnlinkRespondent.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UnlinkRespondent.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@Component
+public class UnlinkRespondent implements Task<UserDetails> {
+    private final CaseMaintenanceClient caseMaintenanceClient;
+
+    @Autowired
+    public UnlinkRespondent(CaseMaintenanceClient caseMaintenanceClient) {
+        this.caseMaintenanceClient = caseMaintenanceClient;
+    }
+
+    @Override
+    public UserDetails execute(TaskContext context, UserDetails payLoad) {
+        caseMaintenanceClient.unlinkRespondent(
+            String.valueOf(context.getTransientObject(AUTH_TOKEN_JSON_KEY)),
+            String.valueOf(context.getTransientObject(CASE_ID_JSON_KEY))
+        );
+
+        return payLoad;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/LinkRespondentWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/LinkRespondentWorkflow.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -9,37 +10,64 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.LinkRespondent;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.RetrievePinUserDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.UnlinkRespondent;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateRespondentDetails;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PIN;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.UPDATE_REPONDENT_DATA_ERROR_KEY;
 
 @Component
+@Slf4j
 public class LinkRespondentWorkflow extends DefaultWorkflow<UserDetails> {
     private final RetrievePinUserDetails retrievePinUserDetails;
     private final LinkRespondent linkRespondent;
     private final UpdateRespondentDetails updateRespondentDetails;
+    private final UnlinkRespondent unlinkRespondent;
 
     @Autowired
     public LinkRespondentWorkflow(RetrievePinUserDetails retrievePinUserDetails,
                                   LinkRespondent linkRespondent,
-                                  UpdateRespondentDetails updateRespondentDetails) {
+                                  UpdateRespondentDetails updateRespondentDetails,
+                                  UnlinkRespondent unlinkRespondent) {
         this.retrievePinUserDetails = retrievePinUserDetails;
         this.linkRespondent = linkRespondent;
         this.updateRespondentDetails = updateRespondentDetails;
+        this.unlinkRespondent = unlinkRespondent;
     }
 
     public UserDetails run(String authToken, String caseId, String pin) throws WorkflowException {
-        return this.execute(
-            new Task[] {
-                retrievePinUserDetails,
-                linkRespondent,
-                updateRespondentDetails
+        final UserDetails userDetail = UserDetails.builder().authToken(authToken).build();
+
+        try {
+            return this.execute(
+                new Task[]{
+                    retrievePinUserDetails,
+                    linkRespondent,
+                    updateRespondentDetails
+                },
+                userDetail,
+                ImmutablePair.of(PIN, pin),
+                ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
+                ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
+            );
+        } catch (WorkflowException e) {
+            if (this.errors().containsKey(UPDATE_REPONDENT_DATA_ERROR_KEY)) {
+                rollbackOperation(userDetail, caseId);
+            }
+            throw e;
+        }
+    }
+
+    private void rollbackOperation(UserDetails userDetail, String caseId) throws WorkflowException {
+        log.error("Can not link respondent for caseId {} and user {}", caseId, userDetail.getId());
+        this.execute(
+            new Task[]{
+                unlinkRespondent
             },
-            UserDetails.builder().authToken(authToken).build(),
-            ImmutablePair.of(PIN, pin),
-            ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
+            userDetail,
+            ImmutablePair.of(AUTH_TOKEN_JSON_KEY, userDetail.getAuthToken()),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UnlinkRespondentUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UnlinkRespondentUTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnlinkRespondentUTest {
+
+    @Mock
+    private CaseMaintenanceClient caseMaintenanceClient;
+
+    @InjectMocks
+    private UnlinkRespondent classUnderTest;
+
+    @Test
+    public void whenExecute_thenProceedAsExpected() {
+        final UserDetails userDetails = UserDetails.builder().build();
+        final TaskContext taskContext = new DefaultTaskContext();
+
+        taskContext.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        taskContext.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+
+        doNothing().when(caseMaintenanceClient).unlinkRespondent(AUTH_TOKEN, TEST_CASE_ID);
+
+        UserDetails actual = classUnderTest.execute(taskContext, userDetails);
+
+        assertEquals(userDetails, actual);
+
+        verify(caseMaintenanceClient).unlinkRespondent(AUTH_TOKEN, TEST_CASE_ID);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.util.Collections;
@@ -54,7 +55,7 @@ public class UpdateRespondentDetailsUTest {
     private UpdateRespondentDetails classUnderTest;
 
     @Test
-    public void whenAosAwaiting_thenProceedAsExpected() {
+    public void whenAosAwaiting_thenProceedAsExpected() throws TaskException {
         final UserDetails payload = UserDetails.builder().build();
 
         final TaskContext taskContext = new DefaultTaskContext();
@@ -96,7 +97,7 @@ public class UpdateRespondentDetailsUTest {
     }
 
     @Test
-    public void whenNonStandardState_thenProceedAsExpected() {
+    public void whenNonStandardState_thenProceedAsExpected() throws TaskException {
         final UserDetails payload = UserDetails.builder().build();
 
         final TaskContext taskContext = new DefaultTaskContext();
@@ -138,7 +139,7 @@ public class UpdateRespondentDetailsUTest {
     }
 
     @Test
-    public void givenCaseOnAosOverdueState_whenUpdateRespondentDetails_thenRespondentDetailsIsUpdated() {
+    public void givenCaseOnAosOverdueState_whenUpdateRespondentDetails_thenRespondentDetailsIsUpdated() throws TaskException {
         final UserDetails payload = UserDetails.builder().build();
 
         final TaskContext taskContext = new DefaultTaskContext();
@@ -163,7 +164,7 @@ public class UpdateRespondentDetailsUTest {
     }
 
     @Test
-    public void givenCaseOnReissueState_whenUpdateRespondentDetails_thenStartAosFromReissueEventIsTriggered() {
+    public void givenCaseOnReissueState_whenUpdateRespondentDetails_thenStartAosFromReissueEventIsTriggered() throws TaskException {
         final UserDetails payload = UserDetails.builder().build();
 
         final TaskContext taskContext = new DefaultTaskContext();


### PR DESCRIPTION
# Description

Rolled back user permission  when update respondent data failed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
