### PR TITLE
Use Boolean Query param instead of email

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -62,7 +62,7 @@ public interface CosApiClient {
     )
     void saveDraft(@RequestHeader(AUTHORIZATION) String authorisation,
                                   @RequestBody JsonNode caseDataContent,
-                   @RequestParam(name = "notificationEmail") String notificationEmail
+                   @RequestParam(name = "sendEmail") boolean sendEmail
    );
 
     @RequestMapping(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -62,7 +62,7 @@ public interface CosApiClient {
     )
     void saveDraft(@RequestHeader(AUTHORIZATION) String authorisation,
                                   @RequestBody JsonNode caseDataContent,
-                   @RequestParam(name = "sendEmail") boolean sendEmail
+                   @RequestParam(name = "sendEmail") String sendEmail
    );
 
     @RequestMapping(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/DraftsSubmissionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/DraftsSubmissionSupport.java
@@ -23,7 +23,7 @@ public class DraftsSubmissionSupport {
 
     public void saveDraft(UserDetails userDetails, String fileName) {
         JsonNode draftResource = ResourceLoader.loadJsonToObject(fileName, JsonNode.class);
-        cosApiClient.saveDraft(userDetails.getAuthToken(), draftResource, userDetails.getEmailAddress());
+        cosApiClient.saveDraft(userDetails.getAuthToken(), draftResource, true);
     }
 
     public void deleteDraft(UserDetails userDetails) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/DraftsSubmissionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/DraftsSubmissionSupport.java
@@ -23,7 +23,7 @@ public class DraftsSubmissionSupport {
 
     public void saveDraft(UserDetails userDetails, String fileName) {
         JsonNode draftResource = ResourceLoader.loadJsonToObject(fileName, JsonNode.class);
-        cosApiClient.saveDraft(userDetails.getAuthToken(), draftResource, true);
+        cosApiClient.saveDraft(userDetails.getAuthToken(), draftResource, Boolean.TRUE.toString());
     }
 
     public void deleteDraft(UserDetails userDetails) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.MediaType;
 
@@ -219,11 +218,11 @@ public class OrchestrationController {
         @ApiParam(value = "The case draft", required = true)
         @RequestBody
         @NotNull Map<String, Object> payload,
-        @RequestParam(value = "notificationEmail", required = false)
+        @RequestParam(value = "sendEmail", required = false)
         @ApiParam(value = "The email address that will receive the notification that the draft has been saved")
-        @Email final String notificationEmail) throws WorkflowException {
+        final boolean sendEmail) throws WorkflowException {
 
-        return ResponseEntity.ok(orchestrationService.saveDraft(payload, authorizationToken, notificationEmail));
+        return ResponseEntity.ok(orchestrationService.saveDraft(payload, authorizationToken, sendEmail));
     }
 
     @DeleteMapping(path = "/draftsapi/version/1")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
@@ -219,9 +219,10 @@ public class OrchestrationController {
         @RequestBody
         @NotNull Map<String, Object> payload,
         @RequestParam(value = "sendEmail", required = false)
-        @ApiParam(value = "The email address that will receive the notification that the draft has been saved")
-        final boolean sendEmail) throws WorkflowException {
+        @ApiParam(value = "Determines if the petitioner should receive the notification that the draft has been saved")
+        final String sendEmail) throws WorkflowException {
 
+        // Deprecation Warning: sendEmail as String instead of Boolean to be backwards compatible with current PFE
         return ResponseEntity.ok(orchestrationService.saveDraft(payload, authorizationToken, sendEmail));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -62,6 +62,7 @@ public class OrchestrationConstants {
 
     // Divorce Session
     public static final String DIVORCE_SESSION_EXISTING_PAYMENTS = "existingPayments";
+    public static final String DIVORCE_SESSION_PETITIONER_EMAIL = "petitionerEmail";
 
     public static final String ID = "id";
     public static final String PIN = "pin";
@@ -78,6 +79,7 @@ public class OrchestrationConstants {
 
     //Notification
     public static final String NOTIFICATION_EMAIL = "email_address";
+    public static final String NOTIFICATION_SEND_EMAIL = "send_email";
     public static final String NOTIFICATION_TEMPLATE = "notification_template";
     public static final String NOTIFICATION_TEMPLATE_VARS = "notification_template_vars";
     public static final String NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY = "first name";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -41,7 +41,7 @@ public interface CaseOrchestrationService {
 
     Map<String,Object> saveDraft(Map<String, Object> payLoad,
                                  String authorizationToken,
-                                 String notificationEmail) throws WorkflowException;
+                                 boolean sendEmail) throws WorkflowException;
 
     Map<String,Object> deleteDraft(String authorizationToken) throws WorkflowException;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -41,7 +41,7 @@ public interface CaseOrchestrationService {
 
     Map<String,Object> saveDraft(Map<String, Object> payLoad,
                                  String authorizationToken,
-                                 boolean sendEmail) throws WorkflowException;
+                                 String sendEmail) throws WorkflowException;
 
     Map<String,Object> deleteDraft(String authorizationToken) throws WorkflowException;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -195,7 +195,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     @Override
     public Map<String, Object> saveDraft(Map<String, Object> payLoad,
                                          String authToken,
-                                         boolean sendEmail) throws WorkflowException {
+                                         String sendEmail) throws WorkflowException {
         Map<String, Object> response = saveDraftWorkflow.run(payLoad, authToken, sendEmail);
 
         if (saveDraftWorkflow.errors().isEmpty()) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -195,8 +195,8 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     @Override
     public Map<String, Object> saveDraft(Map<String, Object> payLoad,
                                          String authToken,
-                                         String notificationEmail) throws WorkflowException {
-        Map<String, Object> response = saveDraftWorkflow.run(payLoad, authToken, notificationEmail);
+                                         boolean sendEmail) throws WorkflowException {
+        Map<String, Object> response = saveDraftWorkflow.run(payLoad, authToken, sendEmail);
 
         if (saveDraftWorkflow.errors().isEmpty()) {
             log.info("Draft saved");

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotification.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotification.java
@@ -10,7 +10,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_PETITIONER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @Component
 public class EmailNotification  implements Task<Map<String, Object>> {
@@ -26,8 +27,9 @@ public class EmailNotification  implements Task<Map<String, Object>> {
     @Override
     public Map<String, Object> execute(TaskContext context,
                                        Map<String, Object> draft) {
-        String emailAddress = String.valueOf(context.getTransientObject(NOTIFICATION_EMAIL));
-        if (StringUtils.isNotBlank(emailAddress) && "null" != emailAddress) {
+        boolean sendEmail = Boolean.parseBoolean(String.valueOf(context.getTransientObject(NOTIFICATION_SEND_EMAIL)));
+        String emailAddress = String.valueOf(draft.get(DIVORCE_SESSION_PETITIONER_EMAIL));
+        if (StringUtils.isNotBlank(emailAddress) && sendEmail) {
             return emailService.sendSaveDraftConfirmationEmail(emailAddress);
         }
         return new LinkedHashMap<>();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotification.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotification.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_PETITIONER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @Component
@@ -28,8 +28,8 @@ public class EmailNotification  implements Task<Map<String, Object>> {
     public Map<String, Object> execute(TaskContext context,
                                        Map<String, Object> draft) {
         boolean sendEmail = Boolean.parseBoolean(String.valueOf(context.getTransientObject(NOTIFICATION_SEND_EMAIL)));
-        String emailAddress = String.valueOf(draft.get(DIVORCE_SESSION_PETITIONER_EMAIL));
-        if (StringUtils.isNotBlank(emailAddress) && sendEmail) {
+        String emailAddress = String.valueOf((context.getTransientObject(NOTIFICATION_EMAIL)));
+        if (sendEmail && StringUtils.isNotBlank(emailAddress)) {
             return emailService.sendSaveDraftConfirmationEmail(emailAddress);
         }
         return new LinkedHashMap<>();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotification.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotification.java
@@ -27,11 +27,19 @@ public class EmailNotification  implements Task<Map<String, Object>> {
     @Override
     public Map<String, Object> execute(TaskContext context,
                                        Map<String, Object> draft) {
-        boolean sendEmail = Boolean.parseBoolean(String.valueOf(context.getTransientObject(NOTIFICATION_SEND_EMAIL)));
+        boolean sendEmail = parseBooleanFromString(String.valueOf(context.getTransientObject(NOTIFICATION_SEND_EMAIL)));
         String emailAddress = String.valueOf((context.getTransientObject(NOTIFICATION_EMAIL)));
         if (sendEmail && StringUtils.isNotBlank(emailAddress)) {
             return emailService.sendSaveDraftConfirmationEmail(emailAddress);
         }
         return new LinkedHashMap<>();
+    }
+
+    // For temporary backwards compatibility
+    private boolean parseBooleanFromString(String email) {
+        // Email is not just whitespace, is not null string (from String.valueOf) and not false
+        return StringUtils.isNotBlank(email)
+                && !"null".equalsIgnoreCase(email)
+                && !Boolean.FALSE.toString().equalsIgnoreCase(email);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflow.java
@@ -32,7 +32,7 @@ public class SaveDraftWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     public Map<String, Object> run(Map<String, Object> payLoad,
                                    String authToken,
-                                   boolean sendEmail) throws WorkflowException {
+                                   String sendEmail) throws WorkflowException {
         return this.execute(
                 new Task[]{
                     saveToDraftStore,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflow.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.SaveToDraftStore;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @Component
 public class SaveDraftWorkflow extends DefaultWorkflow<Map<String, Object>> {
@@ -30,7 +30,7 @@ public class SaveDraftWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     public Map<String, Object> run(Map<String, Object> payLoad,
                                    String authToken,
-                                   String notificationEmail) throws WorkflowException {
+                                   boolean sendEmail) throws WorkflowException {
         return this.execute(
                 new Task[]{
                     saveToDraftStore,
@@ -38,7 +38,7 @@ public class SaveDraftWorkflow extends DefaultWorkflow<Map<String, Object>> {
                 },
                 payLoad,
                 ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
-                ImmutablePair.of(NOTIFICATION_EMAIL, notificationEmail)
+                ImmutablePair.of(NOTIFICATION_SEND_EMAIL, sendEmail)
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflow.java
@@ -12,6 +12,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.SaveToDraftStore;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_PETITIONER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @Component
@@ -38,7 +40,8 @@ public class SaveDraftWorkflow extends DefaultWorkflow<Map<String, Object>> {
                 },
                 payLoad,
                 ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
-                ImmutablePair.of(NOTIFICATION_SEND_EMAIL, sendEmail)
+                ImmutablePair.of(NOTIFICATION_SEND_EMAIL, sendEmail),
+                ImmutablePair.of(NOTIFICATION_EMAIL, payLoad.get(DIVORCE_SESSION_PETITIONER_EMAIL))
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -55,7 +55,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EVENT
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PIN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_TOKEN;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PIN;
 
 
@@ -212,8 +211,8 @@ public class CaseOrchestrationServiceImplTest {
         Map<String, Object> payload = mock(Map.class);
         Map<String, Object> testExpectedPayload = mock(Map.class);
 
-        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, TEST_USER_EMAIL)).thenReturn(testExpectedPayload);
-        assertEquals(testExpectedPayload,classUnderTest.saveDraft(payload, AUTH_TOKEN, TEST_USER_EMAIL));
+        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, true)).thenReturn(testExpectedPayload);
+        assertEquals(testExpectedPayload,classUnderTest.saveDraft(payload, AUTH_TOKEN, true));
     }
 
     @SuppressWarnings("unchecked")
@@ -223,10 +222,10 @@ public class CaseOrchestrationServiceImplTest {
         Map<String, Object> payload = mock(Map.class);
         Map<String, Object> workflowResponsePayload = mock(Map.class);
 
-        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, TEST_USER_EMAIL)).thenReturn(workflowResponsePayload);
+        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, true)).thenReturn(workflowResponsePayload);
         when(saveDraftWorkflow.errors()).thenReturn(expectedErrors);
 
-        assertEquals(expectedErrors,classUnderTest.saveDraft(payload, AUTH_TOKEN, TEST_USER_EMAIL));
+        assertEquals(expectedErrors,classUnderTest.saveDraft(payload, AUTH_TOKEN, true));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -211,8 +211,8 @@ public class CaseOrchestrationServiceImplTest {
         Map<String, Object> payload = mock(Map.class);
         Map<String, Object> testExpectedPayload = mock(Map.class);
 
-        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, true)).thenReturn(testExpectedPayload);
-        assertEquals(testExpectedPayload,classUnderTest.saveDraft(payload, AUTH_TOKEN, true));
+        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, Boolean.TRUE.toString())).thenReturn(testExpectedPayload);
+        assertEquals(testExpectedPayload,classUnderTest.saveDraft(payload, AUTH_TOKEN, Boolean.TRUE.toString()));
     }
 
     @SuppressWarnings("unchecked")
@@ -222,10 +222,10 @@ public class CaseOrchestrationServiceImplTest {
         Map<String, Object> payload = mock(Map.class);
         Map<String, Object> workflowResponsePayload = mock(Map.class);
 
-        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, true)).thenReturn(workflowResponsePayload);
+        when(saveDraftWorkflow.run(payload,AUTH_TOKEN, Boolean.TRUE.toString())).thenReturn(workflowResponsePayload);
         when(saveDraftWorkflow.errors()).thenReturn(expectedErrors);
 
-        assertEquals(expectedErrors,classUnderTest.saveDraft(payload, AUTH_TOKEN, true));
+        assertEquals(expectedErrors,classUnderTest.saveDraft(payload, AUTH_TOKEN, Boolean.TRUE.toString()));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotificationTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -17,7 +18,8 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_PETITIONER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EmailNotificationTest {
@@ -29,11 +31,11 @@ public class EmailNotificationTest {
     private EmailNotification target;
 
     @Test
-    public void whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailIsCalled() {
-        Map<String, Object> payload = mock(Map.class);
+    public void givenSendEmailTrue_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailIsCalled() {
+        Map<String, Object> payload = Collections.singletonMap(DIVORCE_SESSION_PETITIONER_EMAIL, TEST_USER_EMAIL);
         TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
-        context.setTransientObject(NOTIFICATION_EMAIL, TEST_USER_EMAIL);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, true);
 
         target.execute(context, payload);
 
@@ -41,14 +43,26 @@ public class EmailNotificationTest {
     }
 
     @Test
-    public void givenBlankEmail_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNoyCalled() {
+    public void givenSendEmailFalse_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNoyCalled() {
+        Map<String, Object> payload = Collections.singletonMap(DIVORCE_SESSION_PETITIONER_EMAIL, TEST_USER_EMAIL);
         TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
-        Map<String, Object> payload = mock(Map.class);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, false);
 
         target.execute(context, payload);
 
         verify(emailService, never()).sendSaveDraftConfirmationEmail(TEST_USER_EMAIL);
     }
 
+    @Test
+    public void givenBlankEmail_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNotCalled() {
+        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, true);
+        Map<String, Object> payload = mock(Map.class);
+
+        target.execute(context, payload);
+
+        verify(emailService, never()).sendSaveDraftConfirmationEmail(TEST_USER_EMAIL);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotificationTest.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -18,7 +17,7 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_PETITIONER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -32,10 +31,11 @@ public class EmailNotificationTest {
 
     @Test
     public void givenSendEmailTrue_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailIsCalled() {
-        Map<String, Object> payload = Collections.singletonMap(DIVORCE_SESSION_PETITIONER_EMAIL, TEST_USER_EMAIL);
         TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
         context.setTransientObject(NOTIFICATION_SEND_EMAIL, true);
+        context.setTransientObject(NOTIFICATION_EMAIL, TEST_USER_EMAIL);
+        Map<String, Object> payload = mock(Map.class);
 
         target.execute(context, payload);
 
@@ -43,11 +43,12 @@ public class EmailNotificationTest {
     }
 
     @Test
-    public void givenSendEmailFalse_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNoyCalled() {
-        Map<String, Object> payload = Collections.singletonMap(DIVORCE_SESSION_PETITIONER_EMAIL, TEST_USER_EMAIL);
+    public void givenSendEmailFalse_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNotCalled() {
         TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
         context.setTransientObject(NOTIFICATION_SEND_EMAIL, false);
+        context.setTransientObject(NOTIFICATION_EMAIL, TEST_USER_EMAIL);
+        Map<String, Object> payload = mock(Map.class);
 
         target.execute(context, payload);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/EmailNotificationTest.java
@@ -33,7 +33,20 @@ public class EmailNotificationTest {
     public void givenSendEmailTrue_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailIsCalled() {
         TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
-        context.setTransientObject(NOTIFICATION_SEND_EMAIL, true);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, Boolean.TRUE.toString());
+        context.setTransientObject(NOTIFICATION_EMAIL, TEST_USER_EMAIL);
+        Map<String, Object> payload = mock(Map.class);
+
+        target.execute(context, payload);
+
+        verify(emailService).sendSaveDraftConfirmationEmail(TEST_USER_EMAIL);
+    }
+
+    @Test
+    public void givenSendEmailIsString_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailIsCalled() {
+        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, TEST_USER_EMAIL);
         context.setTransientObject(NOTIFICATION_EMAIL, TEST_USER_EMAIL);
         Map<String, Object> payload = mock(Map.class);
 
@@ -46,7 +59,20 @@ public class EmailNotificationTest {
     public void givenSendEmailFalse_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNotCalled() {
         TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
-        context.setTransientObject(NOTIFICATION_SEND_EMAIL, false);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, Boolean.FALSE.toString());
+        context.setTransientObject(NOTIFICATION_EMAIL, TEST_USER_EMAIL);
+        Map<String, Object> payload = mock(Map.class);
+
+        target.execute(context, payload);
+
+        verify(emailService, never()).sendSaveDraftConfirmationEmail(TEST_USER_EMAIL);
+    }
+
+    @Test
+    public void givenSendEmailNull_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNotCalled() {
+        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, null);
         context.setTransientObject(NOTIFICATION_EMAIL, TEST_USER_EMAIL);
         Map<String, Object> payload = mock(Map.class);
 
@@ -59,7 +85,7 @@ public class EmailNotificationTest {
     public void givenBlankEmail_whenExecuteEmailNotificationTask_thenSendSaveDraftConfirmationEmailNotCalled() {
         TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
-        context.setTransientObject(NOTIFICATION_SEND_EMAIL, true);
+        context.setTransientObject(NOTIFICATION_SEND_EMAIL, Boolean.TRUE.toString());
         Map<String, Object> payload = mock(Map.class);
 
         target.execute(context, payload);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflowTest.java
@@ -57,7 +57,7 @@ public class SaveDraftWorkflowTest {
         when(emailNotification.execute(argThat(CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER), eq(draftSavedPayload)))
                 .thenReturn(emailNotificationPayload);
 
-        assertEquals(emailNotificationPayload, target.run(payload, AUTH_TOKEN, true));
+        assertEquals(emailNotificationPayload, target.run(payload, AUTH_TOKEN, Boolean.TRUE.toString()));
 
         verify(saveToDraftStore).execute(argThat(CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER),
                 eq(payload));
@@ -76,7 +76,7 @@ public class SaveDraftWorkflowTest {
                     context.setTaskFailed(true);
                     return draftSavedPayload;
                 });
-        target.run(payload, AUTH_TOKEN, true);
+        target.run(payload, AUTH_TOKEN, Boolean.TRUE.toString());
 
         verify(saveToDraftStore).execute(argThat(CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER), eq(payload));
         verify(emailNotification, never()).execute(any(TaskContext.class), any());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflowTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.EmailNotification;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SaveToDraftStore;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -22,7 +23,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_SESSION_PETITIONER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,12 +42,13 @@ public class SaveDraftWorkflowTest {
 
     private static final ArgumentMatcher<TaskContext> CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER =
         argument -> argument.getTransientObject(AUTH_TOKEN_JSON_KEY) != null
-        && argument.getTransientObject(NOTIFICATION_SEND_EMAIL) != null;
+        && argument.getTransientObject(NOTIFICATION_SEND_EMAIL) != null
+        && argument.getTransientObject(NOTIFICATION_EMAIL) != null;
 
     @SuppressWarnings("unchecked")
     @Test
     public void givenADraft_whenExecuteSaveDraftWorkflow_thenExecuteAllTaskInOrder() throws WorkflowException {
-        Map<String, Object> payload = mock(Map.class);
+        Map<String, Object> payload = Collections.singletonMap(DIVORCE_SESSION_PETITIONER_EMAIL, TEST_USER_EMAIL);
         Map<String, Object> draftSavedPayload = mock(Map.class);
         Map<String, Object> emailNotificationPayload = mock(Map.class);
 
@@ -62,7 +67,7 @@ public class SaveDraftWorkflowTest {
     @SuppressWarnings("unchecked")
     @Test
     public void givenAError_whenExecuteSaveDraftWorkflow_thenStopExecution() throws WorkflowException {
-        final Map<String, Object> payload = mock(Map.class);
+        final Map<String, Object> payload = Collections.singletonMap(DIVORCE_SESSION_PETITIONER_EMAIL, TEST_USER_EMAIL);
         final Map<String, Object> draftSavedPayload = mock(Map.class);
 
         when(saveToDraftStore.execute(argThat(CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER), eq(payload)))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SaveDraftWorkflowTest.java
@@ -22,9 +22,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SEND_EMAIL;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SaveDraftWorkflowTest {
@@ -39,7 +38,7 @@ public class SaveDraftWorkflowTest {
 
     private static final ArgumentMatcher<TaskContext> CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER =
         argument -> argument.getTransientObject(AUTH_TOKEN_JSON_KEY) != null
-        && argument.getTransientObject(NOTIFICATION_EMAIL) != null;
+        && argument.getTransientObject(NOTIFICATION_SEND_EMAIL) != null;
 
     @SuppressWarnings("unchecked")
     @Test
@@ -53,7 +52,7 @@ public class SaveDraftWorkflowTest {
         when(emailNotification.execute(argThat(CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER), eq(draftSavedPayload)))
                 .thenReturn(emailNotificationPayload);
 
-        assertEquals(emailNotificationPayload, target.run(payload, AUTH_TOKEN, TEST_USER_EMAIL));
+        assertEquals(emailNotificationPayload, target.run(payload, AUTH_TOKEN, true));
 
         verify(saveToDraftStore).execute(argThat(CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER),
                 eq(payload));
@@ -72,7 +71,7 @@ public class SaveDraftWorkflowTest {
                     context.setTaskFailed(true);
                     return draftSavedPayload;
                 });
-        target.run(payload, AUTH_TOKEN, TEST_USER_EMAIL);
+        target.run(payload, AUTH_TOKEN, true);
 
         verify(saveToDraftStore).execute(argThat(CONTEXT_WITH_AUTH_TOKEN_AND_EMAIL_MATCHER), eq(payload));
         verify(emailNotification, never()).execute(any(TaskContext.class), any());


### PR DESCRIPTION
# Description

[DIV-2130](https://tools.hmcts.net/jira/browse/DIV-2130)

This changes the saveDraft call to use a boolean value as the request param instead of the actual email, so it won't be exposed.
The  email will be sent using the request body email value instead.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit, end to end and manual testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
