### PR TITLE
DIV-4841 - handle NoNoAdmission response in resp notification email task

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflow.java
@@ -22,6 +22,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @Slf4j
 public class SendRespondentSubmissionNotificationWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
+    private static final String NOT_DEFENDING_NOT_ADMITTING = "NoNoAdmission";
+
     @Autowired
     private SendRespondentSubmissionNotificationForDefendedDivorceEmail
         sendRespondentSubmissionNotificationForDefendedDivorceEmailTask;
@@ -38,7 +40,7 @@ public class SendRespondentSubmissionNotificationWorkflow extends DefaultWorkflo
 
         if (YES_VALUE.equalsIgnoreCase(defended)) {
             tasks = new Task[] {sendRespondentSubmissionNotificationForDefendedDivorceEmailTask};
-        } else if (NO_VALUE.equalsIgnoreCase(defended)) {
+        } else if (NO_VALUE.equalsIgnoreCase(defended) || NOT_DEFENDING_NOT_ADMITTING.equalsIgnoreCase(defended)) {
             tasks = new Task[] {sendRespondentSubmissionNotificationForUndefendedDivorceEmailTask};
         } else {
             String errorMessage = String.format("%s field doesn't contain a valid value: %s",

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RespondentAOSSubmissionNotificationEmailITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RespondentAOSSubmissionNotificationEmailITest.java
@@ -107,6 +107,31 @@ public class RespondentAOSSubmissionNotificationEmailITest {
     }
 
     @Test
+    public void testResponseHasDataAndNoErrors_WhenEmailCanBeSent_ForUndefendedButNoAdmitDivorce() throws Exception {
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingNotAdmittingDivorce.json", CcdCallbackRequest.class);
+        Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
+        CcdCallbackResponse expected = CcdCallbackResponse.builder()
+                .data(caseData)
+                .build();
+
+        webClient.perform(post(API_URL)
+                .content(convertObjectToJsonString(ccdCallbackRequest))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(convertObjectToJsonString(expected)))
+                .andExpect(content().string(allOf(
+                        isJson(),
+                        hasJsonPath("$.errors", nullValue())
+                )));
+
+        verify(mockClient).sendEmail(eq(UNDEFENDED_DIVORCE_EMAIL_TEMPLATE_ID),
+                eq("respondent@divorce.co.uk"),
+                any(), any());
+    }
+
+    @Test
     public void testResponseHasValidationErrors_WhenItIsNotClearIfDivorceWillBeDefended() throws Exception {
         CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
                 "/jsonExamples/payloads/unclearAcknowledgementOfService.json", CcdCallbackRequest.class);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendRespondentSubmissionNotificationWorkflowTest.java
@@ -98,6 +98,23 @@ public class SendRespondentSubmissionNotificationWorkflowTest {
     }
 
     @Test
+    public void testUndefendedTaskIsCalled_WhenRespondentChoosesToNotDefendDivorceButNotAdmitWhatIsSaid() throws IOException,
+            WorkflowException, TaskException {
+        CcdCallbackRequest callbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingNotAdmittingDivorce.json", CcdCallbackRequest.class);
+        Map<String, Object> caseData = callbackRequest.getCaseDetails().getCaseData();
+
+        Map<String, Object> returnedPayloadFromWorkflow = workflow.run(callbackRequest);
+
+        verify(undefendedDivorceNotificationEmailTask).execute(taskContextArgumentCaptor.capture(), same(caseData));
+        verifyZeroInteractions(defendedDivorceNotificationEmailTask);
+        assertThat(returnedPayloadFromWorkflow, is(sameInstance(returnedPayloadFromTask)));
+        TaskContext taskContextPassedToTask = taskContextArgumentCaptor.getValue();
+        String caseIdPassedToTask = taskContextPassedToTask.getTransientObject(CASE_ID_JSON_KEY);
+        assertThat(caseIdPassedToTask, is(equalTo(UNFORMATTED_CASE_ID)));
+    }
+
+    @Test
     public void testExceptionIsThrown_IfNotPossibleToAssert_WhetherDivorceWillBeDefended() throws IOException,
             WorkflowException {
         expectedException.expect(WorkflowException.class);

--- a/src/test/resources/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingNotAdmittingDivorce.json
+++ b/src/test/resources/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingNotAdmittingDivorce.json
@@ -1,0 +1,15 @@
+{
+  "case_details": {
+    "id": "0123456789012345",
+    "case_data": {
+      "RespEmailAddress": "respondent@divorce.co.uk",
+      "RespWillDefendDivorce": "NoNoAdmission",
+      "D8RespondentFirstName": "Sarah",
+      "D8RespondentLastName": "Jones",
+      "D8InferredPetitionerGender": "male",
+      "D8DivorceUnit": "westMidlands",
+      "ReceivedAOSfromRespDate": "2018-09-20",
+      "D8caseReference": "LV17D80101"
+    }
+  }
+}


### PR DESCRIPTION

# Description

When respondent chooses not to defend the divorce but not admit, we
should send them a confirmation email as we do for other responses

Fixes #DIV-4841

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
