### PR TITLE
Remove synchronised and Thread.sleep workaround for IDAM client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,6 +291,12 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
     finalizedBy aggregate
 }
 
+subprojects {
+    tasks.withType(Test) {
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    }
+}
+
 pitest {
     targetClasses = ['uk.gov.hmcts.reform.divorce.orchestration.*']
     excludedClasses = ['uk.gov.hmcts.reform.divorce.orchestration.config.*',

--- a/build.gradle
+++ b/build.gradle
@@ -287,12 +287,9 @@ task bootRunAat(type: BootRun, description: 'Runs the app using AAT config', dep
 task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
     setTestClassesDirs(sourceSets.integrationTest.output.classesDirs)
     setClasspath(sourceSets.integrationTest.runtimeClasspath)
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 
     finalizedBy aggregate
-}
-
-tasks.withType(Test) {
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 pitest {

--- a/build.gradle
+++ b/build.gradle
@@ -291,10 +291,8 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
     finalizedBy aggregate
 }
 
-subprojects {
-    tasks.withType(Test) {
-        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-    }
+tasks.withType(Test) {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 pitest {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -75,18 +75,16 @@ public abstract class IntegrationTest {
     }
 
     protected UserDetails createCaseWorkerUser() {
-        synchronized (this) {
-            if (caseWorkerUser == null) {
-                caseWorkerUser = getUserDetails(
-                    CASE_WORKER_USERNAME + UUID.randomUUID() + EMAIL_DOMAIN, CASE_WORKER_PASSWORD,
-                    CASEWORKER_USERGROUP,
-                    CASEWORKER_ROLE, CASEWORKER_DIVORCE_ROLE,
-                    CASEWORKER_DIVORCE_COURTADMIN_ROLE, CASEWORKER_DIVORCE_COURTADMIN_BETA_ROLE
-                );
-            }
-
-            return caseWorkerUser;
+        if (caseWorkerUser == null) {
+            caseWorkerUser = getUserDetails(
+                CASE_WORKER_USERNAME + UUID.randomUUID() + EMAIL_DOMAIN, CASE_WORKER_PASSWORD,
+                CASEWORKER_USERGROUP,
+                CASEWORKER_ROLE, CASEWORKER_DIVORCE_ROLE,
+                CASEWORKER_DIVORCE_COURTADMIN_ROLE, CASEWORKER_DIVORCE_COURTADMIN_BETA_ROLE
+            );
         }
+
+        return caseWorkerUser;
     }
 
     protected UserDetails createCitizenUser() {
@@ -102,26 +100,18 @@ public abstract class IntegrationTest {
     }
 
     private UserDetails getUserDetails(String username, String password, String userGroup, String... role) {
-        synchronized (this) {
-            idamTestSupportUtil.createUser(username, password, userGroup, role);
+        idamTestSupportUtil.createUser(username, password, userGroup, role);
 
-            try {
-                // calling generate token too soon might fail, so we sleep..
-                Thread.sleep(1000);
-            } catch (InterruptedException ignored) {
-            }
+        final String authToken = idamTestSupportUtil.generateUserTokenWithNoRoles(username, password);
 
-            final String authToken = idamTestSupportUtil.generateUserTokenWithNoRoles(username, password);
+        final String userId = idamTestSupportUtil.getUserId(authToken);
 
-            final String userId = idamTestSupportUtil.getUserId(authToken);
-
-            return UserDetails.builder()
-                .username(username)
-                .emailAddress(username)
-                .password(password)
-                .authToken(authToken)
-                .id(userId)
-                .build();
-        }
+        return UserDetails.builder()
+            .username(username)
+            .emailAddress(username)
+            .password(password)
+            .authToken(authToken)
+            .id(userId)
+            .build();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -75,18 +75,16 @@ public abstract class IntegrationTest {
     }
 
     protected UserDetails createCaseWorkerUser() {
-        synchronized (this) {
-            if (caseWorkerUser == null) {
-                caseWorkerUser = getUserDetails(
-                        CASE_WORKER_USERNAME + UUID.randomUUID() + EMAIL_DOMAIN, CASE_WORKER_PASSWORD,
-                        CASEWORKER_USERGROUP,
-                        CASEWORKER_ROLE, CASEWORKER_DIVORCE_ROLE,
-                        CASEWORKER_DIVORCE_COURTADMIN_ROLE, CASEWORKER_DIVORCE_COURTADMIN_BETA_ROLE
-                );
-            }
-
-            return caseWorkerUser;
+        if (caseWorkerUser == null) {
+            caseWorkerUser = getUserDetails(
+                CASE_WORKER_USERNAME + UUID.randomUUID() + EMAIL_DOMAIN, CASE_WORKER_PASSWORD,
+                CASEWORKER_USERGROUP,
+                CASEWORKER_ROLE, CASEWORKER_DIVORCE_ROLE,
+                CASEWORKER_DIVORCE_COURTADMIN_ROLE, CASEWORKER_DIVORCE_COURTADMIN_BETA_ROLE
+            );
         }
+
+        return caseWorkerUser;
     }
 
     protected UserDetails createCitizenUser() {
@@ -102,26 +100,18 @@ public abstract class IntegrationTest {
     }
 
     private UserDetails getUserDetails(String username, String password, String userGroup, String... role) {
-        synchronized (this) {
-            idamTestSupportUtil.createUser(username, password, userGroup, role);
+        idamTestSupportUtil.createUser(username, password, userGroup, role);
 
-            try {
-                // calling generate token too soon might fail, so we sleep..
-                Thread.sleep(1000);
-            } catch (InterruptedException ignored) {
-            }
+        final String authToken = idamTestSupportUtil.generateUserTokenWithNoRoles(username, password);
 
-            final String authToken = idamTestSupportUtil.generateUserTokenWithNoRoles(username, password);
+        final String userId = idamTestSupportUtil.getUserId(authToken);
 
-            final String userId = idamTestSupportUtil.getUserId(authToken);
-
-            return UserDetails.builder()
-                    .username(username)
-                    .emailAddress(username)
-                    .password(password)
-                    .authToken(authToken)
-                    .id(userId)
-                    .build();
-        }
+        return UserDetails.builder()
+            .username(username)
+            .emailAddress(username)
+            .password(password)
+            .authToken(authToken)
+            .id(userId)
+            .build();
     }
 }


### PR DESCRIPTION
Removes the sync method and Thread.sleep form Integration tests (refactor) based on new IDAM API behaviour. 