### PR TITLE
DIV-4133: Replace old derived fields with new concatenated ones

### DIFF
--- a/src/integrationTest/resources/fixtures/issue-petition/ccd-callback-aos-invitation-service-centre.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/ccd-callback-aos-invitation-service-centre.json
@@ -30,7 +30,7 @@
         "D8ReasonForDivorceAdulteryWishToName": "YES",
         "D8ReasonForDivorceAdultery3rdPartyFName": "Ben",
         "D8ReasonForDivorceAdultery3rdPartyLName": "Stark",
-        "D8DerivedReasonForDivorceAdultery3rdAddr": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+        "D8ReasonForDivorceAdultery3rdAddress": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
         "D8ReasonForDivorceAdulteryKnowWhere": "YES",
         "D8ReasonForDivorceAdulteryKnowWhen": "YES",
         "D8ReasonForDivorceAdulteryWhenDetails": "Last Friday",

--- a/src/integrationTest/resources/fixtures/issue-petition/ccd-callback-aos-invitation.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/ccd-callback-aos-invitation.json
@@ -30,7 +30,7 @@
       "D8ReasonForDivorceAdulteryWishToName": "YES",
       "D8ReasonForDivorceAdultery3rdPartyFName": "Ben",
       "D8ReasonForDivorceAdultery3rdPartyLName": "Stark",
-      "D8DerivedReasonForDivorceAdultery3rdAddr": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+      "D8ReasonForDivorceAdultery3rdAddress": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
       "D8ReasonForDivorceAdulteryKnowWhere": "YES",
       "D8ReasonForDivorceAdulteryKnowWhen": "YES",
       "D8ReasonForDivorceAdulteryWhenDetails": "Last Friday",

--- a/src/integrationTest/resources/fixtures/issue-petition/ccd-callback-petition-issued.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/ccd-callback-petition-issued.json
@@ -16,7 +16,7 @@
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",
-      "D8DerivedPetitionerCurrentFullName": "John Smith",
+      "PetitionerFullName": "John Smith",
       "D8PetitionerNameChangedHow": [
         "marriageCertificate"
       ],
@@ -32,7 +32,7 @@
       "D8PetitionerCorrespondenceUseHomeAddress": "YES",
       "D8RespondentFirstName": "Jane",
       "D8RespondentLastName": "Jamed",
-      "D8DerivedRespondentCurrentName": "Jane Jamed",
+      "RespondentFullName": "Jane Jamed",
       "D8RespondentHomeAddress": {
         "PostCode": "SW9 9PE"
       },

--- a/src/integrationTest/resources/fixtures/issue-petition/invalid-ccd-callback-petition-issued.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/invalid-ccd-callback-petition-issued.json
@@ -16,7 +16,7 @@
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",
-      "D8DerivedPetitionerCurrentFullName": "John Smith",
+      "PetitionerFullName": "John Smith",
       "D8PetitionerNameChangedHow": [
         "marriageCertificate"
       ],
@@ -32,7 +32,7 @@
       "D8PetitionerCorrespondenceUseHomeAddress": "YES",
       "D8RespondentFirstName": "Jane",
       "D8RespondentLastName": "Jamed",
-      "D8DerivedRespondentCurrentName": "Jane Jamed",
+      "RespondentFullName": "Jane Jamed",
       "D8RespondentHomeAddress": {
         "PostCode": "SW9 9PE"
       },

--- a/src/integrationTest/resources/fixtures/issue-petition/submit-complete-case.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/submit-complete-case.json
@@ -13,7 +13,7 @@
   "D8PetitionerPhoneNumber":"01234567890",
   "D8PetitionerFirstName":"John",
   "D8PetitionerLastName":"Smith",
-  "D8DerivedPetitionerCurrentFullName":"John Smith",
+  "PetitionerFullName":"John Smith",
   "D8PetitionerNameChangedHow":[
     "marriageCertificate"
   ],
@@ -29,8 +29,8 @@
   "D8PetitionerCorrespondenceUseHomeAddress":"NO",
   "D8RespondentFirstName":"Jane",
   "D8RespondentLastName":"Jamed",
-  "D8DerivedRespondentCurrentName":"Jane Jamed",
-  "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+  "RespondentFullName":"Jane Jamed",
+  "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
   "D8RespondentHomeAddress":{
     "PostCode":"SS SSS"
   },

--- a/src/integrationTest/resources/fixtures/issue-petition/submit-unlinked-case.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/submit-unlinked-case.json
@@ -13,7 +13,7 @@
   "D8PetitionerPhoneNumber":"01234567890",
   "D8PetitionerFirstName":"John",
   "D8PetitionerLastName":"Smith",
-  "D8DerivedPetitionerCurrentFullName":"John Smith",
+  "PetitionerFullName":"John Smith",
   "D8PetitionerNameChangedHow":[
     "marriageCertificate"
   ],
@@ -29,8 +29,8 @@
   "D8PetitionerCorrespondenceUseHomeAddress":"NO",
   "D8RespondentFirstName":"Jane",
   "D8RespondentLastName":"Jamed",
-  "D8DerivedRespondentCurrentName":"Jane Jamed",
-  "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+  "RespondentFullName":"Jane Jamed",
+  "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
   "D8RespondentHomeAddress":{
     "PostCode":"SS SSS"
   },

--- a/src/integrationTest/resources/fixtures/maintenance/update/submit-case-data.json
+++ b/src/integrationTest/resources/fixtures/maintenance/update/submit-case-data.json
@@ -12,7 +12,7 @@
   "D8PetitionerPhoneNumber":"01234567890",
   "D8PetitionerFirstName":"John",
   "D8PetitionerLastName":"Smith",
-  "D8DerivedPetitionerCurrentFullName":"John Smith",
+  "PetitionerFullName":"John Smith",
   "D8PetitionerNameChangedHow":[
     "marriageCertificate"
   ],
@@ -28,8 +28,8 @@
   "D8PetitionerCorrespondenceUseHomeAddress":"NO",
   "D8RespondentFirstName":"Jane",
   "D8RespondentLastName":"Jamed",
-  "D8DerivedRespondentCurrentName":"Jane Jamed",
-  "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+  "RespondentFullName":"Jane Jamed",
+  "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
   "D8RespondentHomeAddress":{
     "PostCode":"SS SSS"
   },

--- a/src/integrationTest/resources/fixtures/retrieve-aos-case/aos-received.json
+++ b/src/integrationTest/resources/fixtures/retrieve-aos-case/aos-received.json
@@ -30,7 +30,7 @@
       "D8ReasonForDivorceAdulteryWishToName": "YES",
       "D8ReasonForDivorceAdultery3rdPartyFName": "Ben",
       "D8ReasonForDivorceAdultery3rdPartyLName": "Stark",
-      "D8DerivedReasonForDivorceAdultery3rdAddr": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+      "D8ReasonForDivorceAdultery3rdAddress": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
       "D8ReasonForDivorceAdulteryKnowWhere": "YES",
       "D8ReasonForDivorceAdulteryKnowWhen": "YES",
       "D8ReasonForDivorceAdulteryWhenDetails": "Last Friday",

--- a/src/integrationTest/resources/fixtures/solicitor/ccd-request-data.json
+++ b/src/integrationTest/resources/fixtures/solicitor/ccd-request-data.json
@@ -30,7 +30,7 @@
       "D8ReasonForDivorceAdulteryWishToName": "YES",
       "D8ReasonForDivorceAdultery3rdPartyFName": "Ben",
       "D8ReasonForDivorceAdultery3rdPartyLName": "Stark",
-      "D8DerivedReasonForDivorceAdultery3rdAddr": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+      "D8ReasonForDivorceAdultery3rdAddress": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
       "D8ReasonForDivorceAdulteryKnowWhere": "YES",
       "D8ReasonForDivorceAdulteryKnowWhen": "YES",
       "D8ReasonForDivorceAdulteryWhenDetails": "Last Friday",

--- a/src/integrationTest/resources/fixtures/solicitor/solicitor-request-data.json
+++ b/src/integrationTest/resources/fixtures/solicitor/solicitor-request-data.json
@@ -30,7 +30,7 @@
       "D8ReasonForDivorceAdulteryWishToName": "YES",
       "D8ReasonForDivorceAdultery3rdPartyFName": "Ben",
       "D8ReasonForDivorceAdultery3rdPartyLName": "Stark",
-      "D8DerivedReasonForDivorceAdultery3rdAddr": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+      "D8ReasonForDivorceAdultery3rdAddress": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
       "D8ReasonForDivorceAdulteryKnowWhere": "YES",
       "D8ReasonForDivorceAdulteryKnowWhen": "YES",
       "D8ReasonForDivorceAdulteryWhenDetails": "Last Friday",

--- a/src/integrationTest/resources/fixtures/submit-dn/dn-submitted.json
+++ b/src/integrationTest/resources/fixtures/submit-dn/dn-submitted.json
@@ -30,7 +30,7 @@
       "D8ReasonForDivorceAdulteryWishToName": "YES",
       "D8ReasonForDivorceAdultery3rdPartyFName": "Ben",
       "D8ReasonForDivorceAdultery3rdPartyLName": "Stark",
-      "D8DerivedReasonForDivorceAdultery3rdAddr": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+      "D8ReasonForDivorceAdultery3rdAddress": "Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
       "D8ReasonForDivorceAdulteryKnowWhere": "YES",
       "D8ReasonForDivorceAdulteryKnowWhen": "YES",
       "D8ReasonForDivorceAdulteryWhenDetails": "Last Friday",

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/CoreCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/CoreCaseData.java
@@ -78,8 +78,8 @@ public class CoreCaseData extends AosCaseData {
     @JsonProperty("D8PetitionerLastName")
     private String d8PetitionerLastName;
 
-    @JsonProperty("D8DerivedPetitionerCurrentFullName")
-    private String d8DerivedPetitionerCurrentFullName;
+    @JsonProperty("PetitionerFullName")
+    private String petitionerFullName;
 
     @JsonProperty("D8PetitionerNameChangedHow")
     private List<String> d8PetitionerNameChangedHow;
@@ -114,11 +114,11 @@ public class CoreCaseData extends AosCaseData {
     @JsonProperty("D8RespondentLastName")
     private String d8RespondentLastName;
 
-    @JsonProperty("D8DerivedRespondentCurrentName")
-    private String d8DerivedRespondentCurrentName;
+    @JsonProperty("RespondentFullName")
+    private String respondentFullName;
 
-    @JsonProperty("D8DerivedRespondentSolicitorDetails")
-    private String d8DerivedRespondentSolicitorDetails;
+    @JsonProperty("D8RespondentSolicitorDetails")
+    private String d8RespondentSolicitorDetails;
 
     @JsonProperty("D8RespondentHomeAddress")
     private Address d8RespondentHomeAddress;
@@ -375,8 +375,8 @@ public class CoreCaseData extends AosCaseData {
     @JsonProperty("D8ReasonForDivorceSeperationYear")
     private String d8ReasonForDivorceSeperationYear;
 
-    @JsonProperty("D8DerivedReasonForDivorceAdultery3dPtyNm")
-    private String d8DerivedReasonForDivorceAdultery3dPtyNm;
+    @JsonProperty("CoRespondentFullName")
+    private String coRespondentFullName;
 
     @JsonProperty("D8DerivedRespondentSolicitorAddr")
     private String d8DerivedRespondentSolicitorAddr;
@@ -410,9 +410,6 @@ public class CoreCaseData extends AosCaseData {
 
     @JsonProperty("D8ReasonForDivorceDesertion")
     private String d8ReasonForDivorceDesertion;
-
-    @JsonProperty("D8DerivedReasonForDivorceAdultery3rdAddr")
-    private String d8DerivedReasonForDivorceAdultery3rdAddr;
 
     @JsonProperty("D8Cohort")
     private String d8Cohort;


### PR DESCRIPTION
DIV-4133 Replace old Derived fields with new Concatenated fields

Changed from:

D8DerivedReasonForDivorceAdultery3dPtyNm -> CoRespondentFullName 
D8DerivedRespondentSolicitorDetails -> D8RespondentSolicitorDetails 
D8DerivedRespondentCurrentName -> RespondentFullName 
D8DerivedPetitionerCurrentFullName -> PetitionerFullName 
D8DerivedReasonForDivorceAdultery3rdAddr -> D8ReasonForDivorceAdultery3rdAddress