### PR TITLE
Added missing states for CoResp submission

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitCoRespondentAosCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitCoRespondentAosCaseTest.java
@@ -34,7 +34,7 @@ public class SubmitCoRespondentAosCaseTest extends RetrieveAosCaseSupport {
     private static final String RESPONDENT_PAYLOAD_CONTEXT_PATH = "fixtures/maintenance/submit-aos/";
     private static final String TEST_AOS_AWAITING_EVENT_ID = "testAosAwaiting";
     private static final String TEST_AOS_STARTED_EVENT_ID = "testAosStarted";
-    private static final String TEST_AWAITING_DN_EVENT_ID = "testAwaitingDecreeNisi";
+    private static final String TEST_AWAITING_DECREE_ABSOLUTE = "testAwaitingDecreeAbsolute";
 
     private static final String STATE_KEY = "state";
     private static final String ID = "id";
@@ -66,7 +66,7 @@ public class SubmitCoRespondentAosCaseTest extends RetrieveAosCaseSupport {
         final CaseDetails caseDetails = submitCase("submit-complete-case.json", userDetails);
         log.info("Case " + caseDetails.getId() + " created.");
 
-        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, TEST_AWAITING_DN_EVENT_ID, userDetails);
+        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, TEST_AWAITING_DECREE_ABSOLUTE, userDetails);
 
         final String coRespondentAnswersJson = loadJson(CO_RESPONDENT_PAYLOAD_CONTEXT_PATH + "co-respondent-answers.json");
         Response coRespondentSubmissionResponse = submitCoRespondentAosCase(userDetails.getAuthToken(), coRespondentAnswersJson);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -46,6 +46,9 @@ public class OrchestrationConstants {
     public static final String CO_RESPONDENT_SUBMISSION_AOS_SUBMIT_AWAIT_EVENT_ID = "co-RespAOSReceivedAwaitingAnswer";
     public static final String CO_RESPONDENT_SUBMISSION_AOS_OVERDUE_EVENT_ID = "co-RespAOSReceivedOverdue";
     public static final String CO_RESPONDENT_SUBMISSION_AOS_DEFENDED_EVENT_ID = "co-RespAOSReceivedDefended";
+    public static final String CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID = "co-RespAOSCompleted";
+    public static final String CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID = "co-RespAwaitingDN";
+    public static final String CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID = "co-RespAwaitingLAReferral";
     public static final String RESP_ADMIT_OR_CONSENT_TO_FACT = "RespAdmitOrConsentToFact";
     public static final String RESP_WILL_DEFEND_DIVORCE = "RespWillDefendDivorce";
     public static final String RESP_FIRST_NAME_CCD_FIELD = "D8RespondentFirstName";
@@ -78,6 +81,7 @@ public class OrchestrationConstants {
     public static final String DEFENDED = "DefendedDivorce";
     public static final String AWAITING_DECREE_NISI = "AwaitingDecreeNisi";
     public static final String AWAITING_REISSUE = "AwaitingReissue";
+    public static final String AWAITING_LEGAL_ADVISOR_REFERRAL = "AwaitingLegalAdvisorReferral";
 
 
     // CCD Respondent Fields

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -80,6 +80,7 @@ public class OrchestrationConstants {
     public static final String AOS_COMPLETED = "AosCompleted";
     public static final String DEFENDED = "DefendedDivorce";
     public static final String AWAITING_DECREE_NISI = "AwaitingDecreeNisi";
+    public static final String DN_AWAITING = "DNAwaiting";
     public static final String AWAITING_REISSUE = "AwaitingReissue";
     public static final String AWAITING_LEGAL_ADVISOR_REFERRAL = "AwaitingLegalAdvisorReferral";
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitCoRespondentAosCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitCoRespondentAosCase.java
@@ -37,6 +37,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DEFENDED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_AWAITING;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
@@ -122,7 +123,7 @@ public class SubmitCoRespondentAosCase implements Task<Map<String, Object>> {
         if (AOS_COMPLETED.equals(currentCaseState)) {
             return CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID;
         }
-        if (AWAITING_DECREE_NISI.equals(currentCaseState)) {
+        if (AWAITING_DECREE_NISI.equals(currentCaseState) || DN_AWAITING.equals(currentCaseState)) {
             return CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID;
         }
         if (AWAITING_LEGAL_ADVISOR_REFERRAL.equals(currentCaseState)) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitCoRespondentAosCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitCoRespondentAosCase.java
@@ -17,19 +17,25 @@ import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_AWAITING;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_COMPLETED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OVERDUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_STARTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_SUBMITTED_AWAITING_ANSWER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DECREE_NISI;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_LEGAL_ADVISOR_REFERRAL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_DEFENDS_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_DUE_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_AWAITING_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_DEFENDED_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_OVERDUE_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_STARTED_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_SUBMIT_AWAIT_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DEFENDED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP_DATE;
@@ -112,6 +118,15 @@ public class SubmitCoRespondentAosCase implements Task<Map<String, Object>> {
             // The Respondent did their online AOS and their paper defence; case will now go to court hearing.
             // But the co-respondent can still reply as their reply may be relevant in the court hearing.
             return CO_RESPONDENT_SUBMISSION_AOS_DEFENDED_EVENT_ID;
+        }
+        if (AOS_COMPLETED.equals(currentCaseState)) {
+            return CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID;
+        }
+        if (AWAITING_DECREE_NISI.equals(currentCaseState)) {
+            return CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID;
+        }
+        if (AWAITING_LEGAL_ADVISOR_REFERRAL.equals(currentCaseState)) {
+            return CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID;
         }
 
         return null;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitCoRespondentAosCaseUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitCoRespondentAosCaseUTest.java
@@ -39,19 +39,25 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_AWAITING;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_COMPLETED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OVERDUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_STARTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_SUBMITTED_AWAITING_ANSWER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DECREE_NISI;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_LEGAL_ADVISOR_REFERRAL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_DEFENDS_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_DUE_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_AWAITING_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_DEFENDED_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_OVERDUE_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_STARTED_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AOS_SUBMIT_AWAIT_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DEFENDED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP_DATE;
@@ -121,6 +127,57 @@ public class SubmitCoRespondentAosCaseUTest {
         submitCoRespondentAosCase.execute(taskContext, submissionData);
 
         verify(caseMaintenanceClient, never()).updateCase(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    public void givenCaseIsAosCompleted_whenCoRespondentSubmits_thenSubmitCorrectEvent() throws TaskException {
+        final Map<String, Object> submissionData = new HashMap<>();
+
+        final Map<String, Object> caseUpdateResponse = new HashMap<>();
+        caseUpdateResponse.put(CCD_CASE_DATA_FIELD, emptyMap());
+
+        when(caseMaintenanceClient.retrieveAosCase(AUTH_TOKEN)).thenReturn(someCaseWithState(AOS_COMPLETED));
+        when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID, submissionData))
+            .thenReturn(caseUpdateResponse);
+
+        assertThat(submitCoRespondentAosCase.execute(taskContext, submissionData), is(caseUpdateResponse));
+
+        verify(caseMaintenanceClient)
+            .updateCase(AUTH_TOKEN, TEST_CASE_ID, CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID, submissionData);
+    }
+
+    @Test
+    public void givenCaseIsAwaitingDN_whenCoRespondentSubmits_thenSubmitCorrectEvent() throws TaskException {
+        final Map<String, Object> submissionData = new HashMap<>();
+
+        final Map<String, Object> caseUpdateResponse = new HashMap<>();
+        caseUpdateResponse.put(CCD_CASE_DATA_FIELD, emptyMap());
+
+        when(caseMaintenanceClient.retrieveAosCase(AUTH_TOKEN)).thenReturn(someCaseWithState(AWAITING_DECREE_NISI));
+        when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID, submissionData))
+            .thenReturn(caseUpdateResponse);
+
+        assertThat(submitCoRespondentAosCase.execute(taskContext, submissionData), is(caseUpdateResponse));
+
+        verify(caseMaintenanceClient)
+            .updateCase(AUTH_TOKEN, TEST_CASE_ID, CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID, submissionData);
+    }
+
+    @Test
+    public void givenCaseIsAwaitingLAReferral_whenCoRespondentSubmits_thenSubmitCorrectEvent() throws TaskException {
+        final Map<String, Object> submissionData = new HashMap<>();
+
+        final Map<String, Object> caseUpdateResponse = new HashMap<>();
+        caseUpdateResponse.put(CCD_CASE_DATA_FIELD, emptyMap());
+
+        when(caseMaintenanceClient.retrieveAosCase(AUTH_TOKEN)).thenReturn(someCaseWithState(AWAITING_LEGAL_ADVISOR_REFERRAL));
+        when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID, submissionData))
+            .thenReturn(caseUpdateResponse);
+
+        assertThat(submitCoRespondentAosCase.execute(taskContext, submissionData), is(caseUpdateResponse));
+
+        verify(caseMaintenanceClient)
+            .updateCase(AUTH_TOKEN, TEST_CASE_ID, CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID, submissionData);
     }
 
     @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4390

Details
Type: Bug
Status:IN TEST  (View Workflow)
Priority: Medium
Resolution: Unresolved
Affects Version/s:
DIV_5.3.0
Fix Version/s:
DIV_5.3.0
Component/s: None
Labels:
Co-Respondent
Steps Taken:
1. Create a Adultery Case. Issue the case initially and reject the case in CCD.

2. Now the case in Rejected Case

3. Now issue the case will generate the AOS and AOS pack for co-respondent.

Expected Behaviour:
Need to identify what page should show. It should be some thing like Progress bar page.

This progress bar page should show based on Case Status in CCD.

Need to identify the stories - what kind of progress bar should should based on the CCD status.

Actual Behaviour:
currently irrespective with the Rejected status this is showing Linking page when the case is in Rejected state.

Epic Link: Co-Respondent journey
Sprint: Sprint 58 - 5.3.0
Description
Co-respondent - Login with co-respondent email details when the case in Rejected State navigating to Linking page which is not correct

Fix
A Co-respondent should only be able to access the case (to submit a response) when it is in the following states:

AosAwaiting
AosStarted
AosOverdue
AosCompeted
AosSubmittedAwaitingAnswer
DefendedDivorce
AwaitingDecreeNisi
AwaitingLegalAdvisorReferral
