### PR TITLE
DIV-3840 - renamed respDefendsDivorce to respWillDefendDivorce

### DIFF
--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
-    "respWillDefendDivorce" : "YES",
+    "respWillDefendDivorce" : "Yes",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
-    "respDefendsDivorce" : "YES",
+    "respWillDefendDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-no-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-no-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "NO",
-    "respWillDefendDivorce" : "YES",
+    "respWillDefendDivorce" : "Yes",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-no-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-defend-no-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "NO",
-    "respDefendsDivorce" : "YES",
+    "respWillDefendDivorce" : "YES",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
-    "respDefendsDivorce" : "NO",
+    "respWillDefendDivorce" : "NO",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "YES",
-    "respWillDefendDivorce" : "NO",
+    "respWillDefendDivorce" : "No",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-no-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-no-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "NO",
-    "respWillDefendDivorce" : "NO",
+    "respWillDefendDivorce" : "No",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-no-consent.json
+++ b/src/integrationTest/resources/fixtures/maintenance/submit-aos/aos-no-defend-no-consent.json
@@ -1,7 +1,7 @@
 {
     "respConfirmReadPetition" : "YES",
     "respAdmitOrConsentToFact" : "NO",
-    "respDefendsDivorce" : "NO",
+    "respWillDefendDivorce" : "NO",
     "respJurisdictionAgree" : "NO",
     "respJurisdictionDisagreeReason" : "Some Jurisdiction disagree reason",
     "respJurisdictionRespCountryOfResidence" : "UK",

--- a/src/integrationTest/resources/fixtures/respond-to-a-divorce/ccd-callback-aos-submitted-error.json
+++ b/src/integrationTest/resources/fixtures/respond-to-a-divorce/ccd-callback-aos-submitted-error.json
@@ -2,7 +2,7 @@
   "case_details": {
     "id": "0123456789012345",
     "case_data": {
-      "RespDefendsDivorce": "Yes",
+      "RespWillDefendDivorce": "Yes",
       "D8RespondentFirstName": "Ted",
       "D8RespondentLastName": "Jones",
       "D8InferredPetitionerGender": "female",

--- a/src/integrationTest/resources/fixtures/respond-to-a-divorce/ccd-callback-aos-submitted.json
+++ b/src/integrationTest/resources/fixtures/respond-to-a-divorce/ccd-callback-aos-submitted.json
@@ -3,7 +3,7 @@
     "id": "0123456789012345",
     "case_data": {
       "RespEmailAddress": "simulate-delivered@notifications.service.gov.uk",
-      "RespDefendsDivorce": "Yes",
+      "RespWillDefendDivorce": "Yes",
       "D8RespondentFirstName": "Ted",
       "D8RespondentLastName": "Jones",
       "D8InferredPetitionerGender": "female",

--- a/src/kubernetes/config.aat.yaml
+++ b/src/kubernetes/config.aat.yaml
@@ -9,7 +9,7 @@ data:
   SERVICE_AUTH_MICROSERVICE : "divorce_frontend"
   APPLICATION_INSIGHTS_IKEY : "019ed56f-e01d-4651-895d-bc6334f3d1b1"
   SERVICE_AUTH_SECRET : ${SERVICE_AUTH_SECRET}
-  CASE_FORMATTER_SERVICE_API_BASEURL : "http://div-cfs-aat.service.core-compute-aat.internal"
+  CASE_FORMATTER_SERVICE_API_BASEURL : "http://div-cfs-pr-64.service.core-compute-preview.internal"
   SERVICE_AUTH_PROVIDER_URL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
   CASE_VALIDATION_SERVICE_API_BASEURL : "http://div-vs-aat.service.core-compute-aat.internal"
   REFORM_SERVICE_NAME : "cos"

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -34,7 +34,6 @@ public class OrchestrationConstants {
     public static final String RESPONDENT_EMAIL_ADDRESS = "RespEmailAddress";
     public static final String START_AOS_EVENT_ID = "startAos";
     public static final String LINK_RESPONDENT_GENERIC_EVENT_ID = "linkRespondent";
-    public static final String COMPLETE_AOS_EVENT_ID = "aosSubmittedNoAdmissionNoConsent";
     public static final String AWAITING_DN_AOS_EVENT_ID = "aosSubmittedUndefended";
     public static final String AWAITING_ANSWER_AOS_EVENT_ID = "aosSubmittedDefended";
     public static final String D_8_INFERRED_RESPONDENT_GENDER = "D8InferredRespondentGender";
@@ -55,8 +54,6 @@ public class OrchestrationConstants {
     public static final String AOS_START_FROM_REISSUE = "startAosFromReissue";
     public static final String CCD_DATE_FORMAT = "yyyy-MM-dd";
     public static final String CCD_DUE_DATE = "dueDate";
-    public static final String D8_REASON_FOR_DIVORCE = "D8ReasonForDivorce";
-    public static final String UNREASONABLE_BEHAVIOUR = "unreasonable-behaviour";
 
     public static final String ID = "id";
     public static final String PIN = "pin";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -38,8 +38,7 @@ public class OrchestrationConstants {
     public static final String AWAITING_DN_AOS_EVENT_ID = "aosSubmittedUndefended";
     public static final String AWAITING_ANSWER_AOS_EVENT_ID = "aosSubmittedDefended";
     public static final String D_8_INFERRED_RESPONDENT_GENDER = "D8InferredRespondentGender";
-    public static final String RESP_ADMIT_OR_CONSENT_CCD_FIELD = "RespAdmitOrConsentToFact";
-    public static final String RESP_DEFENDS_DIVORCE_CCD_FIELD = "RespDefendsDivorce";
+    public static final String RESP_WILL_DEFEND_DIVORCE = "RespWillDefendDivorce";
     public static final String RESP_FIRST_NAME_CCD_FIELD = "D8RespondentFirstName";
     public static final String RESP_LAST_NAME_CCD_FIELD = "D8RespondentLastName";
     public static final String D_8_INFERRED_PETITIONER_GENDER = "D8InferredPetitionerGender";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -37,7 +37,7 @@ public class OrchestrationConstants {
     public static final String AWAITING_DN_AOS_EVENT_ID = "aosSubmittedUndefended";
     public static final String AWAITING_ANSWER_AOS_EVENT_ID = "aosSubmittedDefended";
     public static final String D_8_INFERRED_RESPONDENT_GENDER = "D8InferredRespondentGender";
-    public static final String RESP_WILL_DEFEND_DIVORCE = "respWillDefendDivorce";
+    public static final String RESP_WILL_DEFEND_DIVORCE = "RespWillDefendDivorce";
     public static final String RESP_FIRST_NAME_CCD_FIELD = "D8RespondentFirstName";
     public static final String RESP_LAST_NAME_CCD_FIELD = "D8RespondentLastName";
     public static final String D_8_INFERRED_PETITIONER_GENDER = "D8InferredPetitionerGender";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -38,7 +38,7 @@ public class OrchestrationConstants {
     public static final String AWAITING_DN_AOS_EVENT_ID = "aosSubmittedUndefended";
     public static final String AWAITING_ANSWER_AOS_EVENT_ID = "aosSubmittedDefended";
     public static final String D_8_INFERRED_RESPONDENT_GENDER = "D8InferredRespondentGender";
-    public static final String RESP_WILL_DEFEND_DIVORCE = "RespWillDefendDivorce";
+    public static final String RESP_WILL_DEFEND_DIVORCE = "respWillDefendDivorce";
     public static final String RESP_FIRST_NAME_CCD_FIELD = "D8RespondentFirstName";
     public static final String RESP_LAST_NAME_CCD_FIELD = "D8RespondentLastName";
     public static final String D_8_INFERRED_PETITIONER_GENDER = "D8InferredPetitionerGender";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/AosCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/AosCaseData.java
@@ -18,8 +18,8 @@ public class AosCaseData {
     @JsonProperty("RespAdmitOrConsentToFact")
     private String respAdmitOrConsentToFact;
 
-    @JsonProperty("RespDefendsDivorce")
-    private String respDefendsDivorce;
+    @JsonProperty("RespWillDefendDivorce")
+    private String respWillDefendDivorce;
 
     @JsonProperty("RespJurisdictionDisagreeReason")
     private String respJurisdictionDisagreeReason;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCase.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
@@ -14,11 +13,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DN_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.COMPLETE_AOS_EVENT_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ADMIT_OR_CONSENT_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_DEFENDS_DIVORCE_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.UNREASONABLE_BEHAVIOUR;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_WILL_DEFEND_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @Component
@@ -30,7 +25,7 @@ public class SubmitAosCase implements Task<Map<String, Object>> {
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> submissionData) {
         String authToken = (String) context.getTransientObject(AUTH_TOKEN_JSON_KEY);
-        String eventId = getAosCompleteEventId(authToken, submissionData);
+        String eventId = getAosCompleteEventId(submissionData);
 
         Map<String, Object> updateCase = caseMaintenanceClient.updateCase(
             authToken,
@@ -46,20 +41,11 @@ public class SubmitAosCase implements Task<Map<String, Object>> {
         return updateCase;
     }
 
-    private String getAosCompleteEventId(String authToken, Map<String, Object> submissionData) {
-        if (YES_VALUE.equalsIgnoreCase((String)submissionData.get(RESP_DEFENDS_DIVORCE_CCD_FIELD))) {
+    private String getAosCompleteEventId(Map<String, Object> submissionData) {
+        if (YES_VALUE.equalsIgnoreCase((String)submissionData.get(RESP_WILL_DEFEND_DIVORCE))) {
             return AWAITING_ANSWER_AOS_EVENT_ID;
         }
 
-        if (YES_VALUE.equalsIgnoreCase((String)submissionData.get(RESP_ADMIT_OR_CONSENT_CCD_FIELD))) {
-            return AWAITING_DN_AOS_EVENT_ID;
-        }
-
-        CaseDetails caseDetails = caseMaintenanceClient.retrieveAosCase(authToken, true);
-        if (UNREASONABLE_BEHAVIOUR.equalsIgnoreCase((String)caseDetails.getCaseData().get(D8_REASON_FOR_DIVORCE))) {
-            return AWAITING_DN_AOS_EVENT_ID;
-        }
-
-        return COMPLETE_AOS_EVENT_ID;
+        return AWAITING_DN_AOS_EVENT_ID;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflow.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_DEFENDS_DIVORCE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_WILL_DEFEND_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @Component
@@ -32,7 +32,7 @@ public class SendRespondentSubmissionNotificationWorkflow extends DefaultWorkflo
 
     public Map<String, Object> run(CreateEvent caseRequestDetails) throws WorkflowException {
         Map<String, Object> caseData = caseRequestDetails.getCaseDetails().getCaseData();
-        String defended = (String)caseData.get(RESP_DEFENDS_DIVORCE_CCD_FIELD);
+        String defended = (String)caseData.get(RESP_WILL_DEFEND_DIVORCE);
 
         Task[] tasks;
 
@@ -41,8 +41,8 @@ public class SendRespondentSubmissionNotificationWorkflow extends DefaultWorkflo
         } else if (NO_VALUE.equalsIgnoreCase(defended)) {
             tasks = new Task[]{sendRespondentSubmissionNotificationForUndefendedDivorceEmailTask};
         } else {
-            String errorMessage = String.format("%s field doesn't contain a valid value",
-                RESP_DEFENDS_DIVORCE_CCD_FIELD);
+            String errorMessage = String.format("%s field doesn't contain a valid value: %s",
+                RESP_WILL_DEFEND_DIVORCE, defended);
             log.error(errorMessage);
             throw new WorkflowException(errorMessage);
         }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RespondentAOSSubmissionNotificationEmailITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RespondentAOSSubmissionNotificationEmailITest.java
@@ -33,7 +33,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_DEFENDS_DIVORCE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_WILL_DEFEND_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.getJsonFromResourceFile;
 
@@ -119,8 +119,8 @@ public class RespondentAOSSubmissionNotificationEmailITest {
                 .andExpect(content().string(allOf(
                         isJson(),
                         hasJsonPath("$.data", is(nullValue())),
-                        hasJsonPath("$.errors", hasItem(String.format("%s field doesn't contain a valid value",
-                            RESP_DEFENDS_DIVORCE_CCD_FIELD)))
+                        hasJsonPath("$.errors", hasItem(String.format("%s field doesn't contain a valid value: null",
+                            RESP_WILL_DEFEND_DIVORCE)))
                 )));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitAosCaseITest.java
@@ -41,11 +41,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CHECK
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_ERROR;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_ANSWER_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DN_AOS_EVENT_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.COMPLETE_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_RESP_DATE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ADMIT_OR_CONSENT_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_DEFENDS_DIVORCE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_WILL_DEFEND_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
@@ -171,7 +169,6 @@ public class SubmitAosCaseITest {
 
         stubFormatterServerEndpoint(OK, caseData, caseDataString);
         stubRetrieveAosCaseFromCMS(convertObjectToJsonString(AOS_CASE_DETAILS));
-        stubMaintenanceServerEndpointForUpdate(OK, COMPLETE_AOS_EVENT_ID, caseData, caseDataString);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)
@@ -230,12 +227,12 @@ public class SubmitAosCaseITest {
 
     private Map<String, Object> getCaseData(String consent, boolean defended) {
         Map<String, Object> caseData = new HashMap<>();
-        caseData.put(RESP_ADMIT_OR_CONSENT_CCD_FIELD, consent);
+        caseData.put(RESP_WILL_DEFEND_DIVORCE, consent);
 
         if (defended) {
-            caseData.put(RESP_DEFENDS_DIVORCE_CCD_FIELD, YES_VALUE);
+            caseData.put(RESP_WILL_DEFEND_DIVORCE, YES_VALUE);
         } else {
-            caseData.put(RESP_DEFENDS_DIVORCE_CCD_FIELD, NO_VALUE);
+            caseData.put(RESP_WILL_DEFEND_DIVORCE, NO_VALUE);
         }
 
         return caseData;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCaseUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitAosCaseUTest.java
@@ -7,7 +7,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
@@ -25,13 +24,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DN_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.COMPLETE_AOS_EVENT_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_RESP_DATE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ADMIT_OR_CONSENT_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_DEFENDS_DIVORCE_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.UNREASONABLE_BEHAVIOUR;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_WILL_DEFEND_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -39,15 +33,6 @@ public class SubmitAosCaseUTest {
     private static final Map<String, Object> EXPECTED_OUTPUT = Collections.emptyMap();
     private static final Map<String, Object> CASE_UPDATE_RESPONSE = new HashMap<>();
     private static final TaskContext TASK_CONTEXT = new DefaultTaskContext();
-    private static final String AOS_RESPONSE_DATE = "2018-10-22";
-
-    private static final CaseDetails AOS_CASE_DETAILS =
-        CaseDetails.builder()
-            .caseData(
-                Collections.singletonMap(
-                    RECEIVED_AOS_FROM_RESP_DATE, AOS_RESPONSE_DATE
-                )
-            ).build();
 
     @Mock
     private CaseMaintenanceClient caseMaintenanceClient;
@@ -89,30 +74,8 @@ public class SubmitAosCaseUTest {
     }
 
     @Test
-    public void givenNoConsentAndNoDefend_whenExecute_thenProceedAsExpected() {
-        final Map<String, Object> divorceSession = getCaseData(NO_VALUE, false);
-
-        when(caseMaintenanceClient.retrieveAosCase(AUTH_TOKEN, true)).thenReturn(AOS_CASE_DETAILS);
-        when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, COMPLETE_AOS_EVENT_ID, divorceSession))
-            .thenReturn(CASE_UPDATE_RESPONSE);
-
-        assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
-
-        verify(caseMaintenanceClient).updateCase(AUTH_TOKEN, TEST_CASE_ID, COMPLETE_AOS_EVENT_ID, divorceSession);
-    }
-
-    @Test
     public void givenBehaviourNoConsentAndNoDefend_whenExecute_thenProceedAsExpected() {
         final Map<String, Object> divorceSession = getCaseData(NO_VALUE, false);
-        final CaseDetails aosCaseDetails =
-                CaseDetails.builder()
-                        .caseData(
-                                Collections.singletonMap(
-                                        D8_REASON_FOR_DIVORCE, UNREASONABLE_BEHAVIOUR
-                                )
-                        ).build();
-
-        when(caseMaintenanceClient.retrieveAosCase(AUTH_TOKEN, true)).thenReturn(aosCaseDetails);
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_DN_AOS_EVENT_ID, divorceSession))
                 .thenReturn(CASE_UPDATE_RESPONSE);
@@ -137,12 +100,12 @@ public class SubmitAosCaseUTest {
 
     private Map<String, Object> getCaseData(String consent, boolean defended) {
         Map<String, Object> caseData = new HashMap<>();
-        caseData.put(RESP_ADMIT_OR_CONSENT_CCD_FIELD, consent);
+        caseData.put(RESP_WILL_DEFEND_DIVORCE, consent);
 
         if (defended) {
-            caseData.put(RESP_DEFENDS_DIVORCE_CCD_FIELD, YES_VALUE);
+            caseData.put(RESP_WILL_DEFEND_DIVORCE, YES_VALUE);
         } else {
-            caseData.put(RESP_DEFENDS_DIVORCE_CCD_FIELD, NO_VALUE);
+            caseData.put(RESP_WILL_DEFEND_DIVORCE, NO_VALUE);
         }
 
         return caseData;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflowTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_DEFENDS_DIVORCE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_WILL_DEFEND_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.getJsonFromResourceFile;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -102,7 +102,7 @@ public class SendRespondentSubmissionNotificationWorkflowTest {
             WorkflowException {
         expectedException.expect(WorkflowException.class);
         expectedException.expectMessage(String.format("%s field doesn't contain a valid value",
-            RESP_DEFENDS_DIVORCE_CCD_FIELD));
+            RESP_WILL_DEFEND_DIVORCE));
 
         CreateEvent caseRequestDetails = getJsonFromResourceFile(
                 "/jsonExamples/payloads/unclearAcknowledgementOfService.json", CreateEvent.class);

--- a/src/test/resources/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json
+++ b/src/test/resources/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json
@@ -2,7 +2,7 @@
   "case_details": {
     "case_data": {
       "RespEmailAddress": "respondent@divorce.co.uk",
-      "RespDefendsDivorce": "Yes",
+      "RespWillDefendDivorce": "Yes",
       "D8RespondentFirstName": "Ted",
       "D8RespondentLastName": "Jones",
       "D8InferredPetitionerGender": "female",

--- a/src/test/resources/jsonExamples/payloads/defendedDivorceAOSMissingFields.json
+++ b/src/test/resources/jsonExamples/payloads/defendedDivorceAOSMissingFields.json
@@ -3,7 +3,7 @@
     "id": "0123456789012345",
     "case_data": {
       "RespEmailAddress": "respondent@divorce.co.uk",
-      "RespDefendsDivorce": "Yes",
+      "RespWillDefendDivorce": "Yes",
       "D8RespondentFirstName": "Ted",
       "D8RespondentLastName": "Jones",
       "D8DivorceUnit": "eastMidlands",

--- a/src/test/resources/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json
+++ b/src/test/resources/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json
@@ -3,7 +3,7 @@
     "id": "0123456789012345",
     "case_data": {
       "RespEmailAddress": "respondent@divorce.co.uk",
-      "RespDefendsDivorce": "Yes",
+      "RespWillDefendDivorce": "Yes",
       "D8RespondentFirstName": "Ted",
       "D8RespondentLastName": "Jones",
       "D8InferredPetitionerGender": "female",

--- a/src/test/resources/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json
+++ b/src/test/resources/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json
@@ -3,7 +3,7 @@
     "id": "0123456789012345",
     "case_data": {
       "RespEmailAddress": "respondent@divorce.co.uk",
-      "RespDefendsDivorce": "No",
+      "RespWillDefendDivorce": "No",
       "D8RespondentFirstName": "Sarah",
       "D8RespondentLastName": "Jones",
       "D8InferredPetitionerGender": "male",

--- a/src/test/resources/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json
+++ b/src/test/resources/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json
@@ -3,7 +3,7 @@
     "id": "0123456789012345",
     "case_data": {
       "RespEmailAddress": "respondent@divorce.co.uk",
-      "RespDefendsDivorce": "No",
+      "RespWillDefendDivorce": "No",
       "D8RespondentFirstName": "Sarah",
       "D8RespondentLastName": "Jones",
       "D8InferredPetitionerGender": "male",


### PR DESCRIPTION
# Description
Also removed references to respAdmitOrConsentToFact for now as it's not currently valid

Fixes #DIV-3840  and #DIV-3829

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
