### PR TITLE
Refactor - class rename

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/BulkPrintCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/BulkPrintCallbackTest.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpHeaders;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 
 import java.time.LocalDate;
@@ -63,12 +63,12 @@ public class BulkPrintCallbackTest extends IntegrationTest {
             .getBody()
             .as(Map.class);
 
-        CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(CaseDetails.builder().caseData(
+        CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(CaseDetails.builder().caseData(
             (Map) response.get("data")).caseId("323").state("submitted").build()
         );
         ResponseBody body = postToRestService(serverUrl + bulkPrintContextPath, caseworkerHeaders,
-            ResourceLoader.objectToJson(createEvent)).getBody();
+            ResourceLoader.objectToJson(ccdCallbackRequest)).getBody();
         String result = ((Map) body.jsonPath().get("data")).get("dueDate").toString();
         assertEquals("Due date is not as expected ",
             LocalDate.now().plus(30, ChronoUnit.DAYS).format(DateTimeFormatter.ISO_LOCAL_DATE), result);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/GetPetitionIssueFeesTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/GetPetitionIssueFeesTest.java
@@ -26,7 +26,7 @@ public class GetPetitionIssueFeesTest extends IntegrationTest {
     private String contextPath;
 
     @Test
-    public void givenCreateEvent_whenGetPetitionIssueFees_thenReturnUpdatedData() throws Exception {
+    public void givenCallbackRequest_whenGetPetitionIssueFees_thenReturnUpdatedData() throws Exception {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PetitionSubmissionNotificationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PetitionSubmissionNotificationTest.java
@@ -25,7 +25,7 @@ public class PetitionSubmissionNotificationTest extends IntegrationTest {
     private String contextPath;
 
     @Test
-    public void givenCreateEvent_whenPetitionSubmitted_thenReturnCallbackResponse() throws Exception {
+    public void givenCallbackRequest_whenPetitionSubmitted_thenReturnCallbackResponse() throws Exception {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/ProcessPbaPaymentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/ProcessPbaPaymentTest.java
@@ -26,7 +26,7 @@ public class ProcessPbaPaymentTest extends IntegrationTest {
     private String contextPath;
 
     @Test
-    public void givenCreateEvent_whenProcessPbaPayment_thenReturnDataWithNoErrors() throws Exception {
+    public void givenCallbackRequest_whenProcessPbaPayment_thenReturnDataWithNoErrors() throws Exception {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         headers.put(HttpHeaders.AUTHORIZATION, createCaseWorkerUser().getAuthToken());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorCreatePaymentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorCreatePaymentTest.java
@@ -28,7 +28,7 @@ public class SolicitorCreatePaymentTest extends IntegrationTest {
     private String contextPath;
 
     @Test
-    public void givenCreateEvent_whenSolicitorCreate_thenReturnUpdatedData() throws Exception {
+    public void givenCallbackRequest_whenSolicitorCreate_thenReturnUpdatedData() throws Exception {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdClientSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdClientSupport.java
@@ -22,7 +22,7 @@ public class CcdClientSupport {
     private String caseType;
 
     @Value("${ccd.eventid.create}")
-    private String createEventId;
+    private String CcdCallbackRequestId;
 
     @Autowired
     private CoreCaseDataApi coreCaseDataApi;
@@ -40,7 +40,7 @@ public class CcdClientSupport {
             userDetails.getId(),
             jurisdictionId,
             caseType,
-            createEventId);
+            CcdCallbackRequestId);
 
         final CaseDataContent caseDataContent = CaseDataContent.builder()
             .eventToken(startEventResponse.getToken())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
@@ -24,8 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CaseDataResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseCreationResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.AllocatedCourt;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
@@ -37,10 +37,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.MediaType;
-
 
 import static java.util.Collections.singletonList;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.BULK_PRINT_ERROR_KEY;
@@ -72,8 +70,8 @@ public class OrchestrationController {
         @RequestHeader(value = "Authorization") String authorizationToken,
         @RequestParam(value = GENERATE_AOS_INVITATION, required = false)
         @ApiParam(GENERATE_AOS_INVITATION) boolean generateAosInvitation,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
-        Map<String, Object> response = orchestrationService.handleIssueEventCallback(caseDetailsRequest, authorizationToken,
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        Map<String, Object> response = orchestrationService.handleIssueEventCallback(ccdCallbackRequest, authorizationToken,
             generateAosInvitation);
 
         if (response != null && response.containsKey(VALIDATION_ERROR_KEY)) {
@@ -116,9 +114,9 @@ public class OrchestrationController {
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> bulkPrint(
         @RequestHeader(value = "Authorization") String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
-        Map<String, Object> response = orchestrationService.ccdCallbackBulkPrintHandler(caseDetailsRequest,
+        Map<String, Object> response = orchestrationService.ccdCallbackBulkPrintHandler(ccdCallbackRequest,
             authorizationToken);
 
         if (response != null && response.containsKey(BULK_PRINT_ERROR_KEY)) {
@@ -318,10 +316,10 @@ public class OrchestrationController {
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> petitionUpdated(
         @RequestHeader(value = "Authorization", required = false) String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
-        orchestrationService.sendPetitionerGenericUpdateNotificationEmail(caseDetailsRequest);
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        orchestrationService.sendPetitionerGenericUpdateNotificationEmail(ccdCallbackRequest);
         return ResponseEntity.ok(CcdCallbackResponse.builder()
-            .data(caseDetailsRequest.getCaseDetails().getCaseData())
+            .data(ccdCallbackRequest.getCaseDetails().getCaseData())
             .build());
     }
 
@@ -335,12 +333,12 @@ public class OrchestrationController {
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> petitionSubmitted(
         @RequestHeader(value = "Authorization", required = false) String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
-        orchestrationService.sendPetitionerSubmissionNotificationEmail(caseDetailsRequest);
+        orchestrationService.sendPetitionerSubmissionNotificationEmail(ccdCallbackRequest);
 
         return ResponseEntity.ok(CcdCallbackResponse.builder()
-            .data(caseDetailsRequest.getCaseDetails().getCaseData())
+            .data(ccdCallbackRequest.getCaseDetails().getCaseData())
             .build());
     }
 
@@ -354,12 +352,12 @@ public class OrchestrationController {
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> respondentAOSSubmitted(
         @RequestHeader(value = "Authorization", required = false) String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) {
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         Map<String, Object> returnedCaseData;
 
         try {
-            returnedCaseData = orchestrationService.sendRespondentSubmissionNotificationEmail(caseDetailsRequest);
+            returnedCaseData = orchestrationService.sendRespondentSubmissionNotificationEmail(ccdCallbackRequest);
         } catch (WorkflowException e) {
             return ResponseEntity.ok(CcdCallbackResponse.builder()
                 .errors(singletonList(e.getMessage()))
@@ -380,9 +378,9 @@ public class OrchestrationController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> getPetitionIssueFees(
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(CcdCallbackResponse.builder()
-            .data(orchestrationService.setOrderSummary(caseDetailsRequest))
+            .data(orchestrationService.setOrderSummary(ccdCallbackRequest))
             .build()
         );
     }
@@ -397,8 +395,8 @@ public class OrchestrationController {
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> processPbaPayment(
         @RequestHeader(value = "Authorization") String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
-        Map<String, Object> response = orchestrationService.processPbaPayment(caseDetailsRequest, authorizationToken);
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        Map<String, Object> response = orchestrationService.processPbaPayment(ccdCallbackRequest, authorizationToken);
 
         if (response != null && response.containsKey(SOLICITOR_VALIDATION_ERROR_KEY)) {
             return ResponseEntity.ok(
@@ -418,9 +416,9 @@ public class OrchestrationController {
             + "creating solicitor cases.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> solicitorCreate(
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(CcdCallbackResponse.builder()
-            .data(orchestrationService.solicitorCreate(caseDetailsRequest))
+            .data(orchestrationService.solicitorCreate(ccdCallbackRequest))
             .build());
     }
 
@@ -434,8 +432,8 @@ public class OrchestrationController {
         @RequestHeader("Authorization")
         @ApiParam(value = "JWT authorisation token issued by IDAM",
             required = true) final String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
-        return ResponseEntity.ok(orchestrationService.aosReceived(caseDetailsRequest, authorizationToken));
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        return ResponseEntity.ok(orchestrationService.aosReceived(ccdCallbackRequest, authorizationToken));
     }
 
     @PostMapping(path = "/co-respondent-received")
@@ -444,8 +442,8 @@ public class OrchestrationController {
         @ApiResponse(code = 200, message = "Notification sent successful"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> corespReceived(
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
-        return ResponseEntity.ok(orchestrationService.sendCoRespReceivedNotificationEmail(caseDetailsRequest));
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        return ResponseEntity.ok(orchestrationService.sendCoRespReceivedNotificationEmail(ccdCallbackRequest));
     }
 
     @PostMapping(path = "/submit-aos/{caseId}",
@@ -506,8 +504,8 @@ public class OrchestrationController {
     public ResponseEntity<CcdCallbackResponse> dnSubmitted(
         @RequestHeader("Authorization")
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) final String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) throws WorkflowException {
-        return ResponseEntity.ok(orchestrationService.dnSubmitted(caseDetailsRequest, authorizationToken));
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        return ResponseEntity.ok(orchestrationService.dnSubmitted(ccdCallbackRequest, authorizationToken));
     }
 
     private List<String> getErrors(Map<String, Object> response) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/CcdCallbackRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/CcdCallbackRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
-public class CreateEvent {
+public class CcdCallbackRequest {
     private String token;
     @JsonProperty("event_id")
     private String eventId;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.divorce.orchestration.service;
 
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CaseDataResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
@@ -11,10 +11,10 @@ import java.util.Map;
 
 public interface CaseOrchestrationService {
 
-    Map<String, Object> handleIssueEventCallback(CreateEvent caseDetailsRequest, String authToken,
+    Map<String, Object> handleIssueEventCallback(CcdCallbackRequest ccdCallbackRequest, String authToken,
                                                  boolean generateAosInvitation) throws WorkflowException;
 
-    Map<String, Object> ccdCallbackBulkPrintHandler(CreateEvent caseDetailsRequest, String authToken)
+    Map<String, Object> ccdCallbackBulkPrintHandler(CcdCallbackRequest ccdCallbackRequest, String authToken)
         throws WorkflowException;
 
     Boolean authenticateRespondent(String authToken) throws WorkflowException;
@@ -34,7 +34,7 @@ public interface CaseOrchestrationService {
     UserDetails linkRespondent(String authToken, String caseId, String pin)
         throws WorkflowException;
 
-    CcdCallbackResponse aosReceived(CreateEvent caseDetailsRequest, String authToken) throws WorkflowException;
+    CcdCallbackResponse aosReceived(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException;
 
 
     Map<String, Object> getDraft(String authToken) throws WorkflowException;
@@ -45,21 +45,21 @@ public interface CaseOrchestrationService {
 
     Map<String,Object> deleteDraft(String authorizationToken) throws WorkflowException;
 
-    Map<String, Object> sendPetitionerSubmissionNotificationEmail(CreateEvent caseDetailsRequest)
+    Map<String, Object> sendPetitionerSubmissionNotificationEmail(CcdCallbackRequest ccdCallbackRequest)
             throws WorkflowException;
 
-    Map<String, Object> sendPetitionerGenericUpdateNotificationEmail(CreateEvent caseDetailsRequest)
+    Map<String, Object> sendPetitionerGenericUpdateNotificationEmail(CcdCallbackRequest ccdCallbackRequest)
             throws WorkflowException;
 
-    Map<String, Object> sendRespondentSubmissionNotificationEmail(CreateEvent caseDetailsRequest)
+    Map<String, Object> sendRespondentSubmissionNotificationEmail(CcdCallbackRequest ccdCallbackRequest)
             throws WorkflowException;
 
-    Map<String, Object> setOrderSummary(CreateEvent caseDetailsRequest) throws WorkflowException;
+    Map<String, Object> setOrderSummary(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;
 
 
-    Map<String, Object> processPbaPayment(CreateEvent caseDetailsRequest, String authToken) throws WorkflowException;
+    Map<String, Object> processPbaPayment(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException;
 
-    Map<String, Object> solicitorCreate(CreateEvent caseDetailsRequest) throws WorkflowException;
+    Map<String, Object> solicitorCreate(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;
 
     Map<String, Object> submitRespondentAosCase(Map<String, Object> payload, String authorizationToken, String caseId)
         throws WorkflowException;
@@ -67,7 +67,7 @@ public interface CaseOrchestrationService {
     Map<String, Object> submitCoRespondentAosCase(Map<String, Object> payload, String authorizationToken)
         throws WorkflowException;
 
-    CcdCallbackResponse dnSubmitted(CreateEvent caseDetailsRequest, String authToken) throws WorkflowException;
+    CcdCallbackResponse dnSubmitted(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException;
 
 
     Map<String, Object> submitDnCase(Map<String, Object> divorceSession, String authorizationToken, String caseId)
@@ -75,5 +75,5 @@ public interface CaseOrchestrationService {
 
     Map<String, Object> amendPetition(String caseId, String authorisation) throws WorkflowException;
 
-    CcdCallbackResponse sendCoRespReceivedNotificationEmail(CreateEvent caseDetailsRequest) throws WorkflowException;
+    CcdCallbackResponse sendCoRespReceivedNotificationEmail(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CaseDataResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Payment;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
@@ -84,35 +84,35 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     private final AmendPetitionWorkflow amendPetitionWorkflow;
 
     @Override
-    public Map<String, Object> handleIssueEventCallback(CreateEvent caseDetailsRequest,
+    public Map<String, Object> handleIssueEventCallback(CcdCallbackRequest ccdCallbackRequest,
                                                         String authToken,
                                                         boolean generateAosInvitation) throws WorkflowException {
-        Map<String, Object> payLoad = issueEventWorkflow.run(caseDetailsRequest, authToken, generateAosInvitation);
+        Map<String, Object> payLoad = issueEventWorkflow.run(ccdCallbackRequest, authToken, generateAosInvitation);
 
         if (issueEventWorkflow.errors().isEmpty()) {
             log.info("Petition issued callback for case with CASE ID: {} successfully completed",
-                caseDetailsRequest.getCaseDetails().getCaseId());
+                ccdCallbackRequest.getCaseDetails().getCaseId());
             return payLoad;
         } else {
             log.error("Petition issued callback for case with CASE ID: {} failed",
-                caseDetailsRequest.getCaseDetails().getCaseId());
+                ccdCallbackRequest.getCaseDetails().getCaseId());
             return issueEventWorkflow.errors();
         }
     }
 
     @Override
-    public Map<String, Object> ccdCallbackBulkPrintHandler(CreateEvent caseDetailsRequest, String authToken)
+    public Map<String, Object> ccdCallbackBulkPrintHandler(CcdCallbackRequest ccdCallbackRequest, String authToken)
         throws WorkflowException {
 
-        Map<String, Object> payLoad = ccdCallbackBulkPrintWorkflow.run(caseDetailsRequest, authToken);
+        Map<String, Object> payLoad = ccdCallbackBulkPrintWorkflow.run(ccdCallbackRequest, authToken);
 
         if (ccdCallbackBulkPrintWorkflow.errors().isEmpty()) {
             log.info("Bulk print callback for case with CASE ID: {} successfully completed",
-                caseDetailsRequest.getCaseDetails().getCaseId());
+                ccdCallbackRequest.getCaseDetails().getCaseId());
             return payLoad;
         } else {
             log.error("Bulk print callback for case with CASE ID: {} failed",
-                caseDetailsRequest.getCaseDetails().getCaseId());
+                ccdCallbackRequest.getCaseDetails().getCaseId());
             return ccdCallbackBulkPrintWorkflow.errors();
         }
     }
@@ -242,10 +242,10 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     }
 
     @Override
-    public CcdCallbackResponse aosReceived(CreateEvent caseDetailsRequest, String authToken) throws WorkflowException {
-        Map<String, Object> response = aosRespondedWorkflow.run(caseDetailsRequest, authToken);
+    public CcdCallbackResponse aosReceived(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException {
+        Map<String, Object> response = aosRespondedWorkflow.run(ccdCallbackRequest, authToken);
         log.info("Aos received notification completed with CASE ID: {}.",
-            caseDetailsRequest.getCaseDetails().getCaseId());
+            ccdCallbackRequest.getCaseDetails().getCaseId());
 
         if (aosRespondedWorkflow.errors().isEmpty()) {
             return CcdCallbackResponse.builder()
@@ -254,7 +254,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
         } else {
             Map<String, Object> workflowErrors = aosRespondedWorkflow.errors();
             log.error("Aos received notification with CASE ID: {} failed." + workflowErrors,
-                caseDetailsRequest.getCaseDetails().getCaseId());
+                ccdCallbackRequest.getCaseDetails().getCaseId());
             return CcdCallbackResponse
                 .builder()
                 .errors(getNotificationErrors(workflowErrors))
@@ -263,10 +263,10 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     }
 
     @Override
-    public CcdCallbackResponse sendCoRespReceivedNotificationEmail(CreateEvent caseDetailsRequest) throws WorkflowException {
-        Map<String, Object> response = sendCoRespondSubmissionNotificationWorkflow.run(caseDetailsRequest);
+    public CcdCallbackResponse sendCoRespReceivedNotificationEmail(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        Map<String, Object> response = sendCoRespondSubmissionNotificationWorkflow.run(ccdCallbackRequest);
         log.info("Co-respondent received notification completed with CASE ID: {}.",
-            caseDetailsRequest.getCaseDetails().getCaseId());
+            ccdCallbackRequest.getCaseDetails().getCaseId());
 
         if (sendCoRespondSubmissionNotificationWorkflow.errors().isEmpty()) {
             return CcdCallbackResponse.builder()
@@ -275,7 +275,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
         } else {
             Map<String, Object> workflowErrors = sendCoRespondSubmissionNotificationWorkflow.errors();
             log.error("Co-respondent received notification with CASE ID: {} failed." + workflowErrors,
-                caseDetailsRequest.getCaseDetails().getCaseId());
+                ccdCallbackRequest.getCaseDetails().getCaseId());
             return CcdCallbackResponse
                 .builder()
                 .errors(getNotificationErrors(workflowErrors))
@@ -293,39 +293,39 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
 
     @Override
     public Map<String, Object> sendPetitionerSubmissionNotificationEmail(
-            CreateEvent caseDetailsRequest) throws WorkflowException {
-        return sendPetitionerSubmissionNotificationWorkflow.run(caseDetailsRequest);
+            CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        return sendPetitionerSubmissionNotificationWorkflow.run(ccdCallbackRequest);
     }
 
     @Override
     public Map<String, Object> sendPetitionerGenericUpdateNotificationEmail(
-            CreateEvent caseDetailsRequest) throws WorkflowException {
-        return sendPetitionerGenericEmailNotificationWorkflow.run(caseDetailsRequest);
+            CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        return sendPetitionerGenericEmailNotificationWorkflow.run(ccdCallbackRequest);
     }
 
     @Override
-    public Map<String, Object> sendRespondentSubmissionNotificationEmail(CreateEvent caseDetailsRequest)
+    public Map<String, Object> sendRespondentSubmissionNotificationEmail(CcdCallbackRequest ccdCallbackRequest)
             throws WorkflowException {
-        return sendRespondentSubmissionNotificationWorkflow.run(caseDetailsRequest);
+        return sendRespondentSubmissionNotificationWorkflow.run(ccdCallbackRequest);
     }
 
     @Override
-    public Map<String, Object> setOrderSummary(CreateEvent caseDetailsRequest) throws WorkflowException {
-        return setOrderSummaryWorkflow.run(caseDetailsRequest.getCaseDetails().getCaseData());
+    public Map<String, Object> setOrderSummary(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        return setOrderSummaryWorkflow.run(ccdCallbackRequest.getCaseDetails().getCaseData());
     }
 
     @Override
-    public Map<String, Object> processPbaPayment(CreateEvent caseDetailsRequest,
+    public Map<String, Object> processPbaPayment(CcdCallbackRequest ccdCallbackRequest,
                                                  String authToken) throws WorkflowException {
-        Map<String, Object> payLoad = processPbaPaymentWorkflow.run(caseDetailsRequest, authToken);
+        Map<String, Object> payLoad = processPbaPaymentWorkflow.run(ccdCallbackRequest, authToken);
 
         if (processPbaPaymentWorkflow.errors().isEmpty()) {
             log.info("Callback pay by account for solicitor with CASE ID: {} successfully completed",
-                caseDetailsRequest.getCaseDetails().getCaseId());
+                ccdCallbackRequest.getCaseDetails().getCaseId());
             return payLoad;
         } else {
             log.error("Callback pay by account for solicitor with CASE ID: {} failed. ",
-                caseDetailsRequest
+                ccdCallbackRequest
                 .getCaseDetails()
                 .getCaseId());
             return processPbaPaymentWorkflow.errors();
@@ -333,8 +333,8 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     }
 
     @Override
-    public Map<String, Object> solicitorCreate(CreateEvent caseDetailsRequest) throws WorkflowException {
-        return solicitorCreateWorkflow.run(caseDetailsRequest.getCaseDetails().getCaseData());
+    public Map<String, Object> solicitorCreate(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        return solicitorCreateWorkflow.run(ccdCallbackRequest.getCaseDetails().getCaseData());
     }
 
     @Override
@@ -364,11 +364,11 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     }
 
     @Override
-    public CcdCallbackResponse dnSubmitted(CreateEvent caseDetailsRequest, String authToken) throws WorkflowException {
-        Map<String, Object> response = dnSubmittedWorkflow.run(caseDetailsRequest, authToken);
+    public CcdCallbackResponse dnSubmitted(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException {
+        Map<String, Object> response = dnSubmittedWorkflow.run(ccdCallbackRequest, authToken);
 
         if (dnSubmittedWorkflow.errors().isEmpty()) {
-            log.info("CASE ID: {}. DN submitted notification sent.", caseDetailsRequest
+            log.info("CASE ID: {}. DN submitted notification sent.", ccdCallbackRequest
                     .getCaseDetails()
                     .getCaseId());
             return CcdCallbackResponse.builder()
@@ -376,7 +376,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
                     .build();
         } else {
             Map<String, Object> workflowErrors = dnSubmittedWorkflow.errors();
-            log.error("CASE ID: {}. DN submitted notification failed." + workflowErrors, caseDetailsRequest
+            log.error("CASE ID: {}. DN submitted notification failed." + workflowErrors, ccdCallbackRequest
                     .getCaseDetails()
                     .getCaseId());
             return CcdCallbackResponse

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CcdCallbackBulkPrintWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CcdCallbackBulkPrintWorkflow.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
@@ -33,7 +33,7 @@ public class CcdCallbackBulkPrintWorkflow extends DefaultWorkflow<Map<String, Ob
         this.modifyDueDate = modifyDueDate;
     }
 
-    public Map<String, Object> run(CreateEvent caseDetailsRequest,
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest,
                                    String authToken) throws WorkflowException {
         return this.execute(
             new Task[] {
@@ -41,9 +41,9 @@ public class CcdCallbackBulkPrintWorkflow extends DefaultWorkflow<Map<String, Ob
                 bulkPrinter,
                 modifyDueDate
             },
-            caseDetailsRequest.getCaseDetails().getCaseData(),
+            ccdCallbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
-            ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetailsRequest.getCaseDetails())
+            ImmutablePair.of(CASE_DETAILS_JSON_KEY, ccdCallbackRequest.getCaseDetails())
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DNSubmittedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DNSubmittedWorkflow.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
@@ -20,16 +20,16 @@ public class DNSubmittedWorkflow extends DefaultWorkflow<Map<String, Object>> {
     @Autowired
     private DnSubmittedEmailNotificationTask genericEmailNotification;
 
-    public Map<String, Object> run(CreateEvent caseDetailsRequest,
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest,
                                    String authToken) throws WorkflowException {
 
-        String caseId = caseDetailsRequest.getCaseDetails().getCaseId();
+        String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
 
         return this.execute(
                 new Task[] {
                     genericEmailNotification
                 },
-                caseDetailsRequest.getCaseDetails().getCaseData(),
+                ccdCallbackRequest.getCaseDetails().getCaseData(),
                 ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
                 ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
         );

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssueEventWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssueEventWorkflow.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
@@ -67,7 +67,7 @@ public class IssueEventWorkflow extends DefaultWorkflow<Map<String, Object>> {
         this.caseFormatterAddDocuments = caseFormatterAddDocuments;
     }
 
-    public Map<String, Object> run(CreateEvent caseDetailsRequest,
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest,
                                    String authToken, boolean generateAosInvitation) throws WorkflowException {
 
         List<Task> tasks = new ArrayList<>();
@@ -76,7 +76,7 @@ public class IssueEventWorkflow extends DefaultWorkflow<Map<String, Object>> {
         tasks.add(setIssueDate);
         tasks.add(petitionGenerator);
 
-        final Map<String, Object> caseData = caseDetailsRequest.getCaseDetails().getCaseData();
+        final Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
 
         if (generateAosInvitation && isServiceCentreDivorceUnit(caseData)) {
             tasks.add(respondentPinGenerator);
@@ -98,7 +98,7 @@ public class IssueEventWorkflow extends DefaultWorkflow<Map<String, Object>> {
             tasks.toArray(new Task[tasks.size()]),
             caseData,
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
-            ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetailsRequest.getCaseDetails())
+            ImmutablePair.of(CASE_DETAILS_JSON_KEY, ccdCallbackRequest.getCaseDetails())
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ProcessPbaPaymentWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ProcessPbaPaymentWorkflow.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
@@ -28,15 +28,15 @@ public class ProcessPbaPaymentWorkflow extends DefaultWorkflow<Map<String, Objec
         this.processPbaPayment = processPbaPayment;
     }
 
-    public Map<String, Object> run(CreateEvent caseDetailsRequest, String authToken) throws WorkflowException {
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException {
 
         return this.execute(new Task[] {
             validateSolicitorCaseData,
             processPbaPayment
         },
-            caseDetailsRequest.getCaseDetails().getCaseData(),
+            ccdCallbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
-            ImmutablePair.of(CASE_ID_JSON_KEY, caseDetailsRequest.getCaseDetails().getCaseId())
+            ImmutablePair.of(CASE_ID_JSON_KEY, ccdCallbackRequest.getCaseDetails().getCaseId())
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/RespondentSubmittedCallbackWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/RespondentSubmittedCallbackWorkflow.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
@@ -40,8 +40,8 @@ public class RespondentSubmittedCallbackWorkflow extends DefaultWorkflow<Map<Str
         this.emailNotificationTask = emailNotificationTask;
     }
 
-    public Map<String, Object> run(CreateEvent caseDetailsRequest, String authToken) throws WorkflowException {
-        CaseDetails caseDetails = caseDetailsRequest.getCaseDetails();
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException {
+        CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();
         String ref = getFieldAsStringOrNull(caseDetails, D_8_CASE_REFERENCE);
 
         String firstName = getFieldAsStringOrNull(caseDetails, D_8_PETITIONER_FIRST_NAME);
@@ -60,7 +60,7 @@ public class RespondentSubmittedCallbackWorkflow extends DefaultWorkflow<Map<Str
             new Task[]{
                 emailNotificationTask
             },
-            caseDetailsRequest.getCaseDetails().getCaseData(),
+            ccdCallbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(NOTIFICATION_EMAIL, petitionerEmail),
             ImmutablePair.of(NOTIFICATION_TEMPLATE_VARS, notificationTemplateVars),

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflow.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.Court;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
@@ -46,8 +46,8 @@ public class SendCoRespondSubmissionNotificationWorkflow extends DefaultWorkflow
     @Autowired
     private final TaskCommons taskCommons;
 
-    public Map<String, Object> run(CreateEvent caseRequestDetails) throws WorkflowException {
-        Map<String, Object> caseData = caseRequestDetails.getCaseDetails().getCaseData();
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
 
         String caseNumber = (String) caseData.get(D_8_CASE_REFERENCE);
         String firstName = (String) caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME);
@@ -81,7 +81,7 @@ public class SendCoRespondSubmissionNotificationWorkflow extends DefaultWorkflow
             emailTask
             },
             caseData,
-            ImmutablePair.of(CASE_ID_JSON_KEY, caseRequestDetails.getCaseDetails().getCaseId()),
+            ImmutablePair.of(CASE_ID_JSON_KEY, ccdCallbackRequest.getCaseDetails().getCaseId()),
             ImmutablePair.of(NOTIFICATION_EMAIL, corespondentEmail),
             ImmutablePair.of(NOTIFICATION_TEMPLATE, template),
             ImmutablePair.of(NOTIFICATION_TEMPLATE_VARS, templateVars)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerGenericEmailNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerGenericEmailNotificationWorkflow.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
@@ -24,13 +24,13 @@ public class SendPetitionerGenericEmailNotificationWorkflow extends DefaultWorkf
         this.sendPetitionerUpdateNotificationsEmail = sendPetitionerUpdateNotificationsEmail;
     }
 
-    public Map<String, Object> run(CreateEvent caseRequestDetails) throws WorkflowException {
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return this.execute(
                 new Task[] {
                     sendPetitionerUpdateNotificationsEmail,
                 },
-                caseRequestDetails.getCaseDetails().getCaseData(),
-                ImmutablePair.of(CASE_ID_JSON_KEY, caseRequestDetails.getCaseDetails().getCaseId())
+                ccdCallbackRequest.getCaseDetails().getCaseData(),
+                ImmutablePair.of(CASE_ID_JSON_KEY, ccdCallbackRequest.getCaseDetails().getCaseId())
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerSubmissionNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerSubmissionNotificationWorkflow.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
@@ -24,13 +24,13 @@ public class SendPetitionerSubmissionNotificationWorkflow extends DefaultWorkflo
         this.sendPetitionerSubmissionNotificationEmail = sendPetitionerSubmissionNotificationEmail;
     }
 
-    public Map<String, Object> run(CreateEvent caseRequestDetails) throws WorkflowException {
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return this.execute(
             new Task[] {
                 sendPetitionerSubmissionNotificationEmail,
             },
-            caseRequestDetails.getCaseDetails().getCaseData(),
-            ImmutablePair.of(CASE_ID_JSON_KEY, caseRequestDetails.getCaseDetails().getCaseId())
+            ccdCallbackRequest.getCaseDetails().getCaseData(),
+            ImmutablePair.of(CASE_ID_JSON_KEY, ccdCallbackRequest.getCaseDetails().getCaseId())
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflow.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
@@ -30,8 +30,8 @@ public class SendRespondentSubmissionNotificationWorkflow extends DefaultWorkflo
     private SendRespondentSubmissionNotificationForUndefendedDivorceEmail
             sendRespondentSubmissionNotificationForUndefendedDivorceEmailTask;
 
-    public Map<String, Object> run(CreateEvent caseRequestDetails) throws WorkflowException {
-        Map<String, Object> caseData = caseRequestDetails.getCaseDetails().getCaseData();
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
         String defended = (String)caseData.get(RESP_WILL_DEFEND_DIVORCE);
 
         Task[] tasks;
@@ -49,7 +49,7 @@ public class SendRespondentSubmissionNotificationWorkflow extends DefaultWorkflo
 
         return execute(tasks,
                 caseData,
-                ImmutablePair.of(CASE_ID_JSON_KEY, caseRequestDetails.getCaseDetails().getCaseId())
+                ImmutablePair.of(CASE_ID_JSON_KEY, ccdCallbackRequest.getCaseDetails().getCaseId())
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
@@ -11,9 +11,9 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CaseDataResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseCreationResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DocumentLink;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.AllocatedCourt;
@@ -62,16 +62,16 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
         CcdCallbackResponse expected = CcdCallbackResponse.builder().data(Collections.emptyMap()).build();
 
-        when(caseOrchestrationService.handleIssueEventCallback(createEvent, AUTH_TOKEN, true))
+        when(caseOrchestrationService.handleIssueEventCallback(ccdCallbackRequest, AUTH_TOKEN, true))
             .thenReturn(Collections.emptyMap());
 
         ResponseEntity<CcdCallbackResponse> actual = classUnderTest.petitionIssuedCallback(AUTH_TOKEN,
-            true, createEvent);
+            true, ccdCallbackRequest);
 
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(expected, actual.getBody());
@@ -94,16 +94,16 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
         CcdCallbackResponse expected =
             CcdCallbackResponse.builder().errors(Collections.emptyList()).warnings(Collections.emptyList())
                 .data(Collections.emptyMap()).build();
 
-        when(caseOrchestrationService.ccdCallbackBulkPrintHandler(createEvent, AUTH_TOKEN))
+        when(caseOrchestrationService.ccdCallbackBulkPrintHandler(ccdCallbackRequest, AUTH_TOKEN))
             .thenReturn(Collections.emptyMap());
-        ResponseEntity<CcdCallbackResponse> actual = classUnderTest.bulkPrint(AUTH_TOKEN, createEvent);
+        ResponseEntity<CcdCallbackResponse> actual = classUnderTest.bulkPrint(AUTH_TOKEN, ccdCallbackRequest);
 
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(expected, actual.getBody());
@@ -123,18 +123,18 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
         CcdCallbackResponse expected = CcdCallbackResponse.builder()
             .errors(expectedError)
             .build();
 
-        when(caseOrchestrationService.handleIssueEventCallback(createEvent, AUTH_TOKEN, false))
+        when(caseOrchestrationService.handleIssueEventCallback(ccdCallbackRequest, AUTH_TOKEN, false))
             .thenReturn(caseData);
 
         ResponseEntity<CcdCallbackResponse> actual = classUnderTest.petitionIssuedCallback(AUTH_TOKEN,
-            false, createEvent);
+            false, ccdCallbackRequest);
 
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(expected, actual.getBody());
@@ -332,12 +332,12 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
-        when(caseOrchestrationService.sendPetitionerSubmissionNotificationEmail(createEvent)).thenReturn(caseData);
+        when(caseOrchestrationService.sendPetitionerSubmissionNotificationEmail(ccdCallbackRequest)).thenReturn(caseData);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.petitionSubmitted(null, createEvent);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.petitionSubmitted(null, ccdCallbackRequest);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
 
@@ -351,10 +351,10 @@ public class OrchestrationControllerTest {
         final CaseDetails caseDetails = CaseDetails.builder()
             .caseData(caseData)
             .build();
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
-        when(caseOrchestrationService.sendPetitionerGenericUpdateNotificationEmail(createEvent)).thenReturn(caseData);
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.petitionUpdated(null, createEvent);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
+        when(caseOrchestrationService.sendPetitionerGenericUpdateNotificationEmail(ccdCallbackRequest)).thenReturn(caseData);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.petitionUpdated(null, ccdCallbackRequest);
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(expectedResponse, response.getBody());
@@ -366,11 +366,11 @@ public class OrchestrationControllerTest {
         final CaseDetails caseDetails = CaseDetails.builder()
             .caseData(caseData)
             .build();
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
-        when(caseOrchestrationService.sendRespondentSubmissionNotificationEmail(createEvent)).thenReturn(caseData);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
+        when(caseOrchestrationService.sendRespondentSubmissionNotificationEmail(ccdCallbackRequest)).thenReturn(caseData);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.respondentAOSSubmitted(null, createEvent);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.respondentAOSSubmitted(null, ccdCallbackRequest);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
@@ -384,12 +384,12 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
-        when(caseOrchestrationService.setOrderSummary(createEvent)).thenReturn(caseData);
+        when(caseOrchestrationService.setOrderSummary(ccdCallbackRequest)).thenReturn(caseData);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.getPetitionIssueFees(createEvent);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.getPetitionIssueFees(ccdCallbackRequest);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
 
@@ -404,12 +404,12 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
-        when(caseOrchestrationService.processPbaPayment(createEvent, AUTH_TOKEN)).thenReturn(caseData);
+        when(caseOrchestrationService.processPbaPayment(ccdCallbackRequest, AUTH_TOKEN)).thenReturn(caseData);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.processPbaPayment(AUTH_TOKEN, createEvent);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.processPbaPayment(AUTH_TOKEN, ccdCallbackRequest);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
 
@@ -428,12 +428,12 @@ public class OrchestrationControllerTest {
             Collections.singletonList(ERROR_STATUS)
         );
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
-        when(caseOrchestrationService.processPbaPayment(createEvent, AUTH_TOKEN)).thenReturn(invalidResponse);
+        when(caseOrchestrationService.processPbaPayment(ccdCallbackRequest, AUTH_TOKEN)).thenReturn(invalidResponse);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.processPbaPayment(AUTH_TOKEN, createEvent);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.processPbaPayment(AUTH_TOKEN, ccdCallbackRequest);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder()
             .errors(Collections.singletonList(ERROR_STATUS))
@@ -450,12 +450,12 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
 
-        when(caseOrchestrationService.solicitorCreate(createEvent)).thenReturn(caseData);
+        when(caseOrchestrationService.solicitorCreate(ccdCallbackRequest)).thenReturn(caseData);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorCreate(createEvent);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorCreate(ccdCallbackRequest);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
 
@@ -513,14 +513,14 @@ public class OrchestrationControllerTest {
             .caseData(caseData)
             .build();
 
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
 
-        when(caseOrchestrationService.dnSubmitted(createEvent, AUTH_TOKEN)).thenReturn(expectedResponse);
+        when(caseOrchestrationService.dnSubmitted(ccdCallbackRequest, AUTH_TOKEN)).thenReturn(expectedResponse);
 
         ResponseEntity<CcdCallbackResponse> response = classUnderTest
-            .dnSubmitted(AUTH_TOKEN, createEvent);
+            .dnSubmitted(AUTH_TOKEN, ccdCallbackRequest);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(expectedResponse, response.getBody());
@@ -548,13 +548,13 @@ public class OrchestrationControllerTest {
         final CaseDetails caseDetails = CaseDetails.builder()
             .caseData(caseData)
             .build();
-        final CreateEvent createEvent = new CreateEvent();
-        createEvent.setCaseDetails(caseDetails);
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
 
-        when(caseOrchestrationService.sendCoRespReceivedNotificationEmail(createEvent)).thenReturn(expectedResponse);
+        when(caseOrchestrationService.sendCoRespReceivedNotificationEmail(ccdCallbackRequest)).thenReturn(expectedResponse);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.corespReceived( createEvent);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.corespReceived( ccdCallbackRequest);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(expectedResponse, response.getBody());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/AosRespondentSubmittedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/AosRespondentSubmittedITest.java
@@ -16,8 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.client.EmailClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -92,7 +92,7 @@ public class AosRespondentSubmittedITest {
 
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
 
-        CreateEvent caseEvent = CreateEvent.builder().eventId(EVENT_ID)
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().eventId(EVENT_ID)
                 .caseDetails(CaseDetails.builder()
                         .caseId(CASE_ID)
                         .caseData(caseDetailMap)
@@ -101,7 +101,7 @@ public class AosRespondentSubmittedITest {
 
         webClient.perform(post(API_URL)
                 .header(AUTHORIZATION, USER_TOKEN)
-                .content(ObjectMapperTestUtil.convertObjectToJsonString(caseEvent))
+                .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(expectedResponse));
@@ -117,7 +117,7 @@ public class AosRespondentSubmittedITest {
                 D_8_CASE_REFERENCE, D8_ID
         );
 
-        CreateEvent caseEvent = CreateEvent.builder().eventId(CASE_ID)
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().eventId(CASE_ID)
                 .caseDetails(CaseDetails.builder()
                         .caseData(caseDetailMap)
                         .build())
@@ -125,12 +125,12 @@ public class AosRespondentSubmittedITest {
 
         CcdCallbackResponse ccdCallbackResponse = CcdCallbackResponse
                 .builder()
-                .data(caseEvent.getCaseDetails().getCaseData())
+                .data(ccdCallbackRequest.getCaseDetails().getCaseData())
                 .build();
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
         webClient.perform(post(API_URL)
                 .header(AUTHORIZATION, USER_TOKEN)
-                .content(ObjectMapperTestUtil.convertObjectToJsonString(caseEvent))
+                .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(expectedResponse));
@@ -146,7 +146,7 @@ public class AosRespondentSubmittedITest {
                 D_8_CASE_REFERENCE, D8_ID
         );
 
-        CreateEvent caseEvent = CreateEvent.builder().eventId(EVENT_ID)
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().eventId(EVENT_ID)
                 .caseDetails(CaseDetails.builder()
                         .caseId(CASE_ID)
                         .caseData(caseDetailMap)
@@ -163,7 +163,7 @@ public class AosRespondentSubmittedITest {
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
         webClient.perform(post(API_URL)
                 .header(AUTHORIZATION, USER_TOKEN)
-                .content(ObjectMapperTestUtil.convertObjectToJsonString(caseEvent))
+                .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(expectedResponse));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentSubmittedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentSubmittedITest.java
@@ -16,8 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.client.EmailClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.Court;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.TaskCommons;
 import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
@@ -100,7 +100,7 @@ public class CoRespondentSubmittedITest {
             CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
             CO_RESPONDENT_DEFENDS_DIVORCE, NO_VALUE
         );
-        CreateEvent caseEvent = CreateEvent.builder().eventId(CASE_ID)
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().eventId(CASE_ID)
                 .caseDetails(CaseDetails.builder()
                         .caseData(caseDetailMap)
                         .build())
@@ -108,12 +108,12 @@ public class CoRespondentSubmittedITest {
 
         CcdCallbackResponse ccdCallbackResponse = CcdCallbackResponse
                 .builder()
-                .data(caseEvent.getCaseDetails().getCaseData())
+                .data(ccdCallbackRequest.getCaseDetails().getCaseData())
                 .build();
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
         webClient.perform(post(API_URL)
                 .header(AUTHORIZATION, USER_TOKEN)
-                .content(ObjectMapperTestUtil.convertObjectToJsonString(caseEvent))
+                .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(expectedResponse));
@@ -133,7 +133,7 @@ public class CoRespondentSubmittedITest {
         caseDetailMap.put(D_8_DIVORCE_UNIT, TEST_COURT);
 
 
-        CreateEvent caseEvent = CreateEvent.builder().eventId(EVENT_ID)
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().eventId(EVENT_ID)
                 .caseDetails(CaseDetails.builder()
                         .caseId(CASE_ID)
                         .caseData(caseDetailMap)
@@ -142,13 +142,13 @@ public class CoRespondentSubmittedITest {
 
         CcdCallbackResponse ccdCallbackResponse = CcdCallbackResponse
             .builder()
-            .data(caseEvent.getCaseDetails().getCaseData())
+            .data(ccdCallbackRequest.getCaseDetails().getCaseData())
             .build();
 
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
         webClient.perform(post(API_URL)
                 .header(AUTHORIZATION, USER_TOKEN)
-                .content(ObjectMapperTestUtil.convertObjectToJsonString(caseEvent))
+                .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(expectedResponse));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/GetPetitionIssueFeesITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/GetPetitionIssueFeesITest.java
@@ -17,8 +17,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees.FeeResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees.OrderSummary;
 
@@ -58,7 +58,7 @@ public class GetPetitionIssueFeesITest {
                     .state(TEST_STATE)
                     .build();
 
-    private static final CreateEvent CREATE_EVENT = CreateEvent.builder()
+    private static final CcdCallbackRequest CREATE_EVENT = CcdCallbackRequest.builder()
             .caseDetails(CASE_DETAILS)
             .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
@@ -20,8 +20,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.DocumentUpdateRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GenerateDocumentRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
@@ -102,7 +102,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
             .caseId(TEST_CASE_ID)
             .build();
 
-    private static final CreateEvent CREATE_EVENT = CreateEvent.builder()
+    private static final CcdCallbackRequest CREATE_EVENT = CcdCallbackRequest.builder()
             .caseDetails(CASE_DETAILS)
             .build();
 
@@ -131,7 +131,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
     }
 
     @Test
-    public void givenCreateEventIsNull_whenPetitionIssued_thenReturnBadRequest()
+    public void givenCallbackRequestIsNull_whenPetitionIssued_thenReturnBadRequest()
             throws Exception {
         webClient.perform(post(API_URL)
                 .header(AUTHORIZATION, AUTH_TOKEN)
@@ -333,8 +333,8 @@ public class PetitionIssuedITest extends IdamTestSupport {
     public void givenGenerateInvitationIsTrueAndIsServiceCentre_whenPetitionIssued_thenReturnCaseExpectedChanges()
         throws Exception {
 
-        CreateEvent createEventWithServiceCentre = CREATE_EVENT;
-        createEventWithServiceCentre.getCaseDetails().getCaseData().put(D_8_DIVORCE_UNIT, DIVORCE_UNIT_SERVICE_CENTRE);
+        CcdCallbackRequest ccdCallbackRequestWithServiceCentre = CREATE_EVENT;
+        ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData().put(D_8_DIVORCE_UNIT, DIVORCE_UNIT_SERVICE_CENTRE);
 
         final ValidationResponse validationResponse = ValidationResponse.builder().build();
 
@@ -350,7 +350,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
             GenerateDocumentRequest.builder()
                 .template(MINI_PETITION_TEMPLATE_NAME)
                 .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
-                        createEventWithServiceCentre.getCaseDetails()))
+                        ccdCallbackRequestWithServiceCentre.getCaseDetails()))
                 .build();
 
         final GeneratedDocumentInfo generatedMiniPetitionResponse =
@@ -363,7 +363,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
             GenerateDocumentRequest.builder()
                 .template(RESPONDENT_INVITATION_TEMPLATE_NAME)
                 .values(ImmutableMap.of(
-                    DOCUMENT_CASE_DETAILS_JSON_KEY, createEventWithServiceCentre.getCaseDetails(),
+                    DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
                     ACCESS_CODE, TEST_PIN_CODE))
                 .build();
 
@@ -376,7 +376,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
                 .documents(asList(generatedMiniPetitionResponse, generatedAosInvitationResponse))
-                .caseData(createEventWithServiceCentre.getCaseDetails().getCaseData())
+                .caseData(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
                 .build();
 
         final Map<String, Object> formattedCaseData = emptyMap();
@@ -384,7 +384,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
         stubSignIn();
         stubPinDetailsEndpoint(BEARER_AUTH_TOKEN_1, pinRequest, pin);
         stubValidationServerEndpoint(HttpStatus.OK,
-            ValidationRequest.builder().data(createEventWithServiceCentre.getCaseDetails().getCaseData())
+            ValidationRequest.builder().data(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
                 .formId(FORM_ID).build(),
             convertObjectToJsonString(validationResponse));
         stubDocumentGeneratorServerEndpoint(generateMiniPetitionRequest, generatedMiniPetitionResponse);
@@ -395,7 +395,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)
-            .content(convertObjectToJsonString(createEventWithServiceCentre))
+            .content(convertObjectToJsonString(ccdCallbackRequestWithServiceCentre))
             .param(GENERATE_AOS_INVITATION, "true")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
@@ -407,10 +407,10 @@ public class PetitionIssuedITest extends IdamTestSupport {
     public void givenGenerateInvitationIsTrueAndIsServiceCentreAndCoRespondentExists_whenPetitionIssued_thenReturnCaseExpectedChanges()
         throws Exception {
 
-        CreateEvent createEventWithServiceCentre = CREATE_EVENT;
-        createEventWithServiceCentre.getCaseDetails().getCaseData().put(D_8_DIVORCE_UNIT, DIVORCE_UNIT_SERVICE_CENTRE);
-        createEventWithServiceCentre.getCaseDetails().getCaseData().put(D_8_REASON_FOR_DIVORCE, ADULTERY);
-        createEventWithServiceCentre.getCaseDetails().getCaseData().put(D_8_CO_RESPONDENT_NAMED, "YES");
+        CcdCallbackRequest ccdCallbackRequestWithServiceCentre = CREATE_EVENT;
+        ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData().put(D_8_DIVORCE_UNIT, DIVORCE_UNIT_SERVICE_CENTRE);
+        ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData().put(D_8_REASON_FOR_DIVORCE, ADULTERY);
+        ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData().put(D_8_CO_RESPONDENT_NAMED, "YES");
 
         final ValidationResponse validationResponse = ValidationResponse.builder().build();
 
@@ -426,7 +426,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
             GenerateDocumentRequest.builder()
                 .template(MINI_PETITION_TEMPLATE_NAME)
                 .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
-                    createEventWithServiceCentre.getCaseDetails()))
+                    ccdCallbackRequestWithServiceCentre.getCaseDetails()))
                 .build();
 
         final GeneratedDocumentInfo generatedMiniPetitionResponse =
@@ -439,7 +439,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
             GenerateDocumentRequest.builder()
                 .template(RESPONDENT_INVITATION_TEMPLATE_NAME)
                 .values(ImmutableMap.of(
-                    DOCUMENT_CASE_DETAILS_JSON_KEY, createEventWithServiceCentre.getCaseDetails(),
+                    DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
                     ACCESS_CODE, TEST_PIN_CODE))
                 .build();
 
@@ -453,7 +453,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
             GenerateDocumentRequest.builder()
                 .template(CO_RESPONDENT_INVITATION_TEMPLATE_NAME)
                 .values(ImmutableMap.of(
-                    DOCUMENT_CASE_DETAILS_JSON_KEY, createEventWithServiceCentre.getCaseDetails(),
+                    DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
                     ACCESS_CODE, TEST_PIN_CODE,
                     PETITION_ISSUE_FEE_FOR_LETTER, "550"))
                 .build();
@@ -469,7 +469,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
         stubSignIn();
         stubPinDetailsEndpoint(BEARER_AUTH_TOKEN_1, pinRequest, pin);
         stubValidationServerEndpoint(HttpStatus.OK,
-            ValidationRequest.builder().data(createEventWithServiceCentre.getCaseDetails().getCaseData())
+            ValidationRequest.builder().data(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
                 .formId(FORM_ID).build(),
             convertObjectToJsonString(validationResponse));
         stubDocumentGeneratorServerEndpoint(generateMiniPetitionRequest, generatedMiniPetitionResponse);
@@ -484,14 +484,14 @@ public class PetitionIssuedITest extends IdamTestSupport {
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
                 .documents(asList(generatedMiniPetitionResponse, generatedAosInvitationResponse, generatedCoRespondentInvitationResponse))
-                .caseData(createEventWithServiceCentre.getCaseDetails().getCaseData())
+                .caseData(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
                 .build();
 
         stubFormatterServerEndpoint(documentUpdateRequest, formattedCaseData);
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)
-            .content(convertObjectToJsonString(createEventWithServiceCentre))
+            .content(convertObjectToJsonString(ccdCallbackRequestWithServiceCentre))
             .param(GENERATE_AOS_INVITATION, "true")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionSubmissionNotificationEmailITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionSubmissionNotificationEmailITest.java
@@ -18,8 +18,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -54,7 +54,7 @@ public class PetitionSubmissionNotificationEmailITest {
     private static final String EMAIL_CONTEXT_PATH = "https://api.notifications.service.gov.uk";
 
     private Map<String, Object> caseData;
-    private CreateEvent createEvent;
+    private CcdCallbackRequest ccdCallbackRequest;
 
     @Autowired
     private MockMvc webClient;
@@ -76,7 +76,7 @@ public class PetitionSubmissionNotificationEmailITest {
             .state(TEST_STATE)
             .build();
 
-        createEvent = CreateEvent.builder()
+        ccdCallbackRequest = CcdCallbackRequest.builder()
                 .caseDetails(caseDetails)
                 .build();
     }
@@ -90,7 +90,7 @@ public class PetitionSubmissionNotificationEmailITest {
         stubEmailServerEndpoint();
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentITest.java
@@ -19,8 +19,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees.FeeResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees.FeeValue;
@@ -91,7 +91,7 @@ public class ProcessPbaPaymentITest {
 
     private Map<String, Object> caseData;
     private CaseDetails caseDetails;
-    private CreateEvent createEvent;
+    private CcdCallbackRequest ccdCallbackRequest;
     private CreditAccountPaymentRequest request;
 
     @Before
@@ -151,7 +151,7 @@ public class ProcessPbaPaymentITest {
                         .state(TEST_STATE)
                         .build();
 
-        createEvent = CreateEvent.builder()
+        ccdCallbackRequest = CcdCallbackRequest.builder()
                         .caseDetails(caseDetails)
                         .build();
 
@@ -163,7 +163,7 @@ public class ProcessPbaPaymentITest {
         stubServiceAuthProvider(HttpStatus.OK, TEST_SERVICE_AUTH_TOKEN);
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .header(AUTHORIZATION, AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -182,7 +182,7 @@ public class ProcessPbaPaymentITest {
                 .state(TEST_STATE)
                 .build();
 
-        createEvent = CreateEvent.builder()
+        ccdCallbackRequest = CcdCallbackRequest.builder()
                 .caseDetails(caseDetails)
                 .build();
 
@@ -193,7 +193,7 @@ public class ProcessPbaPaymentITest {
                 .build();
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .header(AUTHORIZATION, AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RespondentAOSSubmissionNotificationEmailITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RespondentAOSSubmissionNotificationEmailITest.java
@@ -13,8 +13,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.client.EmailClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.service.notify.NotificationClientException;
 
 import java.util.Map;
@@ -58,15 +58,15 @@ public class RespondentAOSSubmissionNotificationEmailITest {
     @Test
     public void testResponseHasDataAndNoErrors_whenEmailCanBeSent_forDefendedDivorce() throws Exception {
 
-        CreateEvent createEvent = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CreateEvent.class);
-        Map<String, Object> caseData = createEvent.getCaseDetails().getCaseData();
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CcdCallbackRequest.class);
+        Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
         CcdCallbackResponse expected = CcdCallbackResponse.builder()
                 .data(caseData)
                 .build();
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -83,15 +83,15 @@ public class RespondentAOSSubmissionNotificationEmailITest {
 
     @Test
     public void testResponseHasDataAndNoErrors_WhenEmailCanBeSent_ForUndefendedDivorce() throws Exception {
-        CreateEvent createEvent = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CreateEvent.class);
-        Map<String, Object> caseData = createEvent.getCaseDetails().getCaseData();
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CcdCallbackRequest.class);
+        Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
         CcdCallbackResponse expected = CcdCallbackResponse.builder()
                 .data(caseData)
                 .build();
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -108,11 +108,11 @@ public class RespondentAOSSubmissionNotificationEmailITest {
 
     @Test
     public void testResponseHasValidationErrors_WhenItIsNotClearIfDivorceWillBeDefended() throws Exception {
-        CreateEvent createEvent = getJsonFromResourceFile(
-                "/jsonExamples/payloads/unclearAcknowledgementOfService.json", CreateEvent.class);
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/unclearAcknowledgementOfService.json", CcdCallbackRequest.class);
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -126,11 +126,11 @@ public class RespondentAOSSubmissionNotificationEmailITest {
 
     @Test
     public void testResponseHasValidationErrors_WhenCaseIdIsMissing_ForDefendedDivorce() throws Exception {
-        CreateEvent createEvent = getJsonFromResourceFile(
-                "/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json", CreateEvent.class);
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json", CcdCallbackRequest.class);
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -144,11 +144,11 @@ public class RespondentAOSSubmissionNotificationEmailITest {
 
     @Test
     public void testResponseHasValidationErrors_WhenFieldsAreMissing_ForDefendedDivorce() throws Exception {
-        CreateEvent createEvent = getJsonFromResourceFile(
-                "/jsonExamples/payloads/defendedDivorceAOSMissingFields.json", CreateEvent.class);
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/defendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -163,11 +163,11 @@ public class RespondentAOSSubmissionNotificationEmailITest {
 
     @Test
     public void testResponseHasValidationErrors_WhenFieldsAreMissing_ForUndefendedDivorce() throws Exception {
-        CreateEvent createEvent = getJsonFromResourceFile(
-                "/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json", CreateEvent.class);
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -182,12 +182,12 @@ public class RespondentAOSSubmissionNotificationEmailITest {
 
     @Test
     public void testResponseHasError_IfEmailCannotBeSent() throws Exception {
-        CreateEvent createEvent = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CreateEvent.class);
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CcdCallbackRequest.class);
         doThrow(NotificationClientException.class).when(mockClient).sendEmail(any(), any(), any(), any());
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(createEvent))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
@@ -13,8 +13,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
@@ -49,7 +49,7 @@ public class SolicitorCreateITest {
                     .state(TEST_STATE)
                     .build();
 
-    private static final CreateEvent CREATE_EVENT = CreateEvent.builder()
+    private static final CcdCallbackRequest CREATE_EVENT = CcdCallbackRequest.builder()
             .caseDetails(CASE_DETAILS)
             .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -9,8 +9,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CaseDataResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Fee;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.Payment;
@@ -136,7 +136,7 @@ public class CaseOrchestrationServiceImplTest {
     @Mock
     private AuthUtil authUtil;
 
-    private CreateEvent createEventRequest;
+    private CcdCallbackRequest ccdCallbackRequest;
 
     private Map<String, Object> requestPayload;
 
@@ -145,7 +145,7 @@ public class CaseOrchestrationServiceImplTest {
     @Before
     public void setUp() {
         requestPayload = Collections.emptyMap();
-        createEventRequest = CreateEvent.builder()
+        ccdCallbackRequest = CcdCallbackRequest.builder()
                 .caseDetails(
                         CaseDetails.builder()
                                 .caseData(requestPayload)
@@ -162,10 +162,10 @@ public class CaseOrchestrationServiceImplTest {
     public void givenGenerateInvitationIsTrue_whenCcdCallbackHandler_thenReturnExpected()
             throws WorkflowException {
         //given
-        when(issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, true)).thenReturn(expectedPayload);
+        when(issueEventWorkflow.run(ccdCallbackRequest, AUTH_TOKEN, true)).thenReturn(expectedPayload);
 
         //when
-        Map<String, Object> actual = classUnderTest.handleIssueEventCallback(createEventRequest, AUTH_TOKEN, true);
+        Map<String, Object> actual = classUnderTest.handleIssueEventCallback(ccdCallbackRequest, AUTH_TOKEN, true);
 
         //then
         assertEquals(expectedPayload, actual);
@@ -176,10 +176,10 @@ public class CaseOrchestrationServiceImplTest {
     public void givenGenerateInvitationIsFalse_whenCcdCallbackHandler_thenReturnExpected()
         throws WorkflowException {
         //given
-        when(issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, false)).thenReturn(expectedPayload);
+        when(issueEventWorkflow.run(ccdCallbackRequest, AUTH_TOKEN, false)).thenReturn(expectedPayload);
 
         //when
-        Map<String, Object> actual = classUnderTest.handleIssueEventCallback(createEventRequest, AUTH_TOKEN, false);
+        Map<String, Object> actual = classUnderTest.handleIssueEventCallback(ccdCallbackRequest, AUTH_TOKEN, false);
 
         //then
         assertEquals(expectedPayload, actual);
@@ -404,39 +404,39 @@ public class CaseOrchestrationServiceImplTest {
     @Test
     public void givenCaseData_whenSendPetitionerSubmissionNotification_thenReturnPayload() throws Exception {
         // given
-        when(sendPetitionerSubmissionNotificationWorkflow.run(createEventRequest))
+        when(sendPetitionerSubmissionNotificationWorkflow.run(ccdCallbackRequest))
                 .thenReturn(requestPayload);
 
         // when
-        Map<String, Object> actual = classUnderTest.sendPetitionerSubmissionNotificationEmail(createEventRequest);
+        Map<String, Object> actual = classUnderTest.sendPetitionerSubmissionNotificationEmail(ccdCallbackRequest);
 
         // then
         assertEquals(requestPayload, actual);
 
-        verify(sendPetitionerSubmissionNotificationWorkflow).run(createEventRequest);
+        verify(sendPetitionerSubmissionNotificationWorkflow).run(ccdCallbackRequest);
     }
 
     @Test
     public void givenCaseData_whenSendPetitionerGenericEmailNotification_thenReturnPayload() throws Exception {
         // given
-        when(sendPetitionerGenericEmailNotificationWorkflow.run(createEventRequest))
+        when(sendPetitionerGenericEmailNotificationWorkflow.run(ccdCallbackRequest))
                 .thenReturn(requestPayload);
         // when
-        Map<String, Object> actual = classUnderTest.sendPetitionerGenericUpdateNotificationEmail(createEventRequest);
+        Map<String, Object> actual = classUnderTest.sendPetitionerGenericUpdateNotificationEmail(ccdCallbackRequest);
         // then
         assertEquals(requestPayload, actual);
-        verify(sendPetitionerGenericEmailNotificationWorkflow).run(createEventRequest);
+        verify(sendPetitionerGenericEmailNotificationWorkflow).run(ccdCallbackRequest);
     }
 
     @Test
     public void givenCaseData_whenSendRespondentSubmissionNotification_thenReturnPayload() throws Exception {
-        when(sendRespondentSubmissionNotificationWorkflow.run(createEventRequest)).thenReturn(requestPayload);
+        when(sendRespondentSubmissionNotificationWorkflow.run(ccdCallbackRequest)).thenReturn(requestPayload);
 
         Map<String, Object> returnedPayload = classUnderTest
-                .sendRespondentSubmissionNotificationEmail(createEventRequest);
+                .sendRespondentSubmissionNotificationEmail(ccdCallbackRequest);
 
         assertEquals(requestPayload, returnedPayload);
-        verify(sendRespondentSubmissionNotificationWorkflow).run(createEventRequest);
+        verify(sendRespondentSubmissionNotificationWorkflow).run(ccdCallbackRequest);
     }
 
     @Test
@@ -446,7 +446,7 @@ public class CaseOrchestrationServiceImplTest {
                 .thenReturn(requestPayload);
 
         // when
-        Map<String, Object> actual = classUnderTest.setOrderSummary(createEventRequest);
+        Map<String, Object> actual = classUnderTest.setOrderSummary(ccdCallbackRequest);
 
         // then
         assertEquals(requestPayload, actual);
@@ -457,34 +457,34 @@ public class CaseOrchestrationServiceImplTest {
     @Test
     public void givenCaseData_whenProcessPbaPayment_thenReturnPayload() throws Exception {
         // given
-        when(processPbaPaymentWorkflow.run(createEventRequest, AUTH_TOKEN))
+        when(processPbaPaymentWorkflow.run(ccdCallbackRequest, AUTH_TOKEN))
                 .thenReturn(requestPayload);
 
         // when
-        Map<String, Object> actual = classUnderTest.processPbaPayment(createEventRequest, AUTH_TOKEN);
+        Map<String, Object> actual = classUnderTest.processPbaPayment(ccdCallbackRequest, AUTH_TOKEN);
 
         // then
         assertEquals(requestPayload, actual);
 
-        verify(processPbaPaymentWorkflow).run(createEventRequest, AUTH_TOKEN);
+        verify(processPbaPaymentWorkflow).run(ccdCallbackRequest, AUTH_TOKEN);
     }
 
 
     @Test
     public void givenCaseDataInvalid_whenProcessPbaPayment_thenReturnListOfErrors() throws Exception {
         // given
-        when(processPbaPaymentWorkflow.run(createEventRequest, AUTH_TOKEN))
+        when(processPbaPaymentWorkflow.run(ccdCallbackRequest, AUTH_TOKEN))
                 .thenReturn(requestPayload);
         Map<String, Object> errors = Collections.singletonMap("new_Error", "An Error");
         when(processPbaPaymentWorkflow.errors()).thenReturn(errors);
 
         // when
-        Map<String, Object> actual = classUnderTest.processPbaPayment(createEventRequest, AUTH_TOKEN);
+        Map<String, Object> actual = classUnderTest.processPbaPayment(ccdCallbackRequest, AUTH_TOKEN);
 
         // then
         assertEquals(errors, actual);
 
-        verify(processPbaPaymentWorkflow).run(createEventRequest, AUTH_TOKEN);
+        verify(processPbaPaymentWorkflow).run(ccdCallbackRequest, AUTH_TOKEN);
         verify(processPbaPaymentWorkflow, times(2)).errors();
     }
 
@@ -495,7 +495,7 @@ public class CaseOrchestrationServiceImplTest {
                 .thenReturn(requestPayload);
 
         // when
-        Map<String, Object> actual = classUnderTest.solicitorCreate(createEventRequest);
+        Map<String, Object> actual = classUnderTest.solicitorCreate(ccdCallbackRequest);
 
         // then
         assertEquals(requestPayload, actual);
@@ -533,14 +533,14 @@ public class CaseOrchestrationServiceImplTest {
     @Test
     public void givenNoError_whenExecuteDnSubmittedWorkflow_thenReturnCaseData() throws WorkflowException {
         CcdCallbackResponse expectedResponse =  CcdCallbackResponse.builder()
-                .data(createEventRequest.getCaseDetails().getCaseData())
+                .data(ccdCallbackRequest.getCaseDetails().getCaseData())
                 .build();
 
         when(dnSubmittedWorkflow
-                .run(createEventRequest, AUTH_TOKEN))
-                .thenReturn(createEventRequest.getCaseDetails().getCaseData());
+                .run(ccdCallbackRequest, AUTH_TOKEN))
+                .thenReturn(ccdCallbackRequest.getCaseDetails().getCaseData());
 
-        CcdCallbackResponse ccdResponse = classUnderTest.dnSubmitted(createEventRequest, AUTH_TOKEN);
+        CcdCallbackResponse ccdResponse = classUnderTest.dnSubmitted(ccdCallbackRequest, AUTH_TOKEN);
 
         assertEquals(expectedResponse, ccdResponse);
     }
@@ -548,14 +548,14 @@ public class CaseOrchestrationServiceImplTest {
     @Test
     public void givenNoError_whenExecuteCoRespReceivedWorkflow_thenReturnCaseData() throws WorkflowException {
         CcdCallbackResponse expectedResponse =  CcdCallbackResponse.builder()
-            .data(createEventRequest.getCaseDetails().getCaseData())
+            .data(ccdCallbackRequest.getCaseDetails().getCaseData())
             .build();
 
         when(sendCoRespondSubmissionNotificationWorkflow
-            .run(createEventRequest))
-            .thenReturn(createEventRequest.getCaseDetails().getCaseData());
+            .run(ccdCallbackRequest))
+            .thenReturn(ccdCallbackRequest.getCaseDetails().getCaseData());
 
-        CcdCallbackResponse ccdResponse = classUnderTest.sendCoRespReceivedNotificationEmail(createEventRequest);
+        CcdCallbackResponse ccdResponse = classUnderTest.sendCoRespReceivedNotificationEmail(ccdCallbackRequest);
 
         assertEquals(expectedResponse, ccdResponse);
     }
@@ -565,8 +565,8 @@ public class CaseOrchestrationServiceImplTest {
 
         Map<String, Object> workflowError = Collections.singletonMap("ErrorKey", "Error value");
         when(dnSubmittedWorkflow
-                .run(createEventRequest, AUTH_TOKEN))
-                .thenReturn(createEventRequest.getCaseDetails().getCaseData());
+                .run(ccdCallbackRequest, AUTH_TOKEN))
+                .thenReturn(ccdCallbackRequest.getCaseDetails().getCaseData());
 
         when(dnSubmittedWorkflow.errors()).thenReturn(workflowError);
 
@@ -574,7 +574,7 @@ public class CaseOrchestrationServiceImplTest {
                 .errors(Collections.singletonList("Error value"))
                 .build();
 
-        CcdCallbackResponse ccdResponse = classUnderTest.dnSubmitted(createEventRequest, AUTH_TOKEN);
+        CcdCallbackResponse ccdResponse = classUnderTest.dnSubmitted(ccdCallbackRequest, AUTH_TOKEN);
 
         assertEquals(expectedResponse, ccdResponse);
     }
@@ -591,7 +591,7 @@ public class CaseOrchestrationServiceImplTest {
 
     @After
     public void tearDown() {
-        createEventRequest = null;
+        ccdCallbackRequest = null;
         requestPayload = null;
         expectedPayload = null;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentSubmissionNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentSubmissionNotificationEmailTest.java
@@ -11,7 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.invocation.Invocation;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.Court;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
@@ -77,8 +77,8 @@ public class SendRespondentSubmissionNotificationEmailTest {
     @Test
     public void testRightEmailIsSent_WhenRespondentChoosesToDefendDivorce()
             throws TaskException, IOException {
-        CreateEvent incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CreateEvent.class);
+        CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = spy(incomingPayload.getCaseDetails().getCaseData());
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();
@@ -112,8 +112,8 @@ public class SendRespondentSubmissionNotificationEmailTest {
         expectedException.expect(TaskException.class);
         expectedException.expectMessage("Could not evaluate value of mandatory property \"D8caseReference\"");
 
-        CreateEvent incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json", CreateEvent.class);
+        CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
+                "/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = incomingPayload.getCaseDetails().getCaseData();
         String caseId = (String) incomingPayload.getCaseDetails().getCaseData()
                 .get(D_8_CASE_REFERENCE);
@@ -131,8 +131,8 @@ public class SendRespondentSubmissionNotificationEmailTest {
                 "Could not evaluate value of mandatory property \"D8InferredPetitionerGender\""
         );
 
-        CreateEvent incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/defendedDivorceAOSMissingFields.json", CreateEvent.class);
+        CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
+                "/jsonExamples/payloads/defendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = incomingPayload.getCaseDetails().getCaseData();
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();
@@ -144,8 +144,8 @@ public class SendRespondentSubmissionNotificationEmailTest {
     @Test
     public void testRightEmailIsSent_WhenRespondentChoosesNotToDefendDivorce()
             throws TaskException, IOException {
-        CreateEvent incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CreateEvent.class);
+        CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = spy(incomingPayload.getCaseDetails().getCaseData());
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();
@@ -177,8 +177,8 @@ public class SendRespondentSubmissionNotificationEmailTest {
         expectedException.expect(TaskException.class);
         expectedException.expectMessage("Could not evaluate value of mandatory property \"D8DivorceUnit\"");
 
-        CreateEvent incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json", CreateEvent.class);
+        CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
+                "/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = incomingPayload.getCaseDetails().getCaseData();
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CcdCallbackBulkPrintWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CcdCallbackBulkPrintWorkflowTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
@@ -47,7 +47,7 @@ public class CcdCallbackBulkPrintWorkflowTest {
     private FetchPrintDocsFromDmStore fetchPrintDocsFromDmStore;
 
 
-    private CreateEvent createEventRequest;
+    private CcdCallbackRequest ccdCallbackRequestRequest;
     private Map<String, Object> payload;
     private TaskContext context;
 
@@ -69,8 +69,8 @@ public class CcdCallbackBulkPrintWorkflowTest {
             .state(TEST_STATE)
             .caseData(payload)
             .build();
-        createEventRequest =
-                CreateEvent.builder()
+        ccdCallbackRequestRequest =
+                CcdCallbackRequest.builder()
                         .eventId(TEST_EVENT_ID)
                         .token(TEST_TOKEN)
                         .caseDetails(
@@ -91,7 +91,7 @@ public class CcdCallbackBulkPrintWorkflowTest {
         when(modifyDueDate.execute(context, payload)).thenReturn(payload);
 
         //When
-        Map<String, Object> response = ccdCallbackBulkPrintWorkflow.run(createEventRequest, AUTH_TOKEN);
+        Map<String, Object> response = ccdCallbackBulkPrintWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN);
 
         //Then
         assertNotNull(response);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DNSubmittedWorkflowUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DNSubmittedWorkflowUTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.TestConstants;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DnSubmittedEmailNotificationTask;
 
@@ -41,11 +41,11 @@ public class DNSubmittedWorkflowUTest {
                         D_8_PETITIONER_LAST_NAME, TestConstants.TEST_USER_LAST_NAME,
                         D_8_PETITIONER_EMAIL, TestConstants.TEST_USER_EMAIL))
                 .build();
-        CreateEvent caseEvent = CreateEvent.builder().caseDetails(caseDetails).build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
 
         when(emailNotificationTask.execute(any(),
                 eq(caseDetails.getCaseData()))).thenReturn(caseDetails.getCaseData());
-        Map<String, Object> response = classToTest.run(caseEvent, TestConstants.TEST_TOKEN);
+        Map<String, Object> response = classToTest.run(ccdCallbackRequest, TestConstants.TEST_TOKEN);
 
         assertEquals(caseDetails.getCaseData(), response);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssueEventWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssueEventWorkflowTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
@@ -72,7 +72,7 @@ public class IssueEventWorkflowTest {
 
     @Mock private GetPetitionIssueFee getPetitionIssueFee;
 
-    private CreateEvent createEventRequest;
+    private CcdCallbackRequest ccdCallbackRequestRequest;
     private Map<String, Object> payload;
     private TaskContext context;
 
@@ -98,8 +98,8 @@ public class IssueEventWorkflowTest {
             .caseData(payload)
             .build();
 
-        createEventRequest =
-                CreateEvent.builder()
+        ccdCallbackRequestRequest =
+                CcdCallbackRequest.builder()
                         .eventId(TEST_EVENT_ID)
                         .token(TEST_TOKEN)
                         .caseDetails(
@@ -127,7 +127,7 @@ public class IssueEventWorkflowTest {
 
 
         //When
-        Map<String, Object> response = issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, true);
+        Map<String, Object> response = issueEventWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN, true);
 
         //Then
         assertThat(response, is(payload));
@@ -155,7 +155,7 @@ public class IssueEventWorkflowTest {
         when(caseFormatterAddDocuments.execute(context, payload)).thenReturn(payload);
 
         //When
-        Map<String, Object> response = issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, true);
+        Map<String, Object> response = issueEventWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN, true);
 
         //Then
         assertThat(response, is(payload));
@@ -175,7 +175,7 @@ public class IssueEventWorkflowTest {
         when(caseFormatterAddDocuments.execute(context, payload)).thenReturn(payload);
 
         //When
-        Map<String, Object> response = issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, true);
+        Map<String, Object> response = issueEventWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN, true);
 
         //Then
         assertThat(response, is(payload));
@@ -200,7 +200,7 @@ public class IssueEventWorkflowTest {
         when(caseFormatterAddDocuments.execute(context, payload)).thenReturn(payload);
 
         //When
-        Map<String, Object> response = issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, true);
+        Map<String, Object> response = issueEventWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN, true);
 
         //Then
         assertThat(response, is(payload));
@@ -220,7 +220,7 @@ public class IssueEventWorkflowTest {
         when(caseFormatterAddDocuments.execute(context, payload)).thenReturn(payload);
 
         //When
-        Map<String, Object> response = issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, true);
+        Map<String, Object> response = issueEventWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN, true);
 
         //Then
         assertThat(response, is(payload));
@@ -241,7 +241,7 @@ public class IssueEventWorkflowTest {
         when(caseFormatterAddDocuments.execute(context, payload)).thenReturn(payload);
 
         //When
-        Map<String, Object> response = issueEventWorkflow.run(createEventRequest, AUTH_TOKEN, false);
+        Map<String, Object> response = issueEventWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN, false);
 
         //Then
         assertThat(response, is(payload));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ProcessPbaPaymentWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ProcessPbaPaymentWorkflowTest.java
@@ -7,7 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ProcessPbaPayment;
@@ -39,7 +39,7 @@ public class ProcessPbaPaymentWorkflowTest {
     @InjectMocks
     private ProcessPbaPaymentWorkflow processPbaPaymentWorkflow;
 
-    private CreateEvent createEventRequest;
+    private CcdCallbackRequest ccdCallbackRequestRequest;
     private Map<String, Object> testData;
     private TaskContext context;
 
@@ -52,8 +52,8 @@ public class ProcessPbaPaymentWorkflowTest {
             .state(TEST_STATE)
             .caseData(testData)
             .build();
-        createEventRequest =
-                CreateEvent.builder()
+        ccdCallbackRequestRequest =
+                CcdCallbackRequest.builder()
                         .eventId(TEST_EVENT_ID)
                         .token(TEST_TOKEN)
                         .caseDetails(
@@ -71,7 +71,7 @@ public class ProcessPbaPaymentWorkflowTest {
         when(validateSolicitorCaseData.execute(context, testData)).thenReturn(testData);
         when(processPbaPayment.execute(context, testData)).thenReturn(testData);
 
-        assertEquals(testData, processPbaPaymentWorkflow.run(createEventRequest, AUTH_TOKEN));
+        assertEquals(testData, processPbaPaymentWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN));
 
         verify(validateSolicitorCaseData).execute(context, testData);
         verify(processPbaPayment).execute(context, testData);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/RespondentSubmittedCallbackWorkflowUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/RespondentSubmittedCallbackWorkflowUTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.TestConstants;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.GenericEmailNotification;
 
@@ -60,10 +60,10 @@ public class RespondentSubmittedCallbackWorkflowUTest {
                         D_8_CASE_REFERENCE, TestConstants.TEST_CASE_FAMILY_MAN_ID,
                         D_8_INFERRED_RESPONDENT_GENDER, "male"))
                 .build();
-        CreateEvent caseEvent = CreateEvent.builder().caseDetails(caseDetails).build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
 
         when(emailNotificationTask.execute(any(), any())).thenReturn(caseDetails.getCaseData());
-        Map<String, Object> response = classToTest.run(caseEvent, TestConstants.TEST_TOKEN);
+        Map<String, Object> response = classToTest.run(ccdCallbackRequest, TestConstants.TEST_TOKEN);
 
         verify(emailNotificationTask, times(1))
                 .execute(argThat(argument ->
@@ -84,10 +84,10 @@ public class RespondentSubmittedCallbackWorkflowUTest {
         CaseDetails caseDetails = CaseDetails.builder()
                 .caseData(ImmutableMap.of())
                 .build();
-        CreateEvent caseEvent = CreateEvent.builder().caseDetails(caseDetails).build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
 
         when(emailNotificationTask.execute(any(), any())).thenReturn(caseDetails.getCaseData());
-        Map<String, Object> response = classToTest.run(caseEvent, TestConstants.TEST_TOKEN);
+        Map<String, Object> response = classToTest.run(ccdCallbackRequest, TestConstants.TEST_TOKEN);
 
         verify(emailNotificationTask, times(1)).execute(argThat(
             argument -> argument.getTransientObject(NOTIFICATION_TEMPLATE_VARS).equals(vars)),any());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflowTest.java
@@ -8,7 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.Court;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
@@ -67,12 +67,12 @@ public class SendCoRespondSubmissionNotificationWorkflowTest {
     @Test
     public void givenUndefendedCoResp_whenSendEmail_thenSendUndefendedTemplate() throws WorkflowException {
 
-        CreateEvent caseEvent = createSubmittedCoEvent(ImmutableMap.of(CO_RESPONDENT_DEFENDS_DIVORCE, "No"));
+        CcdCallbackRequest ccdCallbackRequest = createSubmittedCoEvent(ImmutableMap.of(CO_RESPONDENT_DEFENDS_DIVORCE, "No"));
 
-        classToTest.run(caseEvent);
+        classToTest.run(ccdCallbackRequest);
 
         ArgumentCaptor<TaskContext> argument = ArgumentCaptor.forClass(TaskContext.class);
-        verify(emailTask).execute(argument.capture(), eq(caseEvent.getCaseDetails().getCaseData()));
+        verify(emailTask).execute(argument.capture(), eq(ccdCallbackRequest.getCaseDetails().getCaseData()));
 
         TaskContext capturedTask = argument.getValue();
 
@@ -85,17 +85,17 @@ public class SendCoRespondSubmissionNotificationWorkflowTest {
     @Test
     public void givenDefendedCoResp_whenSendEmail_thenSendDefendedTemplate() throws Exception {
 
-        CreateEvent caseEvent = createSubmittedCoEvent(ImmutableMap.of(
+        CcdCallbackRequest ccdCallbackRequest = createSubmittedCoEvent(ImmutableMap.of(
             CO_RESPONDENT_DEFENDS_DIVORCE, "Yes",
             CO_RESPONDENT_DUE_DATE, TEST_EXPECTED_DUE_DATE));
         Court court = new Court();
         court.setDivorceCentreName(TEST_COURT);
         when(taskCommons.getCourt(TEST_COURT)).thenReturn(court);
 
-        classToTest.run(caseEvent);
+        classToTest.run(ccdCallbackRequest);
 
         ArgumentCaptor<TaskContext> argument = ArgumentCaptor.forClass(TaskContext.class);
-        verify(emailTask).execute(argument.capture(), eq(caseEvent.getCaseDetails().getCaseData()));
+        verify(emailTask).execute(argument.capture(), eq(ccdCallbackRequest.getCaseDetails().getCaseData()));
 
         TaskContext capturedTask = argument.getValue();
 
@@ -126,7 +126,7 @@ public class SendCoRespondSubmissionNotificationWorkflowTest {
         return expectedContext;
     }
 
-    private CreateEvent createSubmittedCoEvent(Map<String,Object> extraFields) {
+    private CcdCallbackRequest createSubmittedCoEvent(Map<String,Object> extraFields) {
 
         Map<String, Object> caseData = new HashMap<>(extraFields);
 
@@ -141,7 +141,7 @@ public class SendCoRespondSubmissionNotificationWorkflowTest {
             .caseData(caseData)
             .build();
 
-        return  CreateEvent
+        return  CcdCallbackRequest
             .builder()
             .caseDetails(caseDetails)
             .build();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerEmailNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerEmailNotificationWorkflowTest.java
@@ -7,7 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerSubmissionNotificationEmail;
@@ -40,7 +40,7 @@ public class SendPetitionerEmailNotificationWorkflowTest {
     @InjectMocks
     private SendPetitionerGenericEmailNotificationWorkflow sendPetitionerGenericEmailNotificationWorkflow;
 
-    private CreateEvent createEventRequest;
+    private CcdCallbackRequest ccdCallbackRequestRequest;
     private Map<String, Object> testData;
     private TaskContext context;
 
@@ -53,8 +53,8 @@ public class SendPetitionerEmailNotificationWorkflowTest {
             .state(TEST_STATE)
             .caseData(testData)
             .build();
-        createEventRequest =
-                CreateEvent.builder()
+        ccdCallbackRequestRequest =
+                CcdCallbackRequest.builder()
                         .eventId(TEST_EVENT_ID)
                         .token(TEST_TOKEN)
                         .caseDetails(
@@ -70,7 +70,7 @@ public class SendPetitionerEmailNotificationWorkflowTest {
     public void genericEmailTaskShouldExecuteAndReturnPayload() throws Exception {
         when(sendPetitionerUpdateNotificationsEmail.execute(context, testData)).thenReturn(testData);
 
-        assertEquals(testData, sendPetitionerGenericEmailNotificationWorkflow.run(createEventRequest));
+        assertEquals(testData, sendPetitionerGenericEmailNotificationWorkflow.run(ccdCallbackRequestRequest));
 
         verify(sendPetitionerUpdateNotificationsEmail).execute(context, testData);
     }
@@ -79,7 +79,7 @@ public class SendPetitionerEmailNotificationWorkflowTest {
     public void submissionEmailTaskShouldExecuteAndReturnPayload() throws Exception {
         when(sendPetitionerSubmissionNotificationEmail.execute(context, testData)).thenReturn(testData);
 
-        assertEquals(testData, sendPetitionerSubmissionNotificationWorkflow.run(createEventRequest));
+        assertEquals(testData, sendPetitionerSubmissionNotificationWorkflow.run(ccdCallbackRequestRequest));
 
         verify(sendPetitionerSubmissionNotificationEmail).execute(context, testData);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflowTest.java
@@ -10,7 +10,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CreateEvent;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
@@ -66,11 +66,11 @@ public class SendRespondentSubmissionNotificationWorkflowTest {
 
     @Test
     public void testDefendedTaskIsCalledWhenWorkflowIsRun() throws WorkflowException, IOException, TaskException {
-        CreateEvent caseRequestDetails = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CreateEvent.class);
-        Map<String, Object> caseData = caseRequestDetails.getCaseDetails().getCaseData();
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CcdCallbackRequest.class);
+        Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
 
-        Map<String, Object> returnedPayloadFromWorkflow = workflow.run(caseRequestDetails);
+        Map<String, Object> returnedPayloadFromWorkflow = workflow.run(ccdCallbackRequest);
 
         verify(defendedDivorceNotificationEmailTask).execute(taskContextArgumentCaptor.capture(), same(caseData));
         verifyZeroInteractions(undefendedDivorceNotificationEmailTask);
@@ -83,11 +83,11 @@ public class SendRespondentSubmissionNotificationWorkflowTest {
     @Test
     public void testUndefendedTaskIsCalled_WhenRespondentChoosesToNotDefendDivorce() throws IOException,
             WorkflowException, TaskException {
-        CreateEvent caseRequestDetails = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CreateEvent.class);
-        Map<String, Object> caseData = caseRequestDetails.getCaseDetails().getCaseData();
+        CcdCallbackRequest callbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CcdCallbackRequest.class);
+        Map<String, Object> caseData = callbackRequest.getCaseDetails().getCaseData();
 
-        Map<String, Object> returnedPayloadFromWorkflow = workflow.run(caseRequestDetails);
+        Map<String, Object> returnedPayloadFromWorkflow = workflow.run(callbackRequest);
 
         verify(undefendedDivorceNotificationEmailTask).execute(taskContextArgumentCaptor.capture(), same(caseData));
         verifyZeroInteractions(defendedDivorceNotificationEmailTask);
@@ -104,11 +104,11 @@ public class SendRespondentSubmissionNotificationWorkflowTest {
         expectedException.expectMessage(String.format("%s field doesn't contain a valid value",
             RESP_WILL_DEFEND_DIVORCE));
 
-        CreateEvent caseRequestDetails = getJsonFromResourceFile(
-                "/jsonExamples/payloads/unclearAcknowledgementOfService.json", CreateEvent.class);
-        Map<String, Object> incomingCaseDate = caseRequestDetails.getCaseDetails().getCaseData();
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/unclearAcknowledgementOfService.json", CcdCallbackRequest.class);
+        Map<String, Object> incomingCaseDate = ccdCallbackRequest.getCaseDetails().getCaseData();
 
-        Map<String, Object> returnedPayloadFromWorkflow = workflow.run(caseRequestDetails);
+        Map<String, Object> returnedPayloadFromWorkflow = workflow.run(ccdCallbackRequest);
 
         assertThat(returnedPayloadFromWorkflow.size(), is(incomingCaseDate.size() + 1));
     }


### PR DESCRIPTION
-Always wondered what a CreateEvent was? Me too! It was the first
use case for a ccd callback and as such got named specifically for that.
It's actually just a callback request sent by CCD which is generic for
all callbacks. I have renamed the class appropriaely to mirror the
CcdCallbackResponse class we already have.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
