### PR TITLE
Pre-factor for Generic document task

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -151,6 +151,8 @@ public class OrchestrationConstants {
     public static final String CO_RESPONDENT_INVITATION_FILE_NAME_FORMAT = "co-respondentaosinvitation%s";
     public static final String CO_RESPONDENT_INVITATION_TEMPLATE_NAME = "co-respondentinvitation";
     public static final String PETITION_ISSUE_FEE_FOR_LETTER = "petitionIssueFee";
+    public static final String DOCUMENT_COLLECTION = "documentCollection";
+
 
     // Fees
     public static final String CURRENCY = "GBP";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/DefaultTaskContext.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/DefaultTaskContext.java
@@ -41,4 +41,9 @@ public class DefaultTaskContext implements TaskContext {
     public Object getTransientObject(String key) {
         return transientObjects.get(key);
     }
+
+    @Override
+    public <T> T computeTransientObjectIfAbsent(final String key, final T defaultVal) {
+        return (T) transientObjects.computeIfAbsent(key, k -> defaultVal);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/TaskContext.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/TaskContext.java
@@ -9,6 +9,8 @@ public interface TaskContext {
     void setTransientObject(String key, Object data);
 
     Object getTransientObject(String key);
+
+    <T> T computeTransientObjectIfAbsent(String key, T defaultVal);
 }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CaseFormatterAddDocuments.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CaseFormatterAddDocuments.java
@@ -9,12 +9,11 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_INVITATION_TEMPLATE_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_TEMPLATE_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_INVITATION_TEMPLATE_NAME;
+import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 
 @Component
 public class CaseFormatterAddDocuments implements Task<Map<String, Object>> {
@@ -27,31 +26,17 @@ public class CaseFormatterAddDocuments implements Task<Map<String, Object>> {
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
-        List<GeneratedDocumentInfo> documents = new ArrayList<>();
 
-        GeneratedDocumentInfo miniPetition
-                = (GeneratedDocumentInfo) context.getTransientObject(MINI_PETITION_TEMPLATE_NAME);
+        final Set<GeneratedDocumentInfo> documentCollection = (Set<GeneratedDocumentInfo>) context.getTransientObject(DOCUMENT_COLLECTION);
 
-        documents.add(miniPetition);
-
-        GeneratedDocumentInfo respondentInvitation
-                = (GeneratedDocumentInfo) context.getTransientObject(RESPONDENT_INVITATION_TEMPLATE_NAME);
-
-        if (respondentInvitation != null) {
-            documents.add(respondentInvitation);
-        }
-
-        GeneratedDocumentInfo coRespondentInvitation
-            = (GeneratedDocumentInfo) context.getTransientObject(CO_RESPONDENT_INVITATION_TEMPLATE_NAME);
-
-        if (coRespondentInvitation != null) {
-            documents.add(coRespondentInvitation);
-        }
-
-        return caseFormatterClient.addDocuments(
+        if (isNotEmpty(documentCollection)) {
+            return caseFormatterClient.addDocuments(
                 DocumentUpdateRequest.builder()
-                        .caseData(caseData)
-                        .documents(documents)
-                        .build());
+                    .caseData(caseData)
+                    .documents(new ArrayList<>(documentCollection))
+                    .build());
+        }
+
+        return caseData;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CoRespondentLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CoRespondentLetterGenerator.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ACCESS_CODE;
@@ -22,6 +23,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_INVITATION_TEMPLATE_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_PIN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_CO_RESPONDENT_INVITATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITION_ISSUE_FEE_FOR_LETTER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITION_ISSUE_FEE_JSON_KEY;
@@ -60,7 +62,9 @@ public class CoRespondentLetterGenerator implements Task<Map<String, Object>> {
         coRespondentInvitation.setFileName(String.format(CO_RESPONDENT_INVITATION_FILE_NAME_FORMAT,
                 caseDetails.getCaseId()));
 
-        context.setTransientObject(CO_RESPONDENT_INVITATION_TEMPLATE_NAME, coRespondentInvitation);
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.computeTransientObjectIfAbsent(DOCUMENT_COLLECTION,
+            new LinkedHashSet<>());
+        documentCollection.add(coRespondentInvitation);
 
         return caseData;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PetitionGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PetitionGenerator.java
@@ -10,11 +10,13 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_PETITION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_FILE_NAME_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_TEMPLATE_NAME;
@@ -29,8 +31,7 @@ public class PetitionGenerator implements Task<Map<String, Object>> {
     }
 
     @Override
-    public Map<String, Object> execute(TaskContext context,
-                                       Map<String, Object> caseData) {
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
         CaseDetails caseDetails = (CaseDetails) context.getTransientObject(CASE_DETAILS_JSON_KEY);
         GeneratedDocumentInfo miniPetition =
                 documentGeneratorClient.generatePDF(
@@ -45,7 +46,9 @@ public class PetitionGenerator implements Task<Map<String, Object>> {
         miniPetition.setDocumentType(DOCUMENT_TYPE_PETITION);
         miniPetition.setFileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, caseDetails.getCaseId()));
 
-        context.setTransientObject(MINI_PETITION_TEMPLATE_NAME, miniPetition);
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.computeTransientObjectIfAbsent(DOCUMENT_COLLECTION,
+            new LinkedHashSet<>());
+        documentCollection.add(miniPetition);
 
         return caseData;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentLetterGenerator.java
@@ -10,12 +10,14 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ACCESS_CODE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_RESPONDENT_INVITATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_INVITATION_FILE_NAME_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_INVITATION_TEMPLATE_NAME;
@@ -51,7 +53,9 @@ public class RespondentLetterGenerator implements Task<Map<String, Object>> {
         aosInvitation.setFileName(String.format(RESPONDENT_INVITATION_FILE_NAME_FORMAT,
                 caseDetails.getCaseId()));
 
-        context.setTransientObject(RESPONDENT_INVITATION_TEMPLATE_NAME, aosInvitation);
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.computeTransientObjectIfAbsent(DOCUMENT_COLLECTION,
+            new LinkedHashSet<>());
+        documentCollection.add(aosInvitation);
 
         return caseData;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/DefaultTaskContextTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/DefaultTaskContextTest.java
@@ -5,7 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
@@ -19,14 +20,30 @@ public class DefaultTaskContextTest {
     }
 
     @Test
-    public void defaultContextStatusIsFalseByDefault() {
-        assertFalse(defaultTaskContext.hasTaskFailed());
+    public void defaultContextTasFailedIsFalseByDefault() {
+        assertThat(defaultTaskContext.hasTaskFailed(), is(false));
     }
 
     @Test
     public void defaultContextStatusIsTrueWhenSetFailedIsCalled() {
         defaultTaskContext.setTaskFailed(true);
         assertTrue(defaultTaskContext.hasTaskFailed());
+    }
+
+    @Test
+    public void computesTransientObjectIfAbsent() {
+        defaultTaskContext.setTransientObject("foo", null);
+        defaultTaskContext.computeTransientObjectIfAbsent("foo", "bar");
+
+        assertThat(defaultTaskContext.getTransientObject("foo"), is("bar"));
+    }
+
+    @Test
+    public void doesNotComputeTransientObjectIfAbsent() {
+        defaultTaskContext.setTransientObject("foo", "bar");
+        defaultTaskContext.computeTransientObjectIfAbsent("foo", "baz");
+
+        assertThat(defaultTaskContext.getTransientObject("foo"), is("bar"));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PetitionGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PetitionGeneratorTest.java
@@ -12,21 +12,23 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_MINI_PETITION_FILE_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PIN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_PETITION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_TEMPLATE_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_PIN;
 
@@ -40,38 +42,39 @@ public class PetitionGeneratorTest {
     private PetitionGenerator petitionGenerator;
 
     @Test
-    public void executeShouldReturnUpdatedPayloadForValidCase() {
+    public void callsDocumentGeneratorAndStoresGeneratedDocument() {
         final Map<String, Object> payload = new HashMap<>();
         final CaseDetails caseDetails = CaseDetails.builder()
             .caseId(TEST_CASE_ID)
             .caseData(payload)
             .build();
+
         final TaskContext context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
         context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
         context.setTransientObject(RESPONDENT_PIN, TEST_PIN);
 
-        final GeneratedDocumentInfo petition = GeneratedDocumentInfo.builder().build();
+        final GeneratedDocumentInfo expectedPetition = GeneratedDocumentInfo.builder()
+            .documentType("foo")
+            .fileName("bar")
+            .build();
 
         final GenerateDocumentRequest generateDocumentRequest =
             GenerateDocumentRequest.builder()
                     .template(MINI_PETITION_TEMPLATE_NAME)
-                    .values(
-                        Collections.singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
+                    .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
                     .build();
 
         //given
-        when(documentGeneratorClient.generatePDF(generateDocumentRequest, AUTH_TOKEN)).thenReturn(petition);
+        when(documentGeneratorClient.generatePDF(generateDocumentRequest, AUTH_TOKEN)).thenReturn(expectedPetition);
 
         //when
         petitionGenerator.execute(context, payload);
 
-        GeneratedDocumentInfo response =
-            (GeneratedDocumentInfo)context.getTransientObject(MINI_PETITION_TEMPLATE_NAME);
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection =
+            (LinkedHashSet<GeneratedDocumentInfo>)context.getTransientObject(DOCUMENT_COLLECTION);
 
-        //then
-        assertEquals(DOCUMENT_TYPE_PETITION, response.getDocumentType());
-        assertEquals(TEST_MINI_PETITION_FILE_NAME, response.getFileName());
+        assertThat(documentCollection, is(newLinkedHashSet(expectedPetition)));
 
         verify(documentGeneratorClient).generatePDF(generateDocumentRequest, AUTH_TOKEN);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentLetterGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentLetterGeneratorTest.java
@@ -14,9 +14,12 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
@@ -27,6 +30,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_RESPONDENT_INVITATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_INVITATION_TEMPLATE_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_PIN;
@@ -41,9 +45,11 @@ public class RespondentLetterGeneratorTest {
     private RespondentLetterGenerator respondentLetterGenerator;
 
     @Test
-    public void executeShouldReturnUpdatedPayloadForValidCase() {
-        final GeneratedDocumentInfo aosInvitation =
+    public void callsDocumentGeneratorAndStoresGeneratedDocument() {
+        final GeneratedDocumentInfo expectedAosInvitation =
             GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_RESPONDENT_INVITATION)
+                .fileName(TEST_AOS_INVITATION_FILE_NAME)
                 .build();
 
         final Map<String, Object> payload = new HashMap<>();
@@ -69,17 +75,15 @@ public class RespondentLetterGeneratorTest {
                 .build();
 
         //given
-        when(documentGeneratorClient.generatePDF(generateDocumentRequest, AUTH_TOKEN)).thenReturn(aosInvitation);
+        when(documentGeneratorClient.generatePDF(generateDocumentRequest, AUTH_TOKEN)).thenReturn(expectedAosInvitation);
 
         //when
         respondentLetterGenerator.execute(context, payload);
 
-        GeneratedDocumentInfo response =
-            (GeneratedDocumentInfo)context.getTransientObject(RESPONDENT_INVITATION_TEMPLATE_NAME);
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection =
+            (LinkedHashSet<GeneratedDocumentInfo>)context.getTransientObject(DOCUMENT_COLLECTION);
 
-        //then
-        assertEquals(DOCUMENT_TYPE_RESPONDENT_INVITATION, response.getDocumentType());
-        assertEquals(TEST_AOS_INVITATION_FILE_NAME, response.getFileName());
+        assertThat(documentCollection, is(newLinkedHashSet(expectedAosInvitation)));
 
         verify(documentGeneratorClient).generatePDF(generateDocumentRequest, AUTH_TOKEN);
     }


### PR DESCRIPTION
[Make generic documents generated handler in COS](https://tools.hmcts.net/jira/browse/DIV-4688)

- Make the CaseFormatterAddDocuments task reusable by adding the
document collection to the task context so documents can be added to it in
different document generator tasks.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
