### PR TITLE
Stop paymentUpdate callback from doing anything

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PaymentUpdateCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PaymentUpdateCallbackTest.java
@@ -1,61 +1,62 @@
-package uk.gov.hmcts.reform.divorce.callback;
-
-import io.restassured.response.Response;
-import org.apache.http.entity.ContentType;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
-import uk.gov.hmcts.reform.divorce.support.CcdClientSupport;
-import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
-import uk.gov.hmcts.reform.divorce.util.RestUtil;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-public class PaymentUpdateCallbackTest extends IntegrationTest {
-
-    private static final String PAYLOAD_CONTEXT_PATH = "fixtures/callback/";
-    private static final String SUBMIT_PAYLOAD_CONTEXT_PATH = "fixtures/maintenance/update/";
-
-    @Value("${case.orchestration.payment-update.context-path}")
-    private String contextPath;
-
-    @Autowired
-    private CcdClientSupport ccdClientSupport;
-
-    @Test
-    public void givenValidPaymentRequest_whenPaymentUpdate_thenReturnStatusOkWithNoErrors() throws Exception {
-        final Map<String, Object> headers = new HashMap<>();
-        headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
-        headers.put(HttpHeaders.AUTHORIZATION, createCitizenUser().getAuthToken());
-
-        UserDetails citizenUser = createCitizenUser();
-
-        String caseId = ccdClientSupport.submitCase(
-                ResourceLoader.loadJsonToObject(SUBMIT_PAYLOAD_CONTEXT_PATH + "submit-case-data.json", Map.class),
-                citizenUser
-        ).getId().toString();
-
-        PaymentUpdate paymentUpdate = ResourceLoader.loadJsonToObject(
-                PAYLOAD_CONTEXT_PATH + "paymentUpdate.json", PaymentUpdate.class
-        );
-
-        paymentUpdate.setCcdCaseNumber(caseId);
-
-        Response response = RestUtil.putToRestService(
-                serverUrl + contextPath,
-                Collections.singletonMap(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString()),
-                ResourceLoader.objectToJson(paymentUpdate)
-        );
-
-        assertEquals(HttpStatus.OK.value(), response.getStatusCode());
-    }
-
-}
+// TODO: Resolve paymentUpdate request issues
+//package uk.gov.hmcts.reform.divorce.callback;
+//
+//import io.restassured.response.Response;
+//import org.apache.http.entity.ContentType;
+//import org.junit.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.http.HttpHeaders;
+//import org.springframework.http.HttpStatus;
+//import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
+//import uk.gov.hmcts.reform.divorce.model.UserDetails;
+//import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
+//import uk.gov.hmcts.reform.divorce.support.CcdClientSupport;
+//import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
+//import uk.gov.hmcts.reform.divorce.util.RestUtil;
+//
+//import java.util.Collections;
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//import static org.junit.Assert.assertEquals;
+//public class PaymentUpdateCallbackTest extends IntegrationTest {
+//
+//    private static final String PAYLOAD_CONTEXT_PATH = "fixtures/callback/";
+//    private static final String SUBMIT_PAYLOAD_CONTEXT_PATH = "fixtures/maintenance/update/";
+//
+//    @Value("${case.orchestration.payment-update.context-path}")
+//    private String contextPath;
+//
+//    @Autowired
+//    private CcdClientSupport ccdClientSupport;
+//
+//    @Test
+//    public void givenValidPaymentRequest_whenPaymentUpdate_thenReturnStatusOkWithNoErrors() throws Exception {
+//        final Map<String, Object> headers = new HashMap<>();
+//        headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
+//        headers.put(HttpHeaders.AUTHORIZATION, createCitizenUser().getAuthToken());
+//
+//        UserDetails citizenUser = createCitizenUser();
+//
+//        String caseId = ccdClientSupport.submitCase(
+//                ResourceLoader.loadJsonToObject(SUBMIT_PAYLOAD_CONTEXT_PATH + "submit-case-data.json", Map.class),
+//                citizenUser
+//        ).getId().toString();
+//
+//        PaymentUpdate paymentUpdate = ResourceLoader.loadJsonToObject(
+//                PAYLOAD_CONTEXT_PATH + "paymentUpdate.json", PaymentUpdate.class
+//        );
+//
+//        paymentUpdate.setCcdCaseNumber(caseId);
+//
+//        Response response = RestUtil.putToRestService(
+//                serverUrl + contextPath,
+//                Collections.singletonMap(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString()),
+//                ResourceLoader.objectToJson(paymentUpdate)
+//        );
+//
+//        assertEquals(HttpStatus.OK.value(), response.getStatusCode());
+//    }
+//
+//}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -7,7 +7,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CaseDataResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Payment;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.CaseOrchestrationService;
@@ -36,15 +35,11 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDnCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitToCCDWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdateToCCDWorkflow;
 
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_DATA_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
 
 @Slf4j
@@ -148,6 +143,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     public Map<String, Object> update(PaymentUpdate paymentUpdate) throws WorkflowException {
         Map<String, Object> payload  = new HashMap<>();
 
+        /* TODO: Resolve paymentUpdate request issues
         if (paymentUpdate.getStatus().equalsIgnoreCase(SUCCESS)) {
             String paymentAmount = Optional.ofNullable(paymentUpdate.getAmount())
                     .map(BigDecimal::intValueExact)
@@ -186,6 +182,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
             log.info("Ignoring payment update as it was not successful payment on case {}",
                 paymentUpdate.getCcdCaseNumber());
         }
+        */
         return payload;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PaymentUpdateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PaymentUpdateITest.java
@@ -1,150 +1,151 @@
-package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
-
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Fee;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Payment;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
-
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.BEARER_AUTH_TOKEN_1;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
-
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = OrchestrationServiceApplication.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@PropertySource(value = "classpath:application.yml")
-@AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class PaymentUpdateITest extends IdamTestSupport {
-
-    private static final String CASE_ID = "1234567890";
-    private static final String EVENT_ID = "paymentMade";
-
-    private static final String API_URL = "/payment-update";
-
-    private static final String RETRIEVE_CASE_CONTEXT_PATH = String.format(
-            "/casemaintenance/version/1/case/%s",
-            CASE_ID
-    );
-    private static final String CCD_FORMAT_CONTEXT_PATH = "/caseformatter/version/1/to-ccd-format";
-    private static final String UPDATE_CONTEXT_PATH = String.format(
-            "/casemaintenance/version/1/updateCase/%s/%s",
-            CASE_ID,
-            EVENT_ID
-    );
-
-    @Autowired
-    private MockMvc webClient;
-
-    @ClassRule
-    public static WireMockClassRule formatterServiceServer = new WireMockClassRule(4011);
-
-    @ClassRule
-    public static WireMockClassRule maintenanceServiceServer = new WireMockClassRule(4010);
-
-    private PaymentUpdate paymentUpdate = new PaymentUpdate();
-    private Payment payment = Payment.builder().build();
-    private Map<String, Object> caseData = new HashMap<>();
-
-    @Before
-    public void setup() {
-        paymentUpdate.setChannel("online");
-        paymentUpdate.setCcdCaseNumber(CASE_ID);
-        paymentUpdate.setReference("paymentReference");
-        paymentUpdate.setSiteId("siteId");
-        paymentUpdate.setStatus("success");
-        paymentUpdate.setExternalReference("externalReference");
-        paymentUpdate.setAmount(new BigDecimal(550.00));
-
-        Fee fee = new Fee();
-        fee.setCode("X243");
-        paymentUpdate.setFees(Arrays.asList(fee, fee));
-
-        payment = Payment.builder()
-            .paymentChannel("online")
-            .paymentReference(paymentUpdate.getReference())
-            .paymentSiteId(paymentUpdate.getSiteId())
-            .paymentStatus(paymentUpdate.getStatus())
-            .paymentTransactionId(paymentUpdate.getExternalReference())
-            .paymentAmount("55000")
-            .paymentFeeId("X243")
-            .build();
-
-        caseData.put("payment", payment);
-    }
-
-    @Test
-    public void givenEventDataAndAuth_whenEventDataIsSubmitted_thenReturnSuccess() throws Exception {
-        stubSignInForCaseworker();
-        stubMaintenanceServerEndpointForRetrieveCaseById();
-        stubFormatterServerEndpoint();
-
-        Map<String, Object> responseData = Collections.singletonMap(ID, TEST_CASE_ID);
-        stubMaintenanceServerEndpointForUpdate(responseData);
-
-        webClient.perform(put(API_URL)
-                .content(convertObjectToJsonString(paymentUpdate))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().is2xxSuccessful());
-    }
-
-    private void stubMaintenanceServerEndpointForRetrieveCaseById() {
-        maintenanceServiceServer.stubFor(WireMock.get(RETRIEVE_CASE_CONTEXT_PATH)
-                .withHeader(AUTHORIZATION, new EqualToPattern(BEARER_AUTH_TOKEN_1))
-                .willReturn(aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(convertObjectToJsonString(caseData))));
-    }
-
-    private void stubFormatterServerEndpoint() {
-        formatterServiceServer.stubFor(WireMock.post(CCD_FORMAT_CONTEXT_PATH)
-                .withRequestBody(equalToJson(convertObjectToJsonString(caseData)))
-                .willReturn(aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(convertObjectToJsonString(caseData))));
-    }
-
-    private void stubMaintenanceServerEndpointForUpdate(Map<String, Object> response) {
-        maintenanceServiceServer.stubFor(WireMock.post(UPDATE_CONTEXT_PATH)
-                .withRequestBody(equalToJson(convertObjectToJsonString(caseData)))
-                .withHeader(AUTHORIZATION, new EqualToPattern(BEARER_AUTH_TOKEN_1))
-                .willReturn(aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(convertObjectToJsonString(response))));
-    }
-}
+// TODO: Resolve paymentUpdate request issues
+//package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
+//
+//import com.github.tomakehurst.wiremock.client.WireMock;
+//import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+//import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+//import org.junit.Before;
+//import org.junit.ClassRule;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.context.annotation.PropertySource;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.MediaType;
+//import org.springframework.test.annotation.DirtiesContext;
+//import org.springframework.test.context.ContextConfiguration;
+//import org.springframework.test.context.junit4.SpringRunner;
+//import org.springframework.test.web.servlet.MockMvc;
+//import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
+//import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Fee;
+//import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Payment;
+//import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
+//
+//import java.math.BigDecimal;
+//import java.util.Arrays;
+//import java.util.Collections;
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+//import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+//import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+//import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+//import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.BEARER_AUTH_TOKEN_1;
+//import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+//import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
+//import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+//
+//@RunWith(SpringRunner.class)
+//@ContextConfiguration(classes = OrchestrationServiceApplication.class)
+//@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+//@PropertySource(value = "classpath:application.yml")
+//@AutoConfigureMockMvc
+//@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+//public class PaymentUpdateITest extends IdamTestSupport {
+//
+//    private static final String CASE_ID = "1234567890";
+//    private static final String EVENT_ID = "paymentMade";
+//
+//    private static final String API_URL = "/payment-update";
+//
+//    private static final String RETRIEVE_CASE_CONTEXT_PATH = String.format(
+//            "/casemaintenance/version/1/case/%s",
+//            CASE_ID
+//    );
+//    private static final String CCD_FORMAT_CONTEXT_PATH = "/caseformatter/version/1/to-ccd-format";
+//    private static final String UPDATE_CONTEXT_PATH = String.format(
+//            "/casemaintenance/version/1/updateCase/%s/%s",
+//            CASE_ID,
+//            EVENT_ID
+//    );
+//
+//    @Autowired
+//    private MockMvc webClient;
+//
+//    @ClassRule
+//    public static WireMockClassRule formatterServiceServer = new WireMockClassRule(4011);
+//
+//    @ClassRule
+//    public static WireMockClassRule maintenanceServiceServer = new WireMockClassRule(4010);
+//
+//    private PaymentUpdate paymentUpdate = new PaymentUpdate();
+//    private Payment payment = Payment.builder().build();
+//    private Map<String, Object> caseData = new HashMap<>();
+//
+//    @Before
+//    public void setup() {
+//        paymentUpdate.setChannel("online");
+//        paymentUpdate.setCcdCaseNumber(CASE_ID);
+//        paymentUpdate.setReference("paymentReference");
+//        paymentUpdate.setSiteId("siteId");
+//        paymentUpdate.setStatus("success");
+//        paymentUpdate.setExternalReference("externalReference");
+//        paymentUpdate.setAmount(new BigDecimal(550.00));
+//
+//        Fee fee = new Fee();
+//        fee.setCode("X243");
+//        paymentUpdate.setFees(Arrays.asList(fee, fee));
+//
+//        payment = Payment.builder()
+//            .paymentChannel("online")
+//            .paymentReference(paymentUpdate.getReference())
+//            .paymentSiteId(paymentUpdate.getSiteId())
+//            .paymentStatus(paymentUpdate.getStatus())
+//            .paymentTransactionId(paymentUpdate.getExternalReference())
+//            .paymentAmount("55000")
+//            .paymentFeeId("X243")
+//            .build();
+//
+//        caseData.put("payment", payment);
+//    }
+//
+//    @Test
+//    public void givenEventDataAndAuth_whenEventDataIsSubmitted_thenReturnSuccess() throws Exception {
+//        stubSignInForCaseworker();
+//        stubMaintenanceServerEndpointForRetrieveCaseById();
+//        stubFormatterServerEndpoint();
+//
+//        Map<String, Object> responseData = Collections.singletonMap(ID, TEST_CASE_ID);
+//        stubMaintenanceServerEndpointForUpdate(responseData);
+//
+//        webClient.perform(put(API_URL)
+//                .content(convertObjectToJsonString(paymentUpdate))
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .accept(MediaType.APPLICATION_JSON))
+//                .andExpect(status().is2xxSuccessful());
+//    }
+//
+//    private void stubMaintenanceServerEndpointForRetrieveCaseById() {
+//        maintenanceServiceServer.stubFor(WireMock.get(RETRIEVE_CASE_CONTEXT_PATH)
+//                .withHeader(AUTHORIZATION, new EqualToPattern(BEARER_AUTH_TOKEN_1))
+//                .willReturn(aResponse()
+//                        .withStatus(HttpStatus.OK.value())
+//                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+//                        .withBody(convertObjectToJsonString(caseData))));
+//    }
+//
+//    private void stubFormatterServerEndpoint() {
+//        formatterServiceServer.stubFor(WireMock.post(CCD_FORMAT_CONTEXT_PATH)
+//                .withRequestBody(equalToJson(convertObjectToJsonString(caseData)))
+//                .willReturn(aResponse()
+//                        .withStatus(HttpStatus.OK.value())
+//                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+//                        .withBody(convertObjectToJsonString(caseData))));
+//    }
+//
+//    private void stubMaintenanceServerEndpointForUpdate(Map<String, Object> response) {
+//        maintenanceServiceServer.stubFor(WireMock.post(UPDATE_CONTEXT_PATH)
+//                .withRequestBody(equalToJson(convertObjectToJsonString(caseData)))
+//                .withHeader(AUTHORIZATION, new EqualToPattern(BEARER_AUTH_TOKEN_1))
+//                .willReturn(aResponse()
+//                        .withStatus(HttpStatus.OK.value())
+//                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+//                        .withBody(convertObjectToJsonString(response))));
+//    }
+//}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -12,9 +12,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Fee;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Payment;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.AmendPetitionWorkflow;
@@ -39,14 +36,10 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDnCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitToCCDWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdateToCCDWorkflow;
 
-import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -322,6 +315,7 @@ public class CaseOrchestrationServiceImplTest {
         verify(updateToCCDWorkflow).run(requestPayload, AUTH_TOKEN, TEST_CASE_ID);
     }
 
+    /* TODO: Resolve paymentUpdate request issues
     @Test
     public void givenValidPaymentData_whenPaymentUpdate_thenReturnPayload() throws Exception {
         PaymentUpdate paymentUpdate  = new PaymentUpdate();
@@ -384,6 +378,7 @@ public class CaseOrchestrationServiceImplTest {
 
         classUnderTest.update(paymentUpdate);
     }
+    */
 
     @Test
     public void whenLinkRespondent_thenProceedAsExpected() throws WorkflowException {


### PR DESCRIPTION
Assuming the queue is not cleared, and there is no limit on the amount of retries for failed payments, we should stop calling CCD at least when hit with a paymentUpdate call.