### PR TITLE
Don't do payment update when case state is not AwaitingPayment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,16 +152,6 @@ dependencies {
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
     compile group: 'org.apache.commons', name: 'commons-lang3', version: versions.commonsLang3
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: versions.javaxWsRs
-    
-    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-core', version: '9.0.19') {
-        force = true
-    }
-    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-websocket', version: '9.0.19') {
-        force = true
-    }
-    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-el', version: '9.0.19') {
-        force = true
-    }
 
     compile group: 'org.springframework', name: 'spring-context-support'
     compile (group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign')

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,16 @@ dependencies {
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
     compile group: 'org.apache.commons', name: 'commons-lang3', version: versions.commonsLang3
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: versions.javaxWsRs
+    
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-core', version: '9.0.19') {
+        force = true
+    }
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-websocket', version: '9.0.19') {
+        force = true
+    }
+    compile (group: 'org.apache.tomcat.embed', name:'tomcat-embed-el', version: '9.0.19') {
+        force = true
+    }
 
     compile group: 'org.springframework', name: 'spring-context-support'
     compile (group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign')

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CaseDataResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
@@ -20,6 +21,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.CcdCallbackBulkPrintW
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.CoRespondentAnswerReceivedWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.DNSubmittedWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.DeleteDraftWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.GetCaseWithIdWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.GetCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.IssueEventWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.LinkRespondentWorkflow;
@@ -45,9 +47,11 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_PAYMENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_DATA_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
@@ -89,6 +93,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     private final AmendPetitionWorkflow amendPetitionWorkflow;
     private final CaseLinkedForHearingWorkflow caseLinkedForHearingWorkflow;
     private final CoRespondentAnswerReceivedWorkflow coRespondentAnswerReceivedWorkflow;
+    private final GetCaseWithIdWorkflow getCaseWithIdWorkflow;
 
     @Override
     public Map<String, Object> handleIssueEventCallback(CcdCallbackRequest ccdCallbackRequest,
@@ -158,39 +163,46 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
         Map<String, Object> payload = new HashMap<>();
 
         if (paymentUpdate.getStatus().equalsIgnoreCase(SUCCESS)) {
-            String paymentAmount = Optional.ofNullable(paymentUpdate.getAmount())
-                .map(BigDecimal::intValueExact)
-                .map(amt -> amt * 100)
-                .map(String::valueOf)
-                .orElseThrow(() -> new WorkflowException("Missing payment amount data"));
+            CaseDetails caseDetails = getCaseWithIdWorkflow.run(paymentUpdate.getCcdCaseNumber());
 
-            String feeId = Optional.ofNullable(paymentUpdate.getFees())
-                .filter(list -> !list.isEmpty())
-                .map(list -> list.get(0))
-                .orElseThrow(() -> new WorkflowException("Missing payment fee data"))
-                .getCode();
+            if (Objects.nonNull(caseDetails) && AWAITING_PAYMENT.equalsIgnoreCase(caseDetails.getState())) {
+                String paymentAmount = Optional.ofNullable(paymentUpdate.getAmount())
+                    .map(BigDecimal::intValueExact)
+                    .map(amt -> amt * 100)
+                    .map(String::valueOf)
+                    .orElseThrow(() -> new WorkflowException("Missing payment amount data"));
 
-            Payment payment = Payment.builder()
-                .paymentChannel(ONLINE)
-                .paymentReference(paymentUpdate.getReference())
-                .paymentSiteId(paymentUpdate.getSiteId())
-                .paymentStatus(paymentUpdate.getStatus())
-                .paymentTransactionId(paymentUpdate.getExternalReference())
-                .paymentAmount(paymentAmount)
-                .paymentFeeId(feeId)
-                .build();
+                String feeId = Optional.ofNullable(paymentUpdate.getFees())
+                    .filter(list -> !list.isEmpty())
+                    .map(list -> list.get(0))
+                    .orElseThrow(() -> new WorkflowException("Missing payment fee data"))
+                    .getCode();
 
-            Map<String, Object> updateEvent = new HashMap<>();
-            Map<String, Object> sessionData = new HashMap<>();
-            sessionData.put(PAYMENT, payment);
-            updateEvent.put(CASE_EVENT_DATA_JSON_KEY, sessionData);
-            updateEvent.put(CASE_EVENT_ID_JSON_KEY, PAYMENT_MADE);
+                Payment payment = Payment.builder()
+                    .paymentChannel(ONLINE)
+                    .paymentReference(paymentUpdate.getReference())
+                    .paymentSiteId(paymentUpdate.getSiteId())
+                    .paymentStatus(paymentUpdate.getStatus())
+                    .paymentTransactionId(paymentUpdate.getExternalReference())
+                    .paymentAmount(paymentAmount)
+                    .paymentFeeId(feeId)
+                    .build();
 
-            payload = updateToCCDWorkflow.run(updateEvent,
-                authUtil.getCaseworkerToken(), paymentUpdate.getCcdCaseNumber());
-            log.info("Case ID is: {}. Payment updated with payment reference {}",
-                payload.get(ID),
-                payment.getPaymentReference());
+                Map<String, Object> updateEvent = new HashMap<>();
+                Map<String, Object> sessionData = new HashMap<>();
+                sessionData.put(PAYMENT, payment);
+                updateEvent.put(CASE_EVENT_DATA_JSON_KEY, sessionData);
+                updateEvent.put(CASE_EVENT_ID_JSON_KEY, PAYMENT_MADE);
+
+                payload = updateToCCDWorkflow.run(updateEvent,
+                    authUtil.getCaseworkerToken(), paymentUpdate.getCcdCaseNumber());
+                log.info("Case ID is: {}. Payment updated with payment reference {}",
+                    payload.get(ID),
+                    payment.getPaymentReference());
+            } else {
+                log.info("Ignoring payment update as the case is not in AwaitingPayment state case {}",
+                    paymentUpdate.getCcdCaseNumber());
+            }
         } else {
             log.info("Ignoring payment update as it was not successful payment on case {}",
                 paymentUpdate.getCcdCaseNumber());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetCaseWithId.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetCaseWithId.java
@@ -28,11 +28,10 @@ public class GetCaseWithId implements Task<UserDetails> {
 
     @Override
     public UserDetails execute(TaskContext context, UserDetails payload) throws TaskException {
-        CaseDetails caseDetails;
-
         final String caseWorkerToken = authUtil.getCaseworkerToken();
         final String caseId = String.valueOf(context.getTransientObject(CASE_ID_JSON_KEY));
-        caseDetails = caseMaintenanceClient.retrievePetitionById(
+        
+        CaseDetails caseDetails = caseMaintenanceClient.retrievePetitionById(
             caseWorkerToken,
             caseId
         );

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/GetCaseWithIdWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/GetCaseWithIdWorkflow.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithId;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@Component
+public class GetCaseWithIdWorkflow extends DefaultWorkflow<CaseDetails> {
+    private final GetCaseWithId getCaseWithId;
+
+    @Autowired
+    public GetCaseWithIdWorkflow(GetCaseWithId getCaseWithId) {
+        this.getCaseWithId = getCaseWithId;
+    }
+
+    public CaseDetails run(String caseId) throws WorkflowException {
+        this.execute(
+            new Task[] {
+                getCaseWithId
+            },
+            null,
+            ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
+        );
+
+        return (CaseDetails) this.getContext().getTransientObject(CASE_DETAILS_JSON_KEY);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -392,7 +392,7 @@ public class CaseOrchestrationServiceImplTest {
 
         verify(updateToCCDWorkflow).run(updateEvent, "testtoken", "1232132");
     }
-  
+
     @Test
     public void givenValidPaymentDataWithoutChannel_whenPaymentUpdate_thenReturnPayloadWithDefaultChannel() throws Exception {
         PaymentUpdate paymentUpdate = new PaymentUpdate();
@@ -428,7 +428,7 @@ public class CaseOrchestrationServiceImplTest {
 
         verify(updateToCCDWorkflow).run(updateEvent, "testtoken", "1232132");
     }
-  
+
     @Test
     public void givenValidPaymentDataButCaseInWrongState_whenPaymentUpdate_thenReturnPayload() throws Exception {
         PaymentUpdate paymentUpdate = new PaymentUpdate();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -403,7 +403,11 @@ public class CaseOrchestrationServiceImplTest {
         fee.setCode("X243");
         paymentUpdate.setFees(Arrays.asList(fee, fee));
 
+        CaseDetails caseDetails = CaseDetails.builder().state(AWAITING_PAYMENT).build();
+
         // given
+        when(getCaseWithIdWorkflow.run(any())).thenReturn(caseDetails);
+
         when(updateToCCDWorkflow.run(any(), any(), any()))
                 .thenReturn(requestPayload);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/GetCaseWithIdWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/GetCaseWithIdWorkflowTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithId;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetCaseWithIdWorkflowTest {
+    @Mock
+    private GetCaseWithId getCaseWithId;
+
+    @InjectMocks
+    private GetCaseWithIdWorkflow classUnderTest;
+
+    @Test
+    public void whenGetCase_thenProcessAsExpected() throws WorkflowException, TaskException {
+        final Task[] tasks = new Task[] {
+            getCaseWithId
+        };
+
+        final CaseDetails caseDetails = CaseDetails.builder().build();
+
+        final DefaultTaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+
+        // getCaseWithId should set the caseDetails on context and return a null payload
+        Answer<UserDetails> getCaseWithIdAnswer = new Answer<UserDetails>() {
+            public UserDetails answer(InvocationOnMock invocation) throws Throwable {
+                // Params are passed in as context, payload. First index will have the context
+                DefaultTaskContext invokedContext = (DefaultTaskContext) invocation.getArguments()[0];
+                invokedContext.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
+                return null;
+            }
+        };
+
+        when(getCaseWithId.execute(context, null)).thenAnswer(getCaseWithIdAnswer);
+
+        CaseDetails actual = classUnderTest.run(TEST_CASE_ID);
+
+        assertEquals(caseDetails, actual);
+    }
+}


### PR DESCRIPTION
Note: This is a temporary measure to stop div-alert spam for false positive failed payment-update calls.

Despite having a successful payment and update in CCD to the correct state, on rare occasions the strategic payment callback is still incorrectly triggered on that case, resulting in a 422. This triggers an Azure alert via email to Developers.
The error is a non-issue since as far as the user and caseworkers are concerned, the case has been moved on correctly.
However this issue does spam Devs with email notifications and also pollutes the appInsights logs.

The proper fix is for payments team to investigate and resolve the issue with callbacks triggering on successful payment status checks, however this PR is a quick measure to stop triggering updates when the case is already moved.

NOTE: This will only resolve the 422 issues, on an even rarer occasion, a 409 can occur due to a race condition between the strategic payment callback triggered by the scheduler and the actual case update.