### PR TITLE
DIV-4732:  solicitor respondent dncosts callback (WIP)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -12,11 +12,11 @@ import org.springframework.test.context.ContextConfiguration;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.IdamUtils;
 
-import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URL;
 import java.util.UUID;
+import javax.annotation.PostConstruct;
 
 @Slf4j
 @RunWith(SerenityRunner.class)
@@ -58,8 +58,8 @@ public abstract class IntegrationTest {
     }
 
     @PostConstruct
-    public void init(){
-        if(!Strings.isNullOrEmpty(httpProxy)) {
+    public void init() {
+        if (!Strings.isNullOrEmpty(httpProxy)) {
             try {
                 URL proxy = new URL(httpProxy);
                 InetAddress.getByName(proxy.getHost()).isReachable(2000); // check proxy connectivity
@@ -108,7 +108,8 @@ public abstract class IntegrationTest {
             try {
                 // calling generate token too soon might fail, so we sleep..
                 Thread.sleep(1000);
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                log.error("Error during sleep", e);
             }
 
             final String authToken = idamTestSupportUtil.generateUserTokenWithNoRoles(username, password);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/ServiceContextConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/ServiceContextConfiguration.java
@@ -93,7 +93,7 @@ public class ServiceContextConfiguration {
     @Bean
     public RequestInterceptor requestInterceptor() {
         return (RequestTemplate template) -> {
-            if(template.request().httpMethod() == Request.HttpMethod.POST) {
+            if (template.request().httpMethod() == Request.HttpMethod.POST) {
                 template.header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
             }
         };

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.controller;
 
+import com.google.common.collect.ImmutableList;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
@@ -58,6 +59,30 @@ public class CallbackController {
             log.error(format("Failed to execute service to process case linked for hearing. Case id:  %s", caseId),
                 exception);
             callbackResponseBuilder.errors(asList(exception.getMessage()));
+        }
+
+        return ResponseEntity.ok(callbackResponseBuilder.build());
+    }
+
+    @PostMapping(path = "/sol-dn-costs",
+            consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Populates DN costs dynamic list options")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Success", response = CcdCallbackResponse.class),
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 500, message = "Internal Server Error")})
+    public ResponseEntity<CcdCallbackResponse> solDnCosts(@RequestBody CcdCallbackRequest ccdCallbackRequest) {
+
+        String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
+        log.debug("Processing solicitor DN costs for Case ID: {}", caseId);
+
+        CcdCallbackResponse.CcdCallbackResponseBuilder callbackResponseBuilder = CcdCallbackResponse.builder();
+
+        try {
+            callbackResponseBuilder.data(caseOrchestrationService.processSolDnCosts(ccdCallbackRequest));
+        } catch (CaseOrchestrationServiceException exception) {
+            log.error(format("Failed to process solicitor DN costs for Case ID: %s", caseId), exception);
+            callbackResponseBuilder.errors(ImmutableList.of(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -78,4 +78,6 @@ public interface CaseOrchestrationService {
     CcdCallbackResponse sendCoRespReceivedNotificationEmail(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;
 
     Map<String, Object> processCaseLinkedForHearingEvent(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException;
+
+    Map<String, Object> processSolDnCosts(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -34,6 +34,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerSubmiss
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendRespondentSubmissionNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SetOrderSummaryWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorCreateWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnCostsWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitCoRespondentAosWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDnCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitRespondentAosCaseWorkflow;
@@ -87,6 +88,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     private final AuthUtil authUtil;
     private final AmendPetitionWorkflow amendPetitionWorkflow;
     private final CaseLinkedForHearingWorkflow caseLinkedForHearingWorkflow;
+    private final SolicitorDnCostsWorkflow solicitorDnCostsWorkflow;
 
     @Override
     public Map<String, Object> handleIssueEventCallback(CcdCallbackRequest ccdCallbackRequest,
@@ -410,6 +412,15 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     public Map<String, Object> processCaseLinkedForHearingEvent(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
         try {
             return caseLinkedForHearingWorkflow.run(ccdCallbackRequest.getCaseDetails());
+        } catch (WorkflowException e) {
+            throw new CaseOrchestrationServiceException(e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> processSolDnCosts(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
+        try {
+            return solicitorDnCostsWorkflow.run(ccdCallbackRequest.getCaseDetails());
         } catch (WorkflowException e) {
             throw new CaseOrchestrationServiceException(e);
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptions.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptions.java
@@ -11,26 +11,46 @@ import java.util.Map;
 @Component
 public class PopulateDivorceCostOptions implements Task<Map<String, Object>> {
 
+    private static final String ORIGINAL_AMOUNT = "originalAmount";
+    private static final String COUNTER_OFFER = "counterOffer";
+    private static final String END_CLAIM = "endClaim";
+
+    private static final String RESP_AGREE_TO_COSTS = "RespAgreeToCosts";
+    private static final String DIFFERENT_AMOUNT = "DifferentAmount";
+    private static final String RESP_COSTS_AMOUNT = "RespCostsAmount";
+
+    private static final String SELECTED_ITEM = "selectedItem";
+    private static final String OPTIONS = "options";
+    private static final String DIVORCE_COSTS_OPTION_DN_ENUM = "DivorceCostsOptionDNEnum";
+
+    private static final String ORIGINAL_AMOUNT_OPTION = "The petition still wants to claim costs and will let the court decide how much";
+    private static final String COUNTER_OFFER_OPTION = "The petitioner will accept the amount proposed by the respondent (£%s)";
+    private static final String END_CLAIM_OPTION = "The petitioner does not want to claim costs anymore";
+
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> payload) {
 
         Map<String, String> options = new LinkedHashMap<>();
-        options.put("originalAmount", "The petition still wants to claim costs and will let the court decide how much");
-        String respondentCostAmount = (String) payload.get("RespCostsAmount");
-        options.put("counterOffer",
-                String.format("The petitioner will accept the amount proposed by the respondent (£%s)",
-                        respondentCostAmount)
-        );
-        options.put("endClaim", "The petitioner does not want to claim costs anymore");
+        options.put(ORIGINAL_AMOUNT, ORIGINAL_AMOUNT_OPTION);
+        String respondentCostAmount = (String) payload.get(RESP_COSTS_AMOUNT);
+
+        if (DIFFERENT_AMOUNT.equals(payload.get(RESP_AGREE_TO_COSTS))) {
+            options.put(COUNTER_OFFER,
+                    String.format(COUNTER_OFFER_OPTION,
+                            respondentCostAmount)
+            );
+        }
+
+        options.put(END_CLAIM, END_CLAIM_OPTION);
 
         Map.Entry<String, String> entry = options.entrySet().iterator().next();
-        String key = entry.getKey();
+        String firstOptionKey = entry.getKey();
 
         Map<String, Object> dnCostsMap = new HashMap<>();
-        dnCostsMap.put("selectedItem", key);
-        dnCostsMap.put("options", options);
+        dnCostsMap.put(SELECTED_ITEM, firstOptionKey);
+        dnCostsMap.put(OPTIONS, options);
 
-        payload.put("DivorceCostsOptionDNEnum", dnCostsMap);
+        payload.put(DIVORCE_COSTS_OPTION_DN_ENUM, dnCostsMap);
 
         return payload;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptions.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptions.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+public class PopulateDivorceCostOptions implements Task<Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> payload) {
+
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put("originalAmount", "The petition still wants to claim costs and will let the court decide how much");
+        String respondentCostAmount = (String) payload.get("RespCostsAmount");
+        options.put("counterOffer",
+                String.format("The petitioner will accept the amount proposed by the respondent (£%s)",
+                        respondentCostAmount)
+        );
+        options.put("endClaim", "The petitioner does not want to claim costs anymore");
+
+        Map.Entry<String, String> entry = options.entrySet().iterator().next();
+        String key = entry.getKey();
+
+        Map<String, Object> dnCostsMap = new HashMap<>();
+        dnCostsMap.put("selectedItem", key);
+        dnCostsMap.put("options", options);
+
+        payload.put("DivorceCostsOptionDNEnum", dnCostsMap);
+
+        return payload;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptions.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptions.java
@@ -23,7 +23,7 @@ public class PopulateDivorceCostOptions implements Task<Map<String, Object>> {
     private static final String OPTIONS = "options";
     private static final String DIVORCE_COSTS_OPTION_DN_ENUM = "DivorceCostsOptionDNEnum";
 
-    private static final String ORIGINAL_AMOUNT_OPTION = "The petition still wants to claim costs and will let the court decide how much";
+    private static final String ORIGINAL_AMOUNT_OPTION = "The petitioner still wants to claim costs and will let the court decide how much";
     private static final String COUNTER_OFFER_OPTION = "The petitioner will accept the amount proposed by the respondent (£%s)";
     private static final String END_CLAIM_OPTION = "The petitioner does not want to claim costs anymore";
 
@@ -35,10 +35,7 @@ public class PopulateDivorceCostOptions implements Task<Map<String, Object>> {
         String respondentCostAmount = (String) payload.get(RESP_COSTS_AMOUNT);
 
         if (DIFFERENT_AMOUNT.equals(payload.get(RESP_AGREE_TO_COSTS))) {
-            options.put(COUNTER_OFFER,
-                    String.format(COUNTER_OFFER_OPTION,
-                            respondentCostAmount)
-            );
+            options.put(COUNTER_OFFER, String.format(COUNTER_OFFER_OPTION, respondentCostAmount));
         }
 
         options.put(END_CLAIM, END_CLAIM_OPTION);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnCostsWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnCostsWorkflow.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDivorceCostOptions;
+
+import java.util.Map;
+
+@Component
+public class SolicitorDnCostsWorkflow extends DefaultWorkflow<Map<String, Object>> {
+
+    private final PopulateDivorceCostOptions populateDivorceCostOptions;
+
+    @Autowired
+    public SolicitorDnCostsWorkflow(PopulateDivorceCostOptions populateDivorceCostOptions) {
+        this.populateDivorceCostOptions = populateDivorceCostOptions;
+    }
+
+    public Map<String, Object> run(CaseDetails caseDetails) throws WorkflowException {
+        return this.execute(new Task[]{
+            populateDivorceCostOptions
+        }, caseDetails.getCaseData());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorDnCostsITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorDnCostsITest.java
@@ -1,0 +1,80 @@
+package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.core.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = OrchestrationServiceApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@PropertySource(value = "classpath:application.yml")
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class SolicitorDnCostsITest {
+
+    private static final String API_URL = "/sol-dn-costs";
+    private static final String DIVORCE_COSTS_OPTION_DN_ENUM = "DivorceCostsOptionDNEnum";
+
+    @Autowired
+    private MockMvc webClient;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void givenCaseData_whenSolicitorIsOnDnCostsPage_thenSetCosts() throws Exception {
+
+        final Map<String, Object> caseData = ObjectMapperTestUtil.getJsonFromResourceFile(
+                "/jsonExamples/payloads/sol-dn-costs-resp-agree.json",
+                Map.class
+        );
+
+        final Map<String, Object> expectedOptions = ObjectMapperTestUtil.getJsonFromResourceFile(
+                "/jsonExamples/payloads/sol-dn-costs-resp-agree-expected-options.json",
+                Map.class
+        );
+
+        final CaseDetails caseDetails =
+                CaseDetails.builder()
+                        .caseData(caseData)
+                        .build();
+
+        Map<String, Object> expectedData = new HashMap<>();
+        expectedData.put(DIVORCE_COSTS_OPTION_DN_ENUM, expectedOptions);
+        CcdCallbackResponse expected = CcdCallbackResponse.builder()
+                .data(expectedData)
+                .build();
+
+        CcdCallbackRequest request = CcdCallbackRequest.builder()
+                .caseDetails(caseDetails)
+                .build();
+
+        webClient.perform(post(API_URL)
+                .content(convertObjectToJsonString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(convertObjectToJsonString(expected)));
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptionsTest.java
@@ -19,7 +19,25 @@ public class PopulateDivorceCostOptionsTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testExecuteSetsCostOptions() throws Exception {
+    public void testExecuteSetsCostOptions_whenRespAgreeToCostsIsNotDifferentAmount_thenOnlyDisplayTwoOptions() throws Exception {
+        Map<String, Object> payload = ObjectMapperTestUtil.getJsonFromResourceFile(
+                "/jsonExamples/payloads/sol-dn-costs.json",
+                Map.class
+        );
+        Map<String, Object> expectedPayload = ObjectMapperTestUtil.getJsonFromResourceFile(
+                "/jsonExamples/payloads/sol-dn-costs-expected-options.json",
+                Map.class
+        );
+
+        Map<String, Object> result = populateMiniPetitionUrl.execute(null, payload);
+
+        assertThat(result, is(payload));
+        assertThat(result.get("DivorceCostsOptionDNEnum"), is(expectedPayload));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testExecuteSetsCostOptions_whenRespAgreeToCostsIsDifferentAmount_thenAdditionalCounterOfferOptionIsAdded() throws Exception {
         Map<String, Object> payload = ObjectMapperTestUtil.getJsonFromResourceFile(
                 "/jsonExamples/payloads/sol-dn-costs-resp-agree.json",
                 Map.class

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDivorceCostOptionsTest.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PopulateDivorceCostOptionsTest {
+
+    @InjectMocks
+    private PopulateDivorceCostOptions populateMiniPetitionUrl;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testExecuteSetsCostOptions() throws Exception {
+        Map<String, Object> payload = ObjectMapperTestUtil.getJsonFromResourceFile(
+                "/jsonExamples/payloads/sol-dn-costs-resp-agree.json",
+                Map.class
+        );
+        Map<String, Object> expectedPayload = ObjectMapperTestUtil.getJsonFromResourceFile(
+                "/jsonExamples/payloads/sol-dn-costs-resp-agree-expected-options.json",
+                Map.class
+        );
+
+        Map<String, Object> result = populateMiniPetitionUrl.execute(null, payload);
+
+        assertThat(result, is(payload));
+        assertThat(result.get("DivorceCostsOptionDNEnum"), is(expectedPayload));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnCostsWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnCostsWorkflowTest.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDivorceCostOptions;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SolicitorDnCostsWorkflowTest {
+
+    @Mock
+    PopulateDivorceCostOptions populateDivorceCostOptions;
+
+    @InjectMocks
+    SolicitorDnCostsWorkflow solicitorDnCostsWorkflow;
+
+    private TaskContext taskContext;
+
+    @Before
+    public void setup() {
+        taskContext = new DefaultTaskContext();
+    }
+
+    @Test
+    public void runShouldExecuteTasksAndReturnPayload() throws Exception {
+
+        Map<String, Object> caseData = Collections.emptyMap();
+
+        CaseDetails caseDetails = CaseDetails.builder()
+                .caseData(caseData)
+                .build();
+
+        when(populateDivorceCostOptions.execute(taskContext, caseData)).thenReturn(caseData);
+
+        assertThat(solicitorDnCostsWorkflow.run(caseDetails), is(caseData));
+
+        verify(populateDivorceCostOptions).execute(taskContext, caseData);
+    }
+}

--- a/src/test/resources/jsonExamples/payloads/sol-dn-costs-expected-options.json
+++ b/src/test/resources/jsonExamples/payloads/sol-dn-costs-expected-options.json
@@ -1,6 +1,6 @@
 {
   "options": {
-    "originalAmount": "The petition still wants to claim costs and will let the court decide how much",
+    "originalAmount": "The petitioner still wants to claim costs and will let the court decide how much",
     "endClaim": "The petitioner does not want to claim costs anymore"
   },
   "selectedItem": "originalAmount"

--- a/src/test/resources/jsonExamples/payloads/sol-dn-costs-expected-options.json
+++ b/src/test/resources/jsonExamples/payloads/sol-dn-costs-expected-options.json
@@ -1,0 +1,7 @@
+{
+  "options": {
+    "originalAmount": "The petition still wants to claim costs and will let the court decide how much",
+    "endClaim": "The petitioner does not want to claim costs anymore"
+  },
+  "selectedItem": "originalAmount"
+}

--- a/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree-expected-options.json
+++ b/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree-expected-options.json
@@ -1,6 +1,6 @@
 {
   "options": {
-    "originalAmount": "The petition still wants to claim costs and will let the court decide how much",
+    "originalAmount": "The petitioner still wants to claim costs and will let the court decide how much",
     "counterOffer": "The petitioner will accept the amount proposed by the respondent (£200)",
     "endClaim": "The petitioner does not want to claim costs anymore"
   },

--- a/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree-expected-options.json
+++ b/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree-expected-options.json
@@ -1,0 +1,8 @@
+{
+  "options": {
+    "originalAmount": "The petition still wants to claim costs and will let the court decide how much",
+    "counterOffer": "The petitioner will accept the amount proposed by the respondent (£200)",
+    "endClaim": "The petitioner does not want to claim costs anymore"
+  },
+  "selectedItem": "originalAmount"
+}

--- a/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree.json
+++ b/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree.json
@@ -1,0 +1,4 @@
+{
+  "RespAgreeToCosts": "YES",
+  "RespCostsAmount": "200"
+}

--- a/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree.json
+++ b/src/test/resources/jsonExamples/payloads/sol-dn-costs-resp-agree.json
@@ -1,4 +1,4 @@
 {
-  "RespAgreeToCosts": "YES",
+  "RespAgreeToCosts": "DifferentAmount",
   "RespCostsAmount": "200"
 }

--- a/src/test/resources/jsonExamples/payloads/sol-dn-costs.json
+++ b/src/test/resources/jsonExamples/payloads/sol-dn-costs.json
@@ -1,0 +1,4 @@
+{
+  "RespAgreeToCosts": "YES",
+  "RespCostsAmount": "200"
+}


### PR DESCRIPTION
# Description

* Added a new endpoint `/sol-dn-costs` which will be set as a "mid-event" callback endpoint in the dncosts page in CCD
* Set the `DivorceCostsOptionDNEnum` field to:
  * 3 options, when `RespCostsAmount` is set to `DifferentAmount`
```
{
  "options": {
    "originalAmount": "The petition still wants to claim costs and will let the court decide how much",
    "counterOffer": "The petitioner will accept the amount proposed by the respondent (£200)",
    "endClaim": "The petitioner does not want to claim costs anymore"
  },
  "selectedItem": "originalAmount"
}
```
  * Otherwise only `origianlAmount` and `endClaim` are set
```
{
  "options": {
    "originalAmount": "The petition still wants to claim costs and will let the court decide how much",
    "endClaim": "The petitioner does not want to claim costs anymore"
  },
  "selectedItem": "originalAmount"
}
```


See contract here: https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=930742860&__ncforminfo=gB65feGX0pGyThLNQ0eijDwdGF6cNoI8rGpyh0xOXgJgZu5xZ3ARVt6KMPPUKKTsehOXsExWvY4WZPHZkaS1xQBUHF4XV7-2&__ncforminfo=5ElAZLn6l_0TwWfoMgk6TORMHr2ph4SByXRKT3VjeC68cFjI_L1q-B_Z49QaV5DW2eNoJY88paxn8t6pgKftZnTAPJXXIyTQQiP5dbIlEuw=

***This has to be done before merging this***: https://tools.hmcts.net/jira/browse/RDM-3201

Fixes #DIV-4732

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
