### PR TITLE
DIV-4789: Replace Joda-Time with native Java DateTime based on Clock

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -12,12 +12,12 @@ import org.springframework.test.context.ContextConfiguration;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.IdamUtils;
 
-import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URL;
 import java.util.UUID;
 import java.util.function.Supplier;
+import javax.annotation.PostConstruct;
 
 @Slf4j
 @RunWith(SerenityRunner.class)
@@ -79,10 +79,10 @@ public abstract class IntegrationTest {
         synchronized (this) {
             if (caseWorkerUser == null) {
                 caseWorkerUser = warpInRetry(() -> getUserDetails(
-                        CASE_WORKER_USERNAME + UUID.randomUUID() + EMAIL_DOMAIN, CASE_WORKER_PASSWORD,
-                        CASEWORKER_USERGROUP,
-                        CASEWORKER_ROLE, CASEWORKER_DIVORCE_ROLE,
-                        CASEWORKER_DIVORCE_COURTADMIN_ROLE, CASEWORKER_DIVORCE_COURTADMIN_BETA_ROLE
+                    CASE_WORKER_USERNAME + UUID.randomUUID() + EMAIL_DOMAIN, CASE_WORKER_PASSWORD,
+                    CASEWORKER_USERGROUP,
+                    CASEWORKER_ROLE, CASEWORKER_DIVORCE_ROLE,
+                    CASEWORKER_DIVORCE_COURTADMIN_ROLE, CASEWORKER_DIVORCE_COURTADMIN_BETA_ROLE
                 ));
             }
             return caseWorkerUser;
@@ -112,12 +112,12 @@ public abstract class IntegrationTest {
             final String userId = idamTestSupportUtil.getUserId(authToken);
 
             return UserDetails.builder()
-                    .username(username)
-                    .emailAddress(username)
-                    .password(password)
-                    .authToken(authToken)
-                    .id(userId)
-                    .build();
+                .username(username)
+                .emailAddress(username)
+                .password(password)
+                .authToken(authToken)
+                .id(userId)
+                .build();
         }
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -59,8 +59,8 @@ public abstract class IntegrationTest {
     }
 
     @PostConstruct
-    public void init(){
-        if(!Strings.isNullOrEmpty(httpProxy)) {
+    public void init() {
+        if (!Strings.isNullOrEmpty(httpProxy)) {
             try {
                 URL proxy = new URL(httpProxy);
                 InetAddress.getByName(proxy.getHost()).isReachable(2000); // check proxy connectivity

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/LinkRespondentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/LinkRespondentTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.maintenance;
 import io.restassured.response.Response;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.http.entity.ContentType;
-import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -14,6 +13,8 @@ import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.RetrieveAosCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -278,7 +279,7 @@ public class LinkRespondentTest extends RetrieveAosCaseSupport {
         assertNull(caseDetails.getData().get(RECEIVED_AOS_FROM_RESP));
         assertNull(caseDetails.getData().get(RECEIVED_AOS_FROM_RESP_DATE));
         assertEquals(YES_VALUE, caseDetails.getData().get(CO_RESP_LINKED_TO_CASE));
-        assertEquals(LocalDate.now().toString(CCD_DATE_FORMAT), caseDetails.getData().get(CO_RESP_LINKED_TO_CASE_DATE));
+        assertEquals(LocalDate.now().format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)), caseDetails.getData().get(CO_RESP_LINKED_TO_CASE_DATE));
     }
 
     private Response linkRespondent(String userToken, Long caseId, String pin) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitRespondentAosCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitRespondentAosCaseTest.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.divorce.maintenance;
 
 import io.restassured.response.Response;
-import org.joda.time.LocalDate;
 import org.junit.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import static org.junit.Assert.assertEquals;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -182,6 +184,6 @@ public class SubmitRespondentAosCaseTest extends CcdSubmissionSupport {
     private void assertAosSubmittedData(UserDetails userDetails, String caseId) {
         CaseDetails caseDetails = this.retrieveCase(userDetails, caseId);
         assertEquals(YES_VALUE, caseDetails.getData().get(RECEIVED_AOS_FROM_RESP));
-        assertEquals(LocalDate.now().toString(CCD_DATE_FORMAT), caseDetails.getData().get(RECEIVED_AOS_FROM_RESP_DATE));
+        assertEquals(LocalDate.now().format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)), caseDetails.getData().get(RECEIVED_AOS_FROM_RESP_DATE));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -27,6 +27,7 @@ public interface CosApiClient {
     Map<String, Object> coRespReceived(@RequestHeader(AUTHORIZATION) String authorisation,
                                        @RequestBody Map<String, Object> caseDataContent
     );
+
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/co-respondent-answered"

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfo.java
@@ -12,9 +12,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +33,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_CHANNEL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_CHANNEL_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_DATE_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_DATE_PATTERN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_FEE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_FEE_ID_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_REFERENCE;
@@ -60,7 +56,7 @@ public class GetInconsistentPaymentInfo implements Task<Map<String, Object>> {
     private final PaymentClient paymentClient;
     private final AuthTokenGenerator serviceAuthGenerator;
     private final TaskCommons taskCommons;
-    private final Clock clock;
+    private final CcdUtil ccdUtil;
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {
@@ -101,7 +97,7 @@ public class GetInconsistentPaymentInfo implements Task<Map<String, Object>> {
             .put(PAYMENT_CHANNEL_KEY, PAYMENT_CHANNEL)
             .put(PAYMENT_TRANSACTION_ID_KEY, paymentInfo.get(EXTERNAL_REFERENCE))
             .put(PAYMENT_REFERENCE_KEY, paymentInfo.get(PAYMENT_SERVICE_REFERENCE))
-            .put(PAYMENT_DATE_KEY, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN)))
+            .put(PAYMENT_DATE_KEY, ccdUtil.getCurrentDatePaymentFormat())
             .put(PAYMENT_AMOUNT_KEY, String.valueOf((Integer) paymentInfo.get(PAYMENT_SERVICE_AMOUNT_KEY) * 100))
             .put(PAYMENT_STATUS_KEY, paymentInfo.get(STATUS_FROM_PAYMENT))
             .put(PAYMENT_FEE_ID_KEY, PAYMENT_FEE_ID)
@@ -111,7 +107,7 @@ public class GetInconsistentPaymentInfo implements Task<Map<String, Object>> {
 
     private Map<String, Object> mapPaymentFromCCDModel(Map<String, Object> ccdFormatPaymentInfo) {
         Map<String, Object> mapCopy = Maps.newHashMap(ccdFormatPaymentInfo);
-        mapCopy.put(PAYMENT_DATE_KEY, CcdUtil.mapCCDDateToDivorceDate(
+        mapCopy.put(PAYMENT_DATE_KEY, ccdUtil.mapCCDDateToDivorceDate(
             (String) ccdFormatPaymentInfo.get(PAYMENT_DATE_KEY)));
         return mapCopy;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfo.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -59,6 +60,7 @@ public class GetInconsistentPaymentInfo implements Task<Map<String, Object>> {
     private final PaymentClient paymentClient;
     private final AuthTokenGenerator serviceAuthGenerator;
     private final TaskCommons taskCommons;
+    private final Clock clock;
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {
@@ -99,7 +101,7 @@ public class GetInconsistentPaymentInfo implements Task<Map<String, Object>> {
             .put(PAYMENT_CHANNEL_KEY, PAYMENT_CHANNEL)
             .put(PAYMENT_TRANSACTION_ID_KEY, paymentInfo.get(EXTERNAL_REFERENCE))
             .put(PAYMENT_REFERENCE_KEY, paymentInfo.get(PAYMENT_SERVICE_REFERENCE))
-            .put(PAYMENT_DATE_KEY, LocalDate.now().format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN)))
+            .put(PAYMENT_DATE_KEY, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN)))
             .put(PAYMENT_AMOUNT_KEY, String.valueOf((Integer) paymentInfo.get(PAYMENT_SERVICE_AMOUNT_KEY) * 100))
             .put(PAYMENT_STATUS_KEY, paymentInfo.get(STATUS_FROM_PAYMENT))
             .put(PAYMENT_FEE_ID_KEY, PAYMENT_FEE_ID)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfo.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.joda.time.LocalDate;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.divorce.orchestration.client.PaymentClient;
@@ -13,6 +12,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class GetInconsistentPaymentInfo implements Task<Map<String, Object>> {
             .put(PAYMENT_CHANNEL_KEY, PAYMENT_CHANNEL)
             .put(PAYMENT_TRANSACTION_ID_KEY, paymentInfo.get(EXTERNAL_REFERENCE))
             .put(PAYMENT_REFERENCE_KEY, paymentInfo.get(PAYMENT_SERVICE_REFERENCE))
-            .put(PAYMENT_DATE_KEY, LocalDate.now().toString(PAYMENT_DATE_PATTERN))
+            .put(PAYMENT_DATE_KEY, LocalDate.now().format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN)))
             .put(PAYMENT_AMOUNT_KEY, String.valueOf((Integer) paymentInfo.get(PAYMENT_SERVICE_AMOUNT_KEY) * 100))
             .put(PAYMENT_STATUS_KEY, paymentInfo.get(STATUS_FROM_PAYMENT))
             .put(PAYMENT_FEE_ID_KEY, PAYMENT_FEE_ID)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerCoRespondentRespondedNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerCoRespondentRespondedNotificationEmail.java
@@ -39,7 +39,7 @@ public class SendPetitionerCoRespondentRespondedNotificationEmail implements Tas
 
         if (StringUtils.isNotBlank(petitionerEmail)) {
             Map<String, String> templateVars = new HashMap<>();
-            
+
             templateVars.put(NOTIFICATION_REFERENCE_KEY, (String) caseData.get(D_8_CASE_REFERENCE));
             templateVars.put(NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY, (String) caseData.get(D_8_PETITIONER_FIRST_NAME));
             templateVars.put(NOTIFICATION_ADDRESSEE_LAST_NAME_KEY, (String) caseData.get(D_8_PETITIONER_LAST_NAME));

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentSubmissionNotificationForDefendedDivorceEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentSubmissionNotificationForDefendedDivorceEmail.java
@@ -30,6 +30,9 @@ public class SendRespondentSubmissionNotificationForDefendedDivorceEmail impleme
     private static final String EMAIL_DESCRIPTION = "respondent submission notification email - defended divorce";
 
     @Autowired
+    private CcdUtil ccdUtil;
+
+    @Autowired
     private TaskCommons taskCommons;
 
     @Override
@@ -55,7 +58,7 @@ public class SendRespondentSubmissionNotificationForDefendedDivorceEmail impleme
         templateFields.put("RDC name", court.getIdentifiableCentreName());
         templateFields.put("court address", court.getFormattedAddress());
 
-        String formSubmissionDateLimit = CcdUtil.getFormattedDueDate(caseDataPayload, CCD_DUE_DATE);
+        String formSubmissionDateLimit = ccdUtil.getFormattedDueDate(caseDataPayload, CCD_DUE_DATE);
         templateFields.put("form submission date limit", formSubmissionDateLimit);
 
         taskCommons.sendEmail(RESPONDENT_DEFENDED_AOS_SUBMISSION_NOTIFICATION,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceived.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceived.java
@@ -1,22 +1,30 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @Component
 public class SetCoRespondentAnswerReceived implements Task<Map<String, Object>> {
+
+    @Autowired
+    private Clock clock;
+
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> payload) {
         payload.put(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE);
-        payload.put(CO_RESPONDENT_ANSWER_RECEIVED_DATE, CcdUtil.getCurrentDate());
+        payload.put(CO_RESPONDENT_ANSWER_RECEIVED_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
         return payload;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceived.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceived.java
@@ -4,13 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
@@ -19,12 +16,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class SetCoRespondentAnswerReceived implements Task<Map<String, Object>> {
 
     @Autowired
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> payload) {
         payload.put(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE);
-        payload.put(CO_RESPONDENT_ANSWER_RECEIVED_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        payload.put(CO_RESPONDENT_ANSWER_RECEIVED_DATE, ccdUtil.getCurrentDateCcdFormat());
         return payload;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetails.java
@@ -1,13 +1,17 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_CENTRE_SITEID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
@@ -15,9 +19,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @Component
 public class SetCourtDetails implements Task<Map<String, Object>> {
 
+    @Autowired
+    private Clock clock;
+
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
-        caseData.put(CREATED_DATE_JSON_KEY, CcdUtil.getCurrentDate());
+        caseData.put(CREATED_DATE_JSON_KEY, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
 
         // Assign Divorce court for Solicitor, currently hardcoded to one specific court
         caseData.put(DIVORCE_UNIT_JSON_KEY, CourtEnum.EASTMIDLANDS.getId());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetails.java
@@ -5,13 +5,10 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_CENTRE_SITEID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
@@ -20,11 +17,11 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class SetCourtDetails implements Task<Map<String, Object>> {
 
     @Autowired
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
-        caseData.put(CREATED_DATE_JSON_KEY, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        caseData.put(CREATED_DATE_JSON_KEY, ccdUtil.getCurrentDateCcdFormat());
 
         // Assign Divorce court for Solicitor, currently hardcoded to one specific court
         caseData.put(DIVORCE_UNIT_JSON_KEY, CourtEnum.EASTMIDLANDS.getId());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDate.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDate.java
@@ -1,20 +1,27 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ISSUE_DATE;
 
 @Component
 public class SetIssueDate implements Task<Map<String, Object>> {
 
+    @Autowired
+    private Clock clock;
+
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> payload) {
-        payload.put(ISSUE_DATE, CcdUtil.getCurrentDate());
+        payload.put(ISSUE_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
         return payload;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDate.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDate.java
@@ -4,24 +4,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ISSUE_DATE;
 
 @Component
 public class SetIssueDate implements Task<Map<String, Object>> {
 
     @Autowired
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> payload) {
-        payload.put(ISSUE_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        payload.put(ISSUE_DATE, ccdUtil.getCurrentDateCcdFormat());
         return payload;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCase.java
@@ -48,8 +48,8 @@ public class SubmitRespondentAosCase implements Task<Map<String, Object>> {
         String caseIDJsonKey = context.getTransientObject(CASE_ID_JSON_KEY);
 
         final CaseDetails currentCaseDetails = caseMaintenanceClient.retrievePetitionById(
-                context.getTransientObject(AUTH_TOKEN_JSON_KEY).toString(),
-                context.getTransientObject(CASE_ID_JSON_KEY).toString()
+            context.getTransientObject(AUTH_TOKEN_JSON_KEY).toString(),
+            context.getTransientObject(CASE_ID_JSON_KEY).toString()
         );
 
         final String reasonForDivorce = (String) currentCaseDetails.getCaseData().get(D_8_REASON_FOR_DIVORCE);
@@ -57,10 +57,10 @@ public class SubmitRespondentAosCase implements Task<Map<String, Object>> {
         submissionData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
         submissionData.put(RECEIVED_AOS_FROM_RESP_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
         Map<String, Object> updateCase = caseMaintenanceClient.updateCase(
-                authToken,
-                caseIDJsonKey,
-                eventId,
-                submissionData
+            authToken,
+            caseIDJsonKey,
+            eventId,
+            submissionData
         );
 
         if (updateCase != null) {
@@ -77,8 +77,8 @@ public class SubmitRespondentAosCase implements Task<Map<String, Object>> {
         if (YES_VALUE.equalsIgnoreCase(respWillDefendDivorce)) {
             return AWAITING_ANSWER_AOS_EVENT_ID;
         } else if ((ADULTERY.equalsIgnoreCase(d8ReasonForDivorce)
-                || SEPARATION_2YRS.equalsIgnoreCase(d8ReasonForDivorce))
-                && NO_VALUE.equalsIgnoreCase(respAdmitOrConsentToFact)) {
+            || SEPARATION_2YRS.equalsIgnoreCase(d8ReasonForDivorce))
+            && NO_VALUE.equalsIgnoreCase(respAdmitOrConsentToFact)) {
 
             return COMPLETED_AOS_EVENT_ID;
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCase.java
@@ -1,15 +1,13 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ADULTERY;
@@ -18,7 +16,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DN_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.COMPLETED_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
@@ -29,18 +26,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SEPARATION_2YRS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
-
 @Component
+@RequiredArgsConstructor
 public class SubmitRespondentAosCase implements Task<Map<String, Object>> {
 
     private final CaseMaintenanceClient caseMaintenanceClient;
-    private final Clock clock;
-
-    @Autowired
-    public SubmitRespondentAosCase(final CaseMaintenanceClient caseMaintenanceClient, final Clock clock) {
-        this.caseMaintenanceClient = caseMaintenanceClient;
-        this.clock = clock;
-    }
+    private final CcdUtil ccdUtil;
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> submissionData) {
@@ -55,7 +46,7 @@ public class SubmitRespondentAosCase implements Task<Map<String, Object>> {
         final String reasonForDivorce = (String) currentCaseDetails.getCaseData().get(D_8_REASON_FOR_DIVORCE);
         String eventId = getAosCompleteEventId(submissionData, reasonForDivorce);
         submissionData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
-        submissionData.put(RECEIVED_AOS_FROM_RESP_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        submissionData.put(RECEIVED_AOS_FROM_RESP_DATE, ccdUtil.getCurrentDateCcdFormat());
         Map<String, Object> updateCase = caseMaintenanceClient.updateCase(
             authToken,
             caseIDJsonKey,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetails.java
@@ -12,10 +12,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,7 +25,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_REISSUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE_DATE;
@@ -52,7 +49,7 @@ public class UpdateRespondentDetails implements Task<UserDetails> {
     private AuthUtil authUtil;
 
     @Autowired
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @Override
     public UserDetails execute(TaskContext context, UserDetails payload) throws TaskException {
@@ -74,7 +71,7 @@ public class UpdateRespondentDetails implements Task<UserDetails> {
             } else {
                 updateFields.put(CO_RESP_EMAIL_ADDRESS, linkedUser.getEmail());
                 updateFields.put(CO_RESP_LINKED_TO_CASE, YES_VALUE);
-                updateFields.put(CO_RESP_LINKED_TO_CASE_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+                updateFields.put(CO_RESP_LINKED_TO_CASE_DATE, ccdUtil.getCurrentDateCcdFormat());
                 eventId = LINK_RESPONDENT_GENERIC_EVENT_ID;
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetails.java
@@ -12,8 +12,10 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,6 +27,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_REISSUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE_DATE;
@@ -48,6 +51,9 @@ public class UpdateRespondentDetails implements Task<UserDetails> {
     @Autowired
     private AuthUtil authUtil;
 
+    @Autowired
+    private Clock clock;
+
     @Override
     public UserDetails execute(TaskContext context, UserDetails payload) throws TaskException {
 
@@ -68,7 +74,7 @@ public class UpdateRespondentDetails implements Task<UserDetails> {
             } else {
                 updateFields.put(CO_RESP_EMAIL_ADDRESS, linkedUser.getEmail());
                 updateFields.put(CO_RESP_LINKED_TO_CASE, YES_VALUE);
-                updateFields.put(CO_RESP_LINKED_TO_CASE_DATE, CcdUtil.getCurrentDate());
+                updateFields.put(CO_RESP_LINKED_TO_CASE_DATE, LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
                 eventId = LINK_RESPONDENT_GENERIC_EVENT_ID;
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
@@ -2,10 +2,10 @@ package uk.gov.hmcts.reform.divorce.orchestration.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
@@ -16,21 +16,14 @@ import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.get
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CcdUtil {
 
-    public static String getCurrentDate() {
-        return LocalDate.now().toString(CCD_DATE_FORMAT);
-    }
-
-    public static String getCurrentDatePlusDays(int days) {
-        return LocalDate.now().plusDays(days).toString(CCD_DATE_FORMAT);
-    }
-
     public static String mapCCDDateToDivorceDate(String date) {
-        return LocalDate.parse(date, DateTimeFormat.forPattern(CCD_DATE_FORMAT)).toString(PAYMENT_DATE_PATTERN);
+        return LocalDate.parse(date, DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
+                .format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN));
     }
 
     public static String getFormattedDueDate(Map<String, Object> caseData, String dateToFormat) throws TaskException {
         String dateAsString = getMandatoryPropertyValueAsString(caseData, dateToFormat);
-        java.time.LocalDate dueDate = java.time.LocalDate.parse(dateAsString);
+        LocalDate dueDate = LocalDate.parse(dateAsString);
         return DateUtils.formatDateWithCustomerFacingFormat(dueDate);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
@@ -18,7 +18,7 @@ public class CcdUtil {
 
     public static String mapCCDDateToDivorceDate(String date) {
         return LocalDate.parse(date, DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
-                .format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN));
+            .format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN));
     }
 
     public static String getFormattedDueDate(Map<String, Object> caseData, String dateToFormat) throws TaskException {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
@@ -1,9 +1,10 @@
 package uk.gov.hmcts.reform.divorce.orchestration.util;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
@@ -13,15 +14,26 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getMandatoryPropertyValueAsString;
 
 @SuppressWarnings("squid:S1118")
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Component
 public class CcdUtil {
 
-    public static String mapCCDDateToDivorceDate(String date) {
+    private final Clock clock;
+
+    public String getCurrentDateCcdFormat() {
+        return LocalDate.now(clock).format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT));
+    }
+
+    public String getCurrentDatePaymentFormat() {
+        return LocalDate.now(clock).format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN));
+    }
+
+    public String mapCCDDateToDivorceDate(String date) {
         return LocalDate.parse(date, DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
             .format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN));
     }
 
-    public static String getFormattedDueDate(Map<String, Object> caseData, String dateToFormat) throws TaskException {
+    public String getFormattedDueDate(Map<String, Object> caseData, String dateToFormat) throws TaskException {
         String dateAsString = getMandatoryPropertyValueAsString(caseData, dateToFormat);
         LocalDate dueDate = LocalDate.parse(dateAsString);
         return DateUtils.formatDateWithCustomerFacingFormat(dueDate);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflow.java
@@ -50,6 +50,9 @@ public class SendCoRespondSubmissionNotificationWorkflow extends DefaultWorkflow
     @Autowired
     private final TaskCommons taskCommons;
 
+    @Autowired
+    private final CcdUtil ccdUtil;
+
     public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
 
@@ -71,7 +74,7 @@ public class SendCoRespondSubmissionNotificationWorkflow extends DefaultWorkflow
             try {
                 Court assignedCourt = taskCommons.getCourt(rdcName);
                 templateVars.put(NOTIFICATION_RDC_NAME_KEY, assignedCourt.getIdentifiableCentreName());
-                String formSubmissionDateLimit = CcdUtil.getFormattedDueDate(caseData, CO_RESPONDENT_DUE_DATE);
+                String formSubmissionDateLimit = ccdUtil.getFormattedDueDate(caseData, CO_RESPONDENT_DUE_DATE);
 
                 templateVars.put(NOTIFICATION_FORM_SUBMISSION_DATE_LIMIT_KEY, formSubmissionDateLimit);
                 templateVars.put(NOTIFICATION_COURT_ADDRESS_KEY, assignedCourt.getFormattedAddress());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentAnswerReceivedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentAnswerReceivedITest.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
@@ -19,20 +17,14 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 
-import static java.time.ZoneOffset.UTC;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
@@ -50,19 +42,11 @@ public class CoRespondentAnswerReceivedITest {
 
     private static final String CASE_ID = "case-id";
 
-    private final LocalDateTime today = LocalDateTime.now();
-
     @Autowired
     private MockMvc webClient;
 
-    @MockBean
-    private Clock clock;
-
-    @Before
-    public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
-    }
+    @Autowired
+    private CcdUtil ccdUtil;
 
     @Test
     public void givenEmptyBody_whenPerformAOSReceived_thenReturnBadRequestResponse() throws Exception {
@@ -75,7 +59,7 @@ public class CoRespondentAnswerReceivedITest {
         CcdCallbackResponse ccdCallbackResponse = CcdCallbackResponse
             .builder()
             .data(ImmutableMap.of(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE,
-                CO_RESPONDENT_ANSWER_RECEIVED_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))))
+                CO_RESPONDENT_ANSWER_RECEIVED_DATE, ccdUtil.getCurrentDateCcdFormat()))
             .build();
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentAnswerReceivedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentAnswerReceivedITest.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
@@ -17,14 +19,20 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 
+import static java.time.ZoneOffset.UTC;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
@@ -42,29 +50,40 @@ public class CoRespondentAnswerReceivedITest {
 
     private static final String CASE_ID = "case-id";
 
+    private final LocalDateTime today = LocalDateTime.now();
+
     @Autowired
     private MockMvc webClient;
+
+    @MockBean
+    private Clock clock;
+
+    @Before
+    public void setup() {
+        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
+    }
 
     @Test
     public void givenEmptyBody_whenPerformAOSReceived_thenReturnBadRequestResponse() throws Exception {
         CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().eventId(CASE_ID)
-            .caseDetails(CaseDetails.builder()
-                .caseData(Collections.emptyMap())
-                .build())
-            .build();
+                .caseDetails(CaseDetails.builder()
+                        .caseData(Collections.emptyMap())
+                        .build())
+                .build();
 
         CcdCallbackResponse ccdCallbackResponse = CcdCallbackResponse
-            .builder()
-            .data(ImmutableMap.of(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE,
-                CO_RESPONDENT_ANSWER_RECEIVED_DATE, CcdUtil.getCurrentDate()))
-            .build();
+                .builder()
+                .data(ImmutableMap.of(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE,
+                        CO_RESPONDENT_ANSWER_RECEIVED_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))))
+                .build();
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
 
         webClient.perform(post(API_URL)
-            .header(AUTHORIZATION, USER_TOKEN)
-            .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(expectedResponse));
+                .header(AUTHORIZATION, USER_TOKEN)
+                .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(expectedResponse));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentAnswerReceivedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CoRespondentAnswerReceivedITest.java
@@ -67,23 +67,23 @@ public class CoRespondentAnswerReceivedITest {
     @Test
     public void givenEmptyBody_whenPerformAOSReceived_thenReturnBadRequestResponse() throws Exception {
         CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().eventId(CASE_ID)
-                .caseDetails(CaseDetails.builder()
-                        .caseData(Collections.emptyMap())
-                        .build())
-                .build();
+            .caseDetails(CaseDetails.builder()
+                .caseData(Collections.emptyMap())
+                .build())
+            .build();
 
         CcdCallbackResponse ccdCallbackResponse = CcdCallbackResponse
-                .builder()
-                .data(ImmutableMap.of(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE,
-                        CO_RESPONDENT_ANSWER_RECEIVED_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))))
-                .build();
+            .builder()
+            .data(ImmutableMap.of(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE,
+                CO_RESPONDENT_ANSWER_RECEIVED_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))))
+            .build();
         String expectedResponse = ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackResponse);
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, USER_TOKEN)
-                .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string(expectedResponse));
+            .header(AUTHORIZATION, USER_TOKEN)
+            .content(ObjectMapperTestUtil.convertObjectToJsonString(ccdCallbackRequest))
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(expectedResponse));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/LinkRespondentIdamITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/LinkRespondentIdamITest.java
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
@@ -20,11 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,9 +32,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -62,7 +56,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EMAIL
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_ERROR;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_LETTER_HOLDER_ID_CODE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PIN;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_LETTER_HOLDER_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE;
@@ -117,10 +110,8 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
             .caseData(CASE_DATA_RESPONDENT)
             .build();
 
-    private final LocalDateTime today = LocalDateTime.now();
-
-    @MockBean
-    private Clock clock;
+    @Autowired
+    private CcdUtil ccdUtil;
 
     @Autowired
     private MockMvc webClient;
@@ -134,8 +125,6 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
 
     @Before
     public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
 
         caseDataAos = ImmutableMap.of(
             RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
@@ -146,7 +135,7 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         caseDataCoRespondentUpdate = ImmutableMap.of(
             CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
             CO_RESP_LINKED_TO_CASE, YES_VALUE,
-            CO_RESP_LINKED_TO_CASE_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
+            CO_RESP_LINKED_TO_CASE_DATE, ccdUtil.getCurrentDateCcdFormat()
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/LinkRespondentIdamITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/LinkRespondentIdamITest.java
@@ -86,36 +86,36 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
     private static final String RETRIEVE_CASE_CONTEXT_PATH = "/casemaintenance/version/1/case/" + TEST_CASE_ID;
     private static final String API_URL = "/link-respondent/" + TEST_CASE_ID + "/" + TEST_PIN;
     private static final String LINK_RESPONDENT_CONTEXT_PATH = "/casemaintenance/version/1/link-respondent/"
-            + TEST_CASE_ID + "/" + TEST_LETTER_HOLDER_ID_CODE;
+        + TEST_CASE_ID + "/" + TEST_LETTER_HOLDER_ID_CODE;
     private static final String UNLINK_USER_CONTEXT_PATH = "/casemaintenance/version/1/link-respondent/"
-            + TEST_CASE_ID;
+        + TEST_CASE_ID;
     private static final String UPDATE_CONTEXT_PATH_AOS = String.format(
-            "/casemaintenance/version/1/updateCase/%s/%s",
-            TEST_CASE_ID,
-            START_AOS_EVENT_ID
+        "/casemaintenance/version/1/updateCase/%s/%s",
+        TEST_CASE_ID,
+        START_AOS_EVENT_ID
     );
     private static final String UPDATE_CONTEXT_PATH_NOT_AOS = String.format(
-            "/casemaintenance/version/1/updateCase/%s/%s",
-            TEST_CASE_ID,
-            LINK_RESPONDENT_GENERIC_EVENT_ID
+        "/casemaintenance/version/1/updateCase/%s/%s",
+        TEST_CASE_ID,
+        LINK_RESPONDENT_GENERIC_EVENT_ID
     );
     private static final Map<String, Object> CASE_DATA_RESPONDENT =
-            ImmutableMap.of(
-                    D_8_DIVORCE_UNIT, TEST_COURT,
-                    RESPONDENT_LETTER_HOLDER_ID, TEST_LETTER_HOLDER_ID_CODE
-            );
+        ImmutableMap.of(
+            D_8_DIVORCE_UNIT, TEST_COURT,
+            RESPONDENT_LETTER_HOLDER_ID, TEST_LETTER_HOLDER_ID_CODE
+        );
     private static final CaseDetails CASE_DETAILS_AOS =
-            CaseDetails.builder()
-                    .caseId(TEST_CASE_ID)
-                    .state(AOS_AWAITING_STATE)
-                    .caseData(CASE_DATA_RESPONDENT)
-                    .build();
+        CaseDetails.builder()
+            .caseId(TEST_CASE_ID)
+            .state(AOS_AWAITING_STATE)
+            .caseData(CASE_DATA_RESPONDENT)
+            .build();
     private static final CaseDetails CASE_DETAILS_NO_AOS =
-            CaseDetails.builder()
-                    .caseId(TEST_CASE_ID)
-                    .state(AWAITING_CONSIDERATION_GENERAL_APPLICATION)
-                    .caseData(CASE_DATA_RESPONDENT)
-                    .build();
+        CaseDetails.builder()
+            .caseId(TEST_CASE_ID)
+            .state(AWAITING_CONSIDERATION_GENERAL_APPLICATION)
+            .caseData(CASE_DATA_RESPONDENT)
+            .build();
 
     private final LocalDateTime today = LocalDateTime.now();
 
@@ -138,23 +138,23 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         when(clock.getZone()).thenReturn(UTC);
 
         caseDataAos = ImmutableMap.of(
-                RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
+            RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
         );
         caseDataNonAos = ImmutableMap.of(
-                RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
+            RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
         );
         caseDataCoRespondentUpdate = ImmutableMap.of(
-                CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
-                CO_RESP_LINKED_TO_CASE, YES_VALUE,
-                CO_RESP_LINKED_TO_CASE_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
+            CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
+            CO_RESP_LINKED_TO_CASE, YES_VALUE,
+            CO_RESP_LINKED_TO_CASE_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
         );
     }
 
     @Test
     public void givenAuthTokenIsNull_whenLinkRespondent_thenReturnBadRequest() throws Exception {
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest());
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -162,9 +162,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubPinAuthoriseEndpoint(UNAUTHORIZED, TEST_ERROR);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isUnauthorized());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -173,10 +173,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubTokenExchangeEndpoint(BAD_REQUEST, TEST_CODE, TEST_ERROR);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString(TEST_ERROR)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -186,10 +186,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(BAD_REQUEST, BEARER_AUTH_TOKEN_1, TEST_ERROR);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString(TEST_ERROR)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -199,9 +199,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN_1, null);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isUnauthorized());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -212,9 +212,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubMaintenanceServerEndpointForLinkRespondent(UNAUTHORIZED);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isUnauthorized());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -227,10 +227,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseFromCMS(CASE_DETAILS_AOS);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isUnauthorized())
-                .andExpect(content().string(containsString(TEST_ERROR)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -248,10 +248,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseByIdFromCMS(HttpStatus.OK, convertObjectToJsonString(CASE_DETAILS_AOS));
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString(TEST_ERROR)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -266,9 +266,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubSignInForCaseworker();
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -282,10 +282,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN_1, USER_DETAILS_PIN_USER_JSON);
 
         CaseDetails caseDetailsCoResp = CaseDetails.builder()
-                .caseId(TEST_CASE_ID)
-                .state(AOS_AWAITING_STATE)
-                .caseData(caseData)
-                .build();
+            .caseId(TEST_CASE_ID)
+            .state(AOS_AWAITING_STATE)
+            .caseData(caseData)
+            .build();
         stubRetrieveCaseByIdFromCMS(OK, convertObjectToJsonString(caseDetailsCoResp));
         stubMaintenanceServerEndpointForLinkRespondent(OK);
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN, USER_DETAILS_JSON);
@@ -293,9 +293,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubMaintenanceServerEndpointForUpdateNotAos(OK, coRespondentCaseData, coRespondentCaseData);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -309,9 +309,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseByIdFromCMS(NOT_FOUND, convertObjectToJsonString(""));
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -325,9 +325,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseFromCMS(CASE_DETAILS_AOS);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -342,9 +342,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseByIdFromCMS(OK, convertObjectToJsonString(CASE_DETAILS_NO_AOS));
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -359,40 +359,40 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubMaintenanceServerEndpointForRemoveUser(OK);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(status().is5xxServerError());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+            .andExpect(status().is5xxServerError());
 
         verify(deleteRequestedFor(urlEqualTo(UNLINK_USER_CONTEXT_PATH)));
     }
 
     private void stubMaintenanceServerEndpointForLinkRespondent(HttpStatus status) {
         maintenanceServiceServer.stubFor(post(LINK_RESPONDENT_CONTEXT_PATH)
-                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-                .withHeader(CONTENT_TYPE, new EqualToPattern(APPLICATION_JSON_VALUE))
-                .willReturn(aResponse()
-                        .withStatus(status.value())
-                ));
+            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+            .withHeader(CONTENT_TYPE, new EqualToPattern(APPLICATION_JSON_VALUE))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+            ));
     }
 
     private void stubMaintenanceServerEndpointForUpdateAos(HttpStatus status, String response) {
         maintenanceServiceServer.stubFor(post(UPDATE_CONTEXT_PATH_AOS)
-                .withRequestBody(equalToJson(convertObjectToJsonString(caseDataAos)))
-                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-                .willReturn(aResponse()
-                        .withStatus(status.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(response)));
+            .withRequestBody(equalToJson(convertObjectToJsonString(caseDataAos)))
+            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(response)));
     }
 
     private void stubMaintenanceServerEndpointForUpdateNotAos(HttpStatus status, String request, String response) {
         maintenanceServiceServer.stubFor(post(urlEqualTo(UPDATE_CONTEXT_PATH_NOT_AOS))
-                .withRequestBody(equalToJson(request))
-                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-                .willReturn(aResponse()
-                        .withStatus(status.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(response)));
+            .withRequestBody(equalToJson(request))
+            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(response)));
     }
 
     private void stubMaintenanceServerEndpointForUpdateNotAos(HttpStatus status, String response) {
@@ -401,10 +401,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
 
     private void stubMaintenanceServerEndpointForRemoveUser(HttpStatus status) {
         maintenanceServiceServer.stubFor(delete(urlEqualTo(UNLINK_USER_CONTEXT_PATH))
-                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-                .willReturn(aResponse()
-                        .withStatus(status.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)));
+            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)));
     }
 
     private void stubRetrieveCaseFromCMS(CaseDetails caseDetails) {
@@ -413,17 +413,17 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
 
     private void stubRetrieveCaseFromCMS(HttpStatus status, String message) {
         maintenanceServiceServer.stubFor(get(urlEqualTo(RETRIEVE_AOS_CASE_CONTEXT_PATH))
-                .willReturn(aResponse()
-                        .withStatus(status.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(message)));
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(message)));
     }
 
     private void stubRetrieveCaseByIdFromCMS(HttpStatus status, String message) {
         maintenanceServiceServer.stubFor(get(urlEqualTo(RETRIEVE_CASE_CONTEXT_PATH))
-                .willReturn(aResponse()
-                        .withStatus(status.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(message)));
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(message)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/LinkRespondentIdamITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/LinkRespondentIdamITest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
@@ -19,8 +20,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +36,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -56,6 +62,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EMAIL
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_ERROR;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_LETTER_HOLDER_ID_CODE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PIN;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_LETTER_HOLDER_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE;
@@ -79,36 +86,41 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
     private static final String RETRIEVE_CASE_CONTEXT_PATH = "/casemaintenance/version/1/case/" + TEST_CASE_ID;
     private static final String API_URL = "/link-respondent/" + TEST_CASE_ID + "/" + TEST_PIN;
     private static final String LINK_RESPONDENT_CONTEXT_PATH = "/casemaintenance/version/1/link-respondent/"
-        + TEST_CASE_ID + "/" + TEST_LETTER_HOLDER_ID_CODE;
+            + TEST_CASE_ID + "/" + TEST_LETTER_HOLDER_ID_CODE;
     private static final String UNLINK_USER_CONTEXT_PATH = "/casemaintenance/version/1/link-respondent/"
             + TEST_CASE_ID;
     private static final String UPDATE_CONTEXT_PATH_AOS = String.format(
-        "/casemaintenance/version/1/updateCase/%s/%s",
-        TEST_CASE_ID,
-        START_AOS_EVENT_ID
+            "/casemaintenance/version/1/updateCase/%s/%s",
+            TEST_CASE_ID,
+            START_AOS_EVENT_ID
     );
     private static final String UPDATE_CONTEXT_PATH_NOT_AOS = String.format(
-        "/casemaintenance/version/1/updateCase/%s/%s",
-        TEST_CASE_ID,
-        LINK_RESPONDENT_GENERIC_EVENT_ID
+            "/casemaintenance/version/1/updateCase/%s/%s",
+            TEST_CASE_ID,
+            LINK_RESPONDENT_GENERIC_EVENT_ID
     );
     private static final Map<String, Object> CASE_DATA_RESPONDENT =
-        ImmutableMap.of(
-            D_8_DIVORCE_UNIT, TEST_COURT,
-            RESPONDENT_LETTER_HOLDER_ID, TEST_LETTER_HOLDER_ID_CODE
-        );
+            ImmutableMap.of(
+                    D_8_DIVORCE_UNIT, TEST_COURT,
+                    RESPONDENT_LETTER_HOLDER_ID, TEST_LETTER_HOLDER_ID_CODE
+            );
     private static final CaseDetails CASE_DETAILS_AOS =
-        CaseDetails.builder()
-            .caseId(TEST_CASE_ID)
-            .state(AOS_AWAITING_STATE)
-            .caseData(CASE_DATA_RESPONDENT)
-            .build();
+            CaseDetails.builder()
+                    .caseId(TEST_CASE_ID)
+                    .state(AOS_AWAITING_STATE)
+                    .caseData(CASE_DATA_RESPONDENT)
+                    .build();
     private static final CaseDetails CASE_DETAILS_NO_AOS =
-        CaseDetails.builder()
-            .caseId(TEST_CASE_ID)
-            .state(AWAITING_CONSIDERATION_GENERAL_APPLICATION)
-            .caseData(CASE_DATA_RESPONDENT)
-            .build();
+            CaseDetails.builder()
+                    .caseId(TEST_CASE_ID)
+                    .state(AWAITING_CONSIDERATION_GENERAL_APPLICATION)
+                    .caseData(CASE_DATA_RESPONDENT)
+                    .build();
+
+    private final LocalDateTime today = LocalDateTime.now();
+
+    @MockBean
+    private Clock clock;
 
     @Autowired
     private MockMvc webClient;
@@ -118,28 +130,31 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
 
     private Map<String, Object> caseDataAos;
     private Map<String, Object> caseDataNonAos;
-    private Map<String, Object> caseDataCoResponentUpdate;
+    private Map<String, Object> caseDataCoRespondentUpdate;
 
     @Before
     public void setup() {
+        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
+
         caseDataAos = ImmutableMap.of(
-            RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
+                RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
         );
         caseDataNonAos = ImmutableMap.of(
-            RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
+                RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
         );
-        caseDataCoResponentUpdate = ImmutableMap.of(
-            CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
-            CO_RESP_LINKED_TO_CASE, YES_VALUE,
-            CO_RESP_LINKED_TO_CASE_DATE, CcdUtil.getCurrentDate()
+        caseDataCoRespondentUpdate = ImmutableMap.of(
+                CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
+                CO_RESP_LINKED_TO_CASE, YES_VALUE,
+                CO_RESP_LINKED_TO_CASE_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
         );
     }
 
     @Test
     public void givenAuthTokenIsNull_whenLinkRespondent_thenReturnBadRequest() throws Exception {
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isBadRequest());
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -147,9 +162,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubPinAuthoriseEndpoint(UNAUTHORIZED, TEST_ERROR);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isUnauthorized());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -158,10 +173,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubTokenExchangeEndpoint(BAD_REQUEST, TEST_CODE, TEST_ERROR);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isBadRequest())
-            .andExpect(content().string(containsString(TEST_ERROR)));
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -171,10 +186,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(BAD_REQUEST, BEARER_AUTH_TOKEN_1, TEST_ERROR);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isBadRequest())
-            .andExpect(content().string(containsString(TEST_ERROR)));
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -184,9 +199,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN_1, null);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isUnauthorized());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -197,9 +212,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubMaintenanceServerEndpointForLinkRespondent(UNAUTHORIZED);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isUnauthorized());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -212,10 +227,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseFromCMS(CASE_DETAILS_AOS);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isUnauthorized())
-            .andExpect(content().string(containsString(TEST_ERROR)));
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -233,10 +248,10 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseByIdFromCMS(HttpStatus.OK, convertObjectToJsonString(CASE_DETAILS_AOS));
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isBadRequest())
-            .andExpect(content().string(containsString(TEST_ERROR)));
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString(TEST_ERROR)));
     }
 
     @Test
@@ -251,9 +266,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubSignInForCaseworker();
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -267,20 +282,20 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN_1, USER_DETAILS_PIN_USER_JSON);
 
         CaseDetails caseDetailsCoResp = CaseDetails.builder()
-            .caseId(TEST_CASE_ID)
-            .state(AOS_AWAITING_STATE)
-            .caseData(caseData)
-            .build();
+                .caseId(TEST_CASE_ID)
+                .state(AOS_AWAITING_STATE)
+                .caseData(caseData)
+                .build();
         stubRetrieveCaseByIdFromCMS(OK, convertObjectToJsonString(caseDetailsCoResp));
         stubMaintenanceServerEndpointForLinkRespondent(OK);
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN, USER_DETAILS_JSON);
-        String  coRespondentCaseData = convertObjectToJsonString(caseDataCoResponentUpdate);
+        String coRespondentCaseData = convertObjectToJsonString(caseDataCoRespondentUpdate);
         stubMaintenanceServerEndpointForUpdateNotAos(OK, coRespondentCaseData, coRespondentCaseData);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -290,13 +305,13 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN_1, USER_DETAILS_PIN_USER_JSON);
         stubMaintenanceServerEndpointForLinkRespondent(OK);
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN, USER_DETAILS_JSON);
-        stubMaintenanceServerEndpointForUpdateAos(OK, convertObjectToJsonString(caseDataCoResponentUpdate));
+        stubMaintenanceServerEndpointForUpdateAos(OK, convertObjectToJsonString(caseDataCoRespondentUpdate));
         stubRetrieveCaseByIdFromCMS(NOT_FOUND, convertObjectToJsonString(""));
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isNotFound());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -306,13 +321,13 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN_1, USER_DETAILS_PIN_USER_JSON);
         stubMaintenanceServerEndpointForLinkRespondent(NOT_FOUND);
         stubUserDetailsEndpoint(OK, BEARER_AUTH_TOKEN, USER_DETAILS_JSON);
-        stubMaintenanceServerEndpointForUpdateAos(OK, convertObjectToJsonString(caseDataCoResponentUpdate));
+        stubMaintenanceServerEndpointForUpdateAos(OK, convertObjectToJsonString(caseDataCoRespondentUpdate));
         stubRetrieveCaseFromCMS(CASE_DETAILS_AOS);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isNotFound());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -327,9 +342,9 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
         stubRetrieveCaseByIdFromCMS(OK, convertObjectToJsonString(CASE_DETAILS_NO_AOS));
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
-            .header(AUTHORIZATION, AUTH_TOKEN)
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk());
+                .header(AUTHORIZATION, AUTH_TOKEN)
+                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -353,31 +368,31 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
 
     private void stubMaintenanceServerEndpointForLinkRespondent(HttpStatus status) {
         maintenanceServiceServer.stubFor(post(LINK_RESPONDENT_CONTEXT_PATH)
-            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-            .withHeader(CONTENT_TYPE, new EqualToPattern(APPLICATION_JSON_VALUE))
-            .willReturn(aResponse()
-                .withStatus(status.value())
-            ));
+                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+                .withHeader(CONTENT_TYPE, new EqualToPattern(APPLICATION_JSON_VALUE))
+                .willReturn(aResponse()
+                        .withStatus(status.value())
+                ));
     }
 
     private void stubMaintenanceServerEndpointForUpdateAos(HttpStatus status, String response) {
         maintenanceServiceServer.stubFor(post(UPDATE_CONTEXT_PATH_AOS)
-            .withRequestBody(equalToJson(convertObjectToJsonString(caseDataAos)))
-            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-            .willReturn(aResponse()
-                .withStatus(status.value())
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                .withBody(response)));
+                .withRequestBody(equalToJson(convertObjectToJsonString(caseDataAos)))
+                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+                .willReturn(aResponse()
+                        .withStatus(status.value())
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withBody(response)));
     }
 
-    private void stubMaintenanceServerEndpointForUpdateNotAos(HttpStatus status, String request,  String response) {
+    private void stubMaintenanceServerEndpointForUpdateNotAos(HttpStatus status, String request, String response) {
         maintenanceServiceServer.stubFor(post(urlEqualTo(UPDATE_CONTEXT_PATH_NOT_AOS))
-            .withRequestBody(equalToJson(request))
-            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-            .willReturn(aResponse()
-                .withStatus(status.value())
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                .withBody(response)));
+                .withRequestBody(equalToJson(request))
+                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+                .willReturn(aResponse()
+                        .withStatus(status.value())
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withBody(response)));
     }
 
     private void stubMaintenanceServerEndpointForUpdateNotAos(HttpStatus status, String response) {
@@ -398,17 +413,17 @@ public abstract class LinkRespondentIdamITest extends IdamTestSupport {
 
     private void stubRetrieveCaseFromCMS(HttpStatus status, String message) {
         maintenanceServiceServer.stubFor(get(urlEqualTo(RETRIEVE_AOS_CASE_CONTEXT_PATH))
-            .willReturn(aResponse()
-                .withStatus(status.value())
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                .withBody(message)));
+                .willReturn(aResponse()
+                        .withStatus(status.value())
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withBody(message)));
     }
 
     private void stubRetrieveCaseByIdFromCMS(HttpStatus status, String message) {
         maintenanceServiceServer.stubFor(get(urlEqualTo(RETRIEVE_CASE_CONTEXT_PATH))
-            .willReturn(aResponse()
-                .withStatus(status.value())
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                .withBody(message)));
+                .willReturn(aResponse()
+                        .withStatus(status.value())
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withBody(message)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -12,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -33,9 +31,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.PinRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.validation.ValidationRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.validation.ValidationResponse;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,11 +40,9 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
@@ -105,8 +99,6 @@ public class PetitionIssuedITest extends IdamTestSupport {
 
     private static final Map<String, Object> CASE_DATA = new HashMap<>();
 
-    private final LocalDateTime today = LocalDateTime.now();
-
     private static final CaseDetails CASE_DETAILS = CaseDetails.builder()
         .caseData(CASE_DATA)
         .caseId(TEST_CASE_ID)
@@ -118,9 +110,6 @@ public class PetitionIssuedITest extends IdamTestSupport {
 
     @Autowired
     private MockMvc webClient;
-
-    @MockBean
-    private Clock clock;
 
     @ClassRule
     public static WireMockClassRule validationServiceServer = new WireMockClassRule(4008);
@@ -134,19 +123,13 @@ public class PetitionIssuedITest extends IdamTestSupport {
     @ClassRule
     public static WireMockClassRule formatterServiceServer = new WireMockClassRule(4011);
 
-    @Before
-    public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
-    }
-
     @BeforeClass
     public static void beforeClass() {
         CASE_DATA.put(D_8_PETITIONER_FIRST_NAME, PETITIONER_FIRST_NAME);
         CASE_DATA.put(D_8_PETITIONER_LAST_NAME, PETITIONER_LAST_NAME);
         CASE_DATA.put(RESPONDENT_LETTER_HOLDER_ID, TEST_LETTER_HOLDER_ID_CODE);
         CASE_DATA.put(CO_RESPONDENT_LETTER_HOLDER_ID, TEST_LETTER_HOLDER_ID_CODE);
-        CASE_DATA.put(ISSUE_DATE, LocalDateTime.now().format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        CASE_DATA.put(ISSUE_DATE, LocalDate.now().format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
@@ -108,13 +108,13 @@ public class PetitionIssuedITest extends IdamTestSupport {
     private final LocalDateTime today = LocalDateTime.now();
 
     private static final CaseDetails CASE_DETAILS = CaseDetails.builder()
-            .caseData(CASE_DATA)
-            .caseId(TEST_CASE_ID)
-            .build();
+        .caseData(CASE_DATA)
+        .caseId(TEST_CASE_ID)
+        .build();
 
     private static final CcdCallbackRequest CREATE_EVENT = CcdCallbackRequest.builder()
-            .caseDetails(CASE_DETAILS)
-            .build();
+        .caseDetails(CASE_DETAILS)
+        .build();
 
     @Autowired
     private MockMvc webClient;
@@ -151,206 +151,206 @@ public class PetitionIssuedITest extends IdamTestSupport {
 
     @Test
     public void givenCallbackRequestIsNull_whenPetitionIssued_thenReturnBadRequest()
-            throws Exception {
+        throws Exception {
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     public void givenJWTTokenIsNull_whenPetitionIssued_thenReturnBadRequest()
-            throws Exception {
+        throws Exception {
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(CREATE_EVENT))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .content(convertObjectToJsonString(CREATE_EVENT))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     public void givenThereIsAConnectionError_whenPetitionIssued_thenReturnBadGateway()
-            throws Exception {
+        throws Exception {
         final String errorMessage = "some error message";
 
         stubValidationServerEndpoint(HttpStatus.BAD_GATEWAY,
-                ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(), errorMessage);
+            ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(), errorMessage);
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .content(convertObjectToJsonString(CREATE_EVENT))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().is5xxServerError());
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(CREATE_EVENT))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is5xxServerError());
     }
 
     @Test
     public void givenValidationFailed_whenPetitionIssued_thenReturnCaseWithValidationErrors()
-            throws Exception {
+        throws Exception {
         final List<String> errors = Collections.singletonList(TEST_ERROR);
 
         final ValidationResponse validationResponse =
-                ValidationResponse.builder()
-                        .errors(errors)
-                        .build();
+            ValidationResponse.builder()
+                .errors(errors)
+                .build();
 
         final CcdCallbackResponse ccdCallbackResponse =
-                CcdCallbackResponse.builder()
-                        .errors(errors)
-                        .build();
+            CcdCallbackResponse.builder()
+                .errors(errors)
+                .build();
 
         stubValidationServerEndpoint(HttpStatus.OK,
-                ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
-                convertObjectToJsonString(validationResponse));
+            ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
+            convertObjectToJsonString(validationResponse));
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .content(convertObjectToJsonString(CREATE_EVENT))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(ccdCallbackResponse)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(CREATE_EVENT))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(ccdCallbackResponse)));
     }
 
     @Test
     public void givenGenerateAOSInvitationIsNull_whenPetitionIssued_thenReturnCaseExpectedChanges()
-            throws Exception {
+        throws Exception {
         final ValidationResponse validationResponse = ValidationResponse.builder().build();
 
         final GenerateDocumentRequest generateMiniPetitionRequest =
-                GenerateDocumentRequest.builder()
-                        .template(MINI_PETITION_TEMPLATE_NAME)
-                        .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(MINI_PETITION_TEMPLATE_NAME)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS))
+                .build();
 
         final GeneratedDocumentInfo generatedMiniPetitionResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_PETITION)
-                        .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_PETITION)
+                .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final DocumentUpdateRequest documentUpdateRequest =
-                DocumentUpdateRequest.builder()
-                        .documents(Collections.singletonList(generatedMiniPetitionResponse))
-                        .caseData(CASE_DATA)
-                        .build();
+            DocumentUpdateRequest.builder()
+                .documents(Collections.singletonList(generatedMiniPetitionResponse))
+                .caseData(CASE_DATA)
+                .build();
 
         final Map<String, Object> formattedCaseData = emptyMap();
 
         stubValidationServerEndpoint(HttpStatus.OK,
-                ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
-                convertObjectToJsonString(validationResponse));
+            ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
+            convertObjectToJsonString(validationResponse));
         stubDocumentGeneratorServerEndpoint(generateMiniPetitionRequest, generatedMiniPetitionResponse);
 
         stubFormatterServerEndpoint(documentUpdateRequest, formattedCaseData);
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .content(convertObjectToJsonString(CREATE_EVENT))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(CREATE_EVENT))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
     }
 
     @Test
     public void givenGenerateAOSInvitationIsFalse_whenPetitionIssued_thenReturnCaseExpectedChanges()
-            throws Exception {
+        throws Exception {
         final ValidationResponse validationResponse = ValidationResponse.builder().build();
 
         final GenerateDocumentRequest generateMiniPetitionRequest =
-                GenerateDocumentRequest.builder()
-                        .template(MINI_PETITION_TEMPLATE_NAME)
-                        .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(MINI_PETITION_TEMPLATE_NAME)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS))
+                .build();
 
         final GeneratedDocumentInfo generatedMiniPetitionResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_PETITION)
-                        .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_PETITION)
+                .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final DocumentUpdateRequest documentUpdateRequest =
-                DocumentUpdateRequest.builder()
-                        .documents(Collections.singletonList(generatedMiniPetitionResponse))
-                        .caseData(CASE_DATA)
-                        .build();
+            DocumentUpdateRequest.builder()
+                .documents(Collections.singletonList(generatedMiniPetitionResponse))
+                .caseData(CASE_DATA)
+                .build();
 
         final Map<String, Object> formattedCaseData = emptyMap();
 
         stubValidationServerEndpoint(HttpStatus.OK,
-                ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
-                convertObjectToJsonString(validationResponse));
+            ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
+            convertObjectToJsonString(validationResponse));
         stubDocumentGeneratorServerEndpoint(generateMiniPetitionRequest, generatedMiniPetitionResponse);
 
         stubFormatterServerEndpoint(documentUpdateRequest, formattedCaseData);
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .content(convertObjectToJsonString(CREATE_EVENT))
-                .param(GENERATE_AOS_INVITATION, "false")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(CREATE_EVENT))
+            .param(GENERATE_AOS_INVITATION, "false")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
     }
 
     @Test
     public void givenGenerateInvitationIsTrue_whenPetitionIssued_thenReturnCaseExpectedChanges()
-            throws Exception {
+        throws Exception {
         final ValidationResponse validationResponse = ValidationResponse.builder().build();
 
         final PinRequest pinRequest =
-                PinRequest.builder()
-                        .firstName(PETITIONER_FIRST_NAME)
-                        .lastName(PETITIONER_LAST_NAME)
-                        .build();
+            PinRequest.builder()
+                .firstName(PETITIONER_FIRST_NAME)
+                .lastName(PETITIONER_LAST_NAME)
+                .build();
 
         final Pin pin = Pin.builder().pin(TEST_PIN_CODE).userId(TEST_LETTER_HOLDER_ID_CODE).build();
 
         final GenerateDocumentRequest generateMiniPetitionRequest =
-                GenerateDocumentRequest.builder()
-                        .template(MINI_PETITION_TEMPLATE_NAME)
-                        .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(MINI_PETITION_TEMPLATE_NAME)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS))
+                .build();
 
         final GeneratedDocumentInfo generatedMiniPetitionResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_PETITION)
-                        .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_PETITION)
+                .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final DocumentUpdateRequest documentUpdateRequest =
-                DocumentUpdateRequest.builder()
-                        .documents(asList(generatedMiniPetitionResponse))
-                        .caseData(CASE_DATA)
-                        .build();
+            DocumentUpdateRequest.builder()
+                .documents(asList(generatedMiniPetitionResponse))
+                .caseData(CASE_DATA)
+                .build();
 
         final Map<String, Object> formattedCaseData = emptyMap();
 
         stubSignIn();
         stubPinDetailsEndpoint(BEARER_AUTH_TOKEN_1, pinRequest, pin);
         stubValidationServerEndpoint(HttpStatus.OK,
-                ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
-                convertObjectToJsonString(validationResponse));
+            ValidationRequest.builder().data(CASE_DATA).formId(FORM_ID).build(),
+            convertObjectToJsonString(validationResponse));
         stubDocumentGeneratorServerEndpoint(generateMiniPetitionRequest, generatedMiniPetitionResponse);
 
         stubFormatterServerEndpoint(documentUpdateRequest, formattedCaseData);
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .content(convertObjectToJsonString(CREATE_EVENT))
-                .param(GENERATE_AOS_INVITATION, "true")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(CREATE_EVENT))
+            .param(GENERATE_AOS_INVITATION, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
     }
 
     @Test
     public void givenGenerateInvitationIsTrueAndIsServiceCentre_whenPetitionIssued_thenReturnCaseExpectedChanges()
-            throws Exception {
+        throws Exception {
 
         CcdCallbackRequest ccdCallbackRequestWithServiceCentre = CREATE_EVENT;
         ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData().put(D_8_DIVORCE_UNIT, DIVORCE_UNIT_SERVICE_CENTRE);
@@ -358,54 +358,54 @@ public class PetitionIssuedITest extends IdamTestSupport {
         final ValidationResponse validationResponse = ValidationResponse.builder().build();
 
         final PinRequest pinRequest =
-                PinRequest.builder()
-                        .firstName(PETITIONER_FIRST_NAME)
-                        .lastName(PETITIONER_LAST_NAME)
-                        .build();
+            PinRequest.builder()
+                .firstName(PETITIONER_FIRST_NAME)
+                .lastName(PETITIONER_LAST_NAME)
+                .build();
 
         final Pin pin = Pin.builder().pin(TEST_PIN_CODE).userId(TEST_LETTER_HOLDER_ID_CODE).build();
 
         final GenerateDocumentRequest generateMiniPetitionRequest =
-                GenerateDocumentRequest.builder()
-                        .template(MINI_PETITION_TEMPLATE_NAME)
-                        .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
-                                ccdCallbackRequestWithServiceCentre.getCaseDetails()))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(MINI_PETITION_TEMPLATE_NAME)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
+                    ccdCallbackRequestWithServiceCentre.getCaseDetails()))
+                .build();
 
         final GeneratedDocumentInfo generatedMiniPetitionResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_PETITION)
-                        .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_PETITION)
+                .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final GenerateDocumentRequest generateAosInvitationRequest =
-                GenerateDocumentRequest.builder()
-                        .template(RESPONDENT_INVITATION_TEMPLATE_NAME)
-                        .values(ImmutableMap.of(
-                                DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
-                                ACCESS_CODE, TEST_PIN_CODE))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(RESPONDENT_INVITATION_TEMPLATE_NAME)
+                .values(ImmutableMap.of(
+                    DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
+                    ACCESS_CODE, TEST_PIN_CODE))
+                .build();
 
         final GeneratedDocumentInfo generatedAosInvitationResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_RESPONDENT_INVITATION)
-                        .fileName(String.format(RESPONDENT_INVITATION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_RESPONDENT_INVITATION)
+                .fileName(String.format(RESPONDENT_INVITATION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final DocumentUpdateRequest documentUpdateRequest =
-                DocumentUpdateRequest.builder()
-                        .documents(asList(generatedMiniPetitionResponse, generatedAosInvitationResponse))
-                        .caseData(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
-                        .build();
+            DocumentUpdateRequest.builder()
+                .documents(asList(generatedMiniPetitionResponse, generatedAosInvitationResponse))
+                .caseData(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
+                .build();
 
         final Map<String, Object> formattedCaseData = emptyMap();
 
         stubSignIn();
         stubPinDetailsEndpoint(BEARER_AUTH_TOKEN_1, pinRequest, pin);
         stubValidationServerEndpoint(HttpStatus.OK,
-                ValidationRequest.builder().data(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
-                        .formId(FORM_ID).build(),
-                convertObjectToJsonString(validationResponse));
+            ValidationRequest.builder().data(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
+                .formId(FORM_ID).build(),
+            convertObjectToJsonString(validationResponse));
         stubDocumentGeneratorServerEndpoint(generateMiniPetitionRequest, generatedMiniPetitionResponse);
         stubDocumentGeneratorServerEndpoint(generateAosInvitationRequest, generatedAosInvitationResponse);
 
@@ -413,18 +413,18 @@ public class PetitionIssuedITest extends IdamTestSupport {
         stubFormatterServerEndpoint(documentUpdateRequest, formattedCaseData);
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .content(convertObjectToJsonString(ccdCallbackRequestWithServiceCentre))
-                .param(GENERATE_AOS_INVITATION, "true")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(ccdCallbackRequestWithServiceCentre))
+            .param(GENERATE_AOS_INVITATION, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
     }
 
     @Test
     public void givenGenerateInvitationIsTrueAndIsServiceCentreAndCoRespondentExists_whenPetitionIssued_thenReturnCaseExpectedChanges()
-            throws Exception {
+        throws Exception {
 
         CcdCallbackRequest ccdCallbackRequestWithServiceCentre = CREATE_EVENT;
         ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData().put(D_8_DIVORCE_UNIT, DIVORCE_UNIT_SERVICE_CENTRE);
@@ -434,63 +434,63 @@ public class PetitionIssuedITest extends IdamTestSupport {
         final ValidationResponse validationResponse = ValidationResponse.builder().build();
 
         final PinRequest pinRequest =
-                PinRequest.builder()
-                        .firstName(PETITIONER_FIRST_NAME)
-                        .lastName(PETITIONER_LAST_NAME)
-                        .build();
+            PinRequest.builder()
+                .firstName(PETITIONER_FIRST_NAME)
+                .lastName(PETITIONER_LAST_NAME)
+                .build();
 
         final Pin pin = Pin.builder().pin(TEST_PIN_CODE).userId(TEST_LETTER_HOLDER_ID_CODE).build();
 
         final GenerateDocumentRequest generateMiniPetitionRequest =
-                GenerateDocumentRequest.builder()
-                        .template(MINI_PETITION_TEMPLATE_NAME)
-                        .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
-                                ccdCallbackRequestWithServiceCentre.getCaseDetails()))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(MINI_PETITION_TEMPLATE_NAME)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
+                    ccdCallbackRequestWithServiceCentre.getCaseDetails()))
+                .build();
 
         final GeneratedDocumentInfo generatedMiniPetitionResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_PETITION)
-                        .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_PETITION)
+                .fileName(String.format(MINI_PETITION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final GenerateDocumentRequest generateAosInvitationRequest =
-                GenerateDocumentRequest.builder()
-                        .template(RESPONDENT_INVITATION_TEMPLATE_NAME)
-                        .values(ImmutableMap.of(
-                                DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
-                                ACCESS_CODE, TEST_PIN_CODE))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(RESPONDENT_INVITATION_TEMPLATE_NAME)
+                .values(ImmutableMap.of(
+                    DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
+                    ACCESS_CODE, TEST_PIN_CODE))
+                .build();
 
         final GeneratedDocumentInfo generatedAosInvitationResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_RESPONDENT_INVITATION)
-                        .fileName(String.format(RESPONDENT_INVITATION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_RESPONDENT_INVITATION)
+                .fileName(String.format(RESPONDENT_INVITATION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final GenerateDocumentRequest generateCoRespondentInvitationRequest =
-                GenerateDocumentRequest.builder()
-                        .template(CO_RESPONDENT_INVITATION_TEMPLATE_NAME)
-                        .values(ImmutableMap.of(
-                                DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
-                                ACCESS_CODE, TEST_PIN_CODE,
-                                PETITION_ISSUE_FEE_FOR_LETTER, "550"))
-                        .build();
+            GenerateDocumentRequest.builder()
+                .template(CO_RESPONDENT_INVITATION_TEMPLATE_NAME)
+                .values(ImmutableMap.of(
+                    DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequestWithServiceCentre.getCaseDetails(),
+                    ACCESS_CODE, TEST_PIN_CODE,
+                    PETITION_ISSUE_FEE_FOR_LETTER, "550"))
+                .build();
 
         final GeneratedDocumentInfo generatedCoRespondentInvitationResponse =
-                GeneratedDocumentInfo.builder()
-                        .documentType(DOCUMENT_TYPE_CO_RESPONDENT_INVITATION)
-                        .fileName(String.format(CO_RESPONDENT_INVITATION_FILE_NAME_FORMAT, TEST_CASE_ID))
-                        .build();
+            GeneratedDocumentInfo.builder()
+                .documentType(DOCUMENT_TYPE_CO_RESPONDENT_INVITATION)
+                .fileName(String.format(CO_RESPONDENT_INVITATION_FILE_NAME_FORMAT, TEST_CASE_ID))
+                .build();
 
         final Map<String, Object> formattedCaseData = emptyMap();
 
         stubSignIn();
         stubPinDetailsEndpoint(BEARER_AUTH_TOKEN_1, pinRequest, pin);
         stubValidationServerEndpoint(HttpStatus.OK,
-                ValidationRequest.builder().data(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
-                        .formId(FORM_ID).build(),
-                convertObjectToJsonString(validationResponse));
+            ValidationRequest.builder().data(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
+                .formId(FORM_ID).build(),
+            convertObjectToJsonString(validationResponse));
         stubDocumentGeneratorServerEndpoint(generateMiniPetitionRequest, generatedMiniPetitionResponse);
         stubDocumentGeneratorServerEndpoint(generateAosInvitationRequest, generatedAosInvitationResponse);
 
@@ -501,59 +501,59 @@ public class PetitionIssuedITest extends IdamTestSupport {
         stubDocumentGeneratorServerEndpoint(generateCoRespondentInvitationRequest, generatedCoRespondentInvitationResponse);
 
         final DocumentUpdateRequest documentUpdateRequest =
-                DocumentUpdateRequest.builder()
-                        .documents(asList(generatedMiniPetitionResponse, generatedAosInvitationResponse, generatedCoRespondentInvitationResponse))
-                        .caseData(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
-                        .build();
+            DocumentUpdateRequest.builder()
+                .documents(asList(generatedMiniPetitionResponse, generatedAosInvitationResponse, generatedCoRespondentInvitationResponse))
+                .caseData(ccdCallbackRequestWithServiceCentre.getCaseDetails().getCaseData())
+                .build();
 
         stubFormatterServerEndpoint(documentUpdateRequest, formattedCaseData);
 
         webClient.perform(post(API_URL)
-                .header(AUTHORIZATION, AUTH_TOKEN)
-                .content(convertObjectToJsonString(ccdCallbackRequestWithServiceCentre))
-                .param(GENERATE_AOS_INVITATION, "true")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(ccdCallbackRequestWithServiceCentre))
+            .param(GENERATE_AOS_INVITATION, "true")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(formattedCaseData)));
     }
 
     private void stubValidationServerEndpoint(HttpStatus status,
                                               ValidationRequest validationRequest, String body) {
         validationServiceServer.stubFor(WireMock.post(VALIDATION_CONTEXT_PATH)
-                .withRequestBody(equalToJson(convertObjectToJsonString(validationRequest)))
-                .willReturn(aResponse()
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withStatus(status.value())
-                        .withBody(body)));
+            .withRequestBody(equalToJson(convertObjectToJsonString(validationRequest)))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withStatus(status.value())
+                .withBody(body)));
     }
 
     private void stubDocumentGeneratorServerEndpoint(GenerateDocumentRequest generateDocumentRequest,
                                                      GeneratedDocumentInfo response) {
         documentGeneratorServiceServer.stubFor(WireMock.post(GENERATE_DOCUMENT_CONTEXT_PATH)
-                .withRequestBody(equalToJson(convertObjectToJsonString(generateDocumentRequest)))
-                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-                .willReturn(aResponse()
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withStatus(HttpStatus.OK.value())
-                        .withBody(convertObjectToJsonString(response))));
+            .withRequestBody(equalToJson(convertObjectToJsonString(generateDocumentRequest)))
+            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withStatus(HttpStatus.OK.value())
+                .withBody(convertObjectToJsonString(response))));
     }
 
     private void stubFormatterServerEndpoint(DocumentUpdateRequest documentUpdateRequest,
                                              Map<String, Object> response) {
         formatterServiceServer.stubFor(WireMock.post(ADD_DOCUMENTS_CONTEXT_PATH)
-                .withRequestBody(equalToJson(convertObjectToJsonString(documentUpdateRequest)))
-                .willReturn(aResponse()
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withStatus(HttpStatus.OK.value())
-                        .withBody(convertObjectToJsonString(response))));
+            .withRequestBody(equalToJson(convertObjectToJsonString(documentUpdateRequest)))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withStatus(HttpStatus.OK.value())
+                .withBody(convertObjectToJsonString(response))));
     }
 
     private void stubGetFeeFromFeesAndPayments(HttpStatus status, FeeResponse feeResponse) {
         feesAndPaymentsServer.stubFor(WireMock.get(PETITION_ISSUE_FEE_CONTEXT_PATH)
-                .willReturn(aResponse()
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withStatus(status.value())
-                        .withBody(convertObjectToJsonString(feeResponse))));
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withStatus(status.value())
+                .withBody(convertObjectToJsonString(feeResponse))));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrieveDraftITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrieveDraftITest.java
@@ -5,13 +5,14 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.google.common.collect.Maps;
-import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,10 @@ import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.testutil.ResourceLoader;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +36,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
@@ -54,22 +61,27 @@ public class RetrieveDraftITest {
     private static final String CMS_UPDATE_CASE_PATH =
         "/casemaintenance/version/1/updateCase/1547073120300616/paymentMade";
     private static final String CFS_CONTEXT_PATH = "/caseformatter/version/1/to-divorce-format";
-    private static final String CFS_TO_CCD_CONTEXT_PATH =  "/caseformatter/version/1/to-ccd-format";
+    private static final String CFS_TO_CCD_CONTEXT_PATH = "/caseformatter/version/1/to-ccd-format";
     private static final String AUTH_SERVICE_PATH = "/lease";
 
     private static final String CARD_PAYMENT_PATH = "/card-payments/RC-1547-0733-1813-9545";
     private static final String USER_TOKEN = "Some JWT Token";
     private static final String CASE_ID = "12345";
 
+    private final LocalDateTime today = LocalDateTime.now();
+
     private static final Map<String, Object> CASE_DATA = new HashMap<>();
     private static final CaseDetails CASE_DETAILS = CaseDetails.builder()
-            .caseData(CASE_DATA)
-            .caseId(CASE_ID)
-            .build();
+        .caseData(CASE_DATA)
+        .caseId(CASE_ID)
+        .build();
 
 
     @Autowired
     private MockMvc webClient;
+
+    @MockBean
+    private Clock clock;
 
     @ClassRule
     public static WireMockClassRule cmsServiceServer = new WireMockClassRule(4010);
@@ -83,45 +95,50 @@ public class RetrieveDraftITest {
     @ClassRule
     public static WireMockClassRule authServiceServer = new WireMockClassRule(4504);
 
+    @Before
+    public void setup() {
+        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
+    }
 
     @Test
     public void givenJWTTokenIsNull_whenRetrieveDraft_thenReturnBadRequest()
-            throws Exception {
+        throws Exception {
         webClient.perform(get(API_URL)
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     public void givenThereIsAConnectionError_whenRetrieveDraft_thenReturnBadGateway()
-            throws Exception {
+        throws Exception {
         final String errorMessage = "some error message";
 
         stubCmsServerEndpoint(CMS_CONTEXT_PATH, HttpStatus.BAD_GATEWAY, errorMessage, HttpMethod.GET);
 
         webClient.perform(get(API_URL)
-                .header(AUTHORIZATION, USER_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadGateway())
-                .andExpect(content().string(containsString(errorMessage)));
+            .header(AUTHORIZATION, USER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadGateway())
+            .andExpect(content().string(containsString(errorMessage)));
     }
 
     @Test
     public void givenNoDraftInDraftStore_whenRetrieveDraft_thenReturnNotFound()
-            throws Exception {
+        throws Exception {
 
         stubCmsServerEndpoint(CMS_CONTEXT_PATH, HttpStatus.OK, convertObjectToJsonString(CASE_DETAILS), HttpMethod.GET);
 
         webClient.perform(get(API_URL)
-                .header(AUTHORIZATION, USER_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(content().string(""));
+            .header(AUTHORIZATION, USER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(content().string(""));
     }
 
     @Test
     public void givenEverythingWorksAsExpected_whenCmsCalled_thenReturnDraft()
-            throws Exception {
+        throws Exception {
 
         CASE_DATA.put("deaftProperty1", "value1");
         CASE_DATA.put("deaftProperty2", "value2");
@@ -136,10 +153,10 @@ public class RetrieveDraftITest {
         expectedResponse.put("fetchedDraft", true);
 
         webClient.perform(get(API_URL)
-                .header(AUTHORIZATION, USER_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(expectedResponse)));
+            .header(AUTHORIZATION, USER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(expectedResponse)));
     }
 
     @Test
@@ -154,27 +171,27 @@ public class RetrieveDraftITest {
         Map<String, Object> expectedResponse = Maps.newHashMap(CASE_DATA);
 
         webClient.perform(get(API_URL)
-                .header(AUTHORIZATION, USER_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(expectedResponse)));
+            .header(AUTHORIZATION, USER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(expectedResponse)));
     }
 
     @Test
     public void givenPaidCaseAwaitingPaymentInState_whenCmsCalled_thenReturnUpdateCase() throws Exception {
         String caseDetailsPath = "jsonExamples/payloads/paymentPendingDraft.json";
-        String caseDetails =  ResourceLoader.loadResourceAsString(caseDetailsPath);
+        String caseDetails = ResourceLoader.loadResourceAsString(caseDetailsPath);
 
         stubCmsServerEndpoint(CMS_CONTEXT_PATH, HttpStatus.OK, caseDetails, HttpMethod.GET);
         stubCfsServerEndpoint(caseDetails);
         stubAuthServerEndpoint();
 
         String paymentPath = "jsonExamples/payloads/paymentSystemPaid.json";
-        String paymentResponse =  ResourceLoader.loadResourceAsString(paymentPath);
+        String paymentResponse = ResourceLoader.loadResourceAsString(paymentPath);
         stubPaymentServerEndpoint(paymentResponse);
 
         String formattedPaymentPath = "jsonExamples/payloads/formattedPayment.json";
-        String formattedPayment =  ResourceLoader.loadResourceAsString(formattedPaymentPath);
+        String formattedPayment = ResourceLoader.loadResourceAsString(formattedPaymentPath);
         stubCfsToCCDServerEndpoint(formattedPayment);
         stubCmsServerEndpoint(CMS_UPDATE_CASE_PATH, HttpStatus.OK, caseDetails, HttpMethod.POST);
 
@@ -191,19 +208,19 @@ public class RetrieveDraftITest {
     }
 
     private void stubCmsServerEndpoint(String path, HttpStatus status, String body, HttpMethod method) {
-        cmsServiceServer.stubFor(WireMock.request(method.name(),urlEqualTo(path))
-                .willReturn(aResponse()
-                        .withStatus(status.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(body)));
+        cmsServiceServer.stubFor(WireMock.request(method.name(), urlEqualTo(path))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(body)));
     }
 
     private void stubCfsServerEndpoint(String body) {
         cfsServiceServer.stubFor(WireMock.post(CFS_CONTEXT_PATH)
-                .willReturn(aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                        .withBody(body)));
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.OK.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(body)));
     }
 
     private void stubCfsToCCDServerEndpoint(String body) {
@@ -218,7 +235,7 @@ public class RetrieveDraftITest {
     private void stubAuthServerEndpoint() {
         Algorithm algorithm = mock(Algorithm.class);
         String body = JWT.create()
-            .withExpiresAt(DateTime.now().plusHours(1).toDate()).sign(algorithm);
+            .withExpiresAt(Date.from(clock.instant())).sign(algorithm);
         authServiceServer.stubFor(WireMock.post(AUTH_SERVICE_PATH)
             .willReturn(aResponse()
                 .withStatus(HttpStatus.OK.value())

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
@@ -1,12 +1,11 @@
 package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
@@ -18,23 +17,17 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.time.ZoneOffset.UTC;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_CENTRE_SITEID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
@@ -61,24 +54,16 @@ public class SolicitorCreateITest {
         .caseDetails(CASE_DETAILS)
         .build();
 
-    private final LocalDateTime today = LocalDateTime.now();
-
-    @MockBean
-    private Clock clock;
+    @Autowired
+    private CcdUtil ccdUtil;
 
     @Autowired
     private MockMvc webClient;
 
-    @Before
-    public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
-    }
-
     @Test
     public void givenCaseData_whenSolicitorCreate_thenReturnEastMidlandsCourtAllocation() throws Exception {
         Map<String, Object> expectedData = new HashMap<>();
-        expectedData.put(CREATED_DATE_JSON_KEY, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        expectedData.put(CREATED_DATE_JSON_KEY, ccdUtil.getCurrentDateCcdFormat());
         expectedData.put(DIVORCE_UNIT_JSON_KEY, CourtEnum.EASTMIDLANDS.getId());
         expectedData.put(DIVORCE_CENTRE_SITEID_JSON_KEY, CourtEnum.EASTMIDLANDS.getSiteId());
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
@@ -51,15 +51,15 @@ public class SolicitorCreateITest {
 
     private static final Map<String, Object> CASE_DATA = Collections.emptyMap();
     private static final CaseDetails CASE_DETAILS =
-            CaseDetails.builder()
-                    .caseData(CASE_DATA)
-                    .caseId(TEST_CASE_ID)
-                    .state(TEST_STATE)
-                    .build();
+        CaseDetails.builder()
+            .caseData(CASE_DATA)
+            .caseId(TEST_CASE_ID)
+            .state(TEST_STATE)
+            .build();
 
     private static final CcdCallbackRequest CREATE_EVENT = CcdCallbackRequest.builder()
-            .caseDetails(CASE_DETAILS)
-            .build();
+        .caseDetails(CASE_DETAILS)
+        .build();
 
     private final LocalDateTime today = LocalDateTime.now();
 
@@ -83,14 +83,14 @@ public class SolicitorCreateITest {
         expectedData.put(DIVORCE_CENTRE_SITEID_JSON_KEY, CourtEnum.EASTMIDLANDS.getSiteId());
 
         CcdCallbackResponse expected = CcdCallbackResponse.builder()
-                .data(expectedData)
-                .build();
+            .data(expectedData)
+            .build();
 
         webClient.perform(post(API_URL)
-                .content(convertObjectToJsonString(CREATE_EVENT))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(convertObjectToJsonString(expected)));
+            .content(convertObjectToJsonString(CREATE_EVENT))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(expected)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateITest.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
@@ -16,17 +18,23 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_CENTRE_SITEID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
@@ -53,13 +61,24 @@ public class SolicitorCreateITest {
             .caseDetails(CASE_DETAILS)
             .build();
 
+    private final LocalDateTime today = LocalDateTime.now();
+
+    @MockBean
+    private Clock clock;
+
     @Autowired
     private MockMvc webClient;
+
+    @Before
+    public void setup() {
+        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
+    }
 
     @Test
     public void givenCaseData_whenSolicitorCreate_thenReturnEastMidlandsCourtAllocation() throws Exception {
         Map<String, Object> expectedData = new HashMap<>();
-        expectedData.put(CREATED_DATE_JSON_KEY, CcdUtil.getCurrentDate());
+        expectedData.put(CREATED_DATE_JSON_KEY, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
         expectedData.put(DIVORCE_UNIT_JSON_KEY, CourtEnum.EASTMIDLANDS.getId());
         expectedData.put(DIVORCE_CENTRE_SITEID_JSON_KEY, CourtEnum.EASTMIDLANDS.getSiteId());
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitRespondentAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitRespondentAosCaseITest.java
@@ -77,8 +77,8 @@ public class SubmitRespondentAosCaseITest {
     private static final String FORMAT_TO_AOS_CASE_CONTEXT_PATH = "/caseformatter/version/1/to-aos-submit-format";
     private static final String UPDATE_CONTEXT_PATH = "/casemaintenance/version/1/updateCase/" + TEST_CASE_ID + "/";
     private static final String RETRIEVE_CASE_CONTEXT_PATH = String.format(
-            "/casemaintenance/version/1/case/%s",
-            TEST_CASE_ID
+        "/casemaintenance/version/1/case/%s",
+        TEST_CASE_ID
     );
 
     @Autowired

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfoUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfoUTest.java
@@ -15,23 +15,20 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.Court;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.io.IOException;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SERVICE_AUTH_TOKEN;
@@ -51,7 +48,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_CHANNEL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_CHANNEL_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_DATE_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_DATE_PATTERN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_FEE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_FEE_ID_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PAYMENT_REFERENCE_KEY;
@@ -74,7 +70,6 @@ public class GetInconsistentPaymentInfoUTest {
     private static final String PAYMENT_ID = "1";
     private static final String PAYLOADS_PAYMENT_FROM_CMS_JSON = "/jsonExamples/payloads/paymentFromCMS.json";
     private static final String PAYLOADS_PAYMENT_FROM_PAYMENT_JSON = "/jsonExamples/payloads/paymentSystemPaid.json";
-    private final LocalDateTime today = LocalDateTime.now();
 
     @InjectMocks
     private GetInconsistentPaymentInfo target;
@@ -88,14 +83,15 @@ public class GetInconsistentPaymentInfoUTest {
     @Mock
     private Court courtInfo;
     @Mock
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     private TaskContext context;
 
     @Before
     public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
+        when(ccdUtil.getCurrentDatePaymentFormat()).thenReturn(PAYMENT_DATE);
+        when(ccdUtil.mapCCDDateToDivorceDate(notNull())).thenReturn(PAYMENT_DATE);
+
         context = new DefaultTaskContext();
         context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
         context.setTransientObject(CASE_STATE_JSON_KEY, TEST_STATE);
@@ -125,7 +121,7 @@ public class GetInconsistentPaymentInfoUTest {
             .thenReturn(getPaymentSystemResponse());
         TaskContext taskContext = createTaskContext(TEST_CASE_ID, AWAITING_PAYMENT);
 
-        validateResponse(getExpectedPayment(today.format(DateTimeFormatter.ofPattern(PAYMENT_DATE_PATTERN))),
+        validateResponse(getExpectedPayment(PAYMENT_DATE),
             target.execute(taskContext, testObjectData));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentSubmissionNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentSubmissionNotificationEmailTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackReq
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.Court;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -29,6 +30,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.spy;
@@ -44,12 +46,16 @@ import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTes
 public class SendRespondentSubmissionNotificationEmailTest {
 
     private static final String FORMATTED_CASE_ID = "LV17D80101";
+    private static final String FORM_SUBMISSION_DUE_DATE = "20 September 2018";
 
     @Rule
     public ExpectedException expectedException = none();
 
     @Mock
     private TaskCommons taskCommons;
+
+    @Mock
+    private CcdUtil ccdUtil;
 
     @Captor
     private ArgumentCaptor<Map<String, String>> templateParametersCaptor;
@@ -64,6 +70,7 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
     @Before
     public void setUp() throws TaskException {
+        when(ccdUtil.getFormattedDueDate(any(), any())).thenReturn(FORM_SUBMISSION_DUE_DATE);
         testCourt = new Court();
         testCourt.setDivorceCentreName("West Midlands Regional Divorce Centre");
         testCourt.setPoBox("PO Box 3650");
@@ -76,9 +83,9 @@ public class SendRespondentSubmissionNotificationEmailTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testRightEmailIsSent_WhenRespondentChoosesToDefendDivorce()
-            throws TaskException, IOException {
+        throws TaskException, IOException {
         CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CcdCallbackRequest.class);
+            "/jsonExamples/payloads/respondentAcknowledgesServiceDefendingDivorce.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = spy(incomingPayload.getCaseDetails().getCaseData());
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();
@@ -88,19 +95,19 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
         assertThat(caseData, is(sameInstance(returnedPayload)));
         verify(taskCommons).sendEmail(eq(RESPONDENT_DEFENDED_AOS_SUBMISSION_NOTIFICATION),
-                eq("respondent submission notification email - defended divorce"),
-                eq("respondent@divorce.co.uk"),
-                templateParametersCaptor.capture());
+            eq("respondent submission notification email - defended divorce"),
+            eq("respondent@divorce.co.uk"),
+            templateParametersCaptor.capture());
         Map<String, String> templateParameters = templateParametersCaptor.getValue();
         assertThat(templateParameters, hasEntry("case number", FORMATTED_CASE_ID));
         assertThat(templateParameters, allOf(
-                hasEntry("email address", "respondent@divorce.co.uk"),
-                hasEntry("first name", "Ted"),
-                hasEntry("last name", "Jones"),
-                hasEntry("husband or wife", "wife"),
-                hasEntry("RDC name", testCourt.getIdentifiableCentreName()),
-                hasEntry("court address", testCourt.getFormattedAddress()),
-                hasEntry("form submission date limit", "20 September 2018")
+            hasEntry("email address", "respondent@divorce.co.uk"),
+            hasEntry("first name", "Ted"),
+            hasEntry("last name", "Jones"),
+            hasEntry("husband or wife", "wife"),
+            hasEntry("RDC name", testCourt.getIdentifiableCentreName()),
+            hasEntry("court address", testCourt.getFormattedAddress()),
+            hasEntry("form submission date limit", FORM_SUBMISSION_DUE_DATE)
         ));
         assertThat(templateParameters.size(), equalTo(8));
         checkThatPropertiesAreCheckedBeforeBeingRetrieved(caseData);
@@ -108,15 +115,15 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
     @Test
     public void testExceptionIsThrown_WhenCaseIdIsMissing_ForDefendedDivorce()
-            throws IOException, TaskException {
+        throws IOException, TaskException {
         expectedException.expect(TaskException.class);
         expectedException.expectMessage("Could not evaluate value of mandatory property \"D8caseReference\"");
 
         CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json", CcdCallbackRequest.class);
+            "/jsonExamples/payloads/defendedDivorceAOSMissingCaseId.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = incomingPayload.getCaseDetails().getCaseData();
         String caseId = (String) incomingPayload.getCaseDetails().getCaseData()
-                .get(D_8_CASE_REFERENCE);
+            .get(D_8_CASE_REFERENCE);
         DefaultTaskContext context = new DefaultTaskContext();
         context.setTransientObject(D_8_CASE_REFERENCE, caseId);
 
@@ -125,14 +132,14 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
     @Test
     public void testExceptionIsThrown_WhenMandatoryFieldIsMissing_ForDefendedDivorce()
-            throws IOException, TaskException {
+        throws IOException, TaskException {
         expectedException.expect(TaskException.class);
         expectedException.expectMessage(
-                "Could not evaluate value of mandatory property \"D8InferredPetitionerGender\""
+            "Could not evaluate value of mandatory property \"D8InferredPetitionerGender\""
         );
 
         CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/defendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
+            "/jsonExamples/payloads/defendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = incomingPayload.getCaseDetails().getCaseData();
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();
@@ -143,9 +150,9 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
     @Test
     public void testRightEmailIsSent_WhenRespondentChoosesNotToDefendDivorce()
-            throws TaskException, IOException {
+        throws TaskException, IOException {
         CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CcdCallbackRequest.class);
+            "/jsonExamples/payloads/respondentAcknowledgesServiceNotDefendingDivorce.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = spy(incomingPayload.getCaseDetails().getCaseData());
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();
@@ -155,17 +162,17 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
         assertThat(caseData, is(sameInstance(returnedPayload)));
         verify(taskCommons).sendEmail(eq(RESPONDENT_UNDEFENDED_AOS_SUBMISSION_NOTIFICATION),
-                eq("respondent submission notification email - undefended divorce"),
-                eq("respondent@divorce.co.uk"),
-                templateParametersCaptor.capture());
+            eq("respondent submission notification email - undefended divorce"),
+            eq("respondent@divorce.co.uk"),
+            templateParametersCaptor.capture());
         Map<String, String> templateParameters = templateParametersCaptor.getValue();
         assertThat(templateParameters, hasEntry("case number", FORMATTED_CASE_ID));
         assertThat(templateParameters, allOf(
-                hasEntry("email address", "respondent@divorce.co.uk"),
-                hasEntry("first name", "Sarah"),
-                hasEntry("last name", "Jones"),
-                hasEntry("husband or wife", "husband"),
-                hasEntry("RDC name", testCourt.getIdentifiableCentreName())
+            hasEntry("email address", "respondent@divorce.co.uk"),
+            hasEntry("first name", "Sarah"),
+            hasEntry("last name", "Jones"),
+            hasEntry("husband or wife", "husband"),
+            hasEntry("RDC name", testCourt.getIdentifiableCentreName())
         ));
         assertThat(templateParameters.size(), equalTo(6));
         checkThatPropertiesAreCheckedBeforeBeingRetrieved(caseData);
@@ -173,12 +180,12 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
     @Test
     public void testExceptionIsThrown_WhenMandatoryFieldIsMissing_ForUndefendedDivorce()
-            throws IOException, TaskException {
+        throws IOException, TaskException {
         expectedException.expect(TaskException.class);
         expectedException.expectMessage("Could not evaluate value of mandatory property \"D8DivorceUnit\"");
 
         CcdCallbackRequest incomingPayload = getJsonFromResourceFile(
-                "/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
+            "/jsonExamples/payloads/undefendedDivorceAOSMissingFields.json", CcdCallbackRequest.class);
         Map<String, Object> caseData = incomingPayload.getCaseDetails().getCaseData();
         String caseId = incomingPayload.getCaseDetails().getCaseId();
         DefaultTaskContext context = new DefaultTaskContext();
@@ -189,20 +196,20 @@ public class SendRespondentSubmissionNotificationEmailTest {
 
     private void checkThatPropertiesAreCheckedBeforeBeingRetrieved(Map<String, Object> mockCaseData) {
         List<String> listOfMethodInvoked = mockingDetails(mockCaseData).getInvocations().stream()
-                .map(Invocation::getMethod)
-                .map(Method::getName)
-                .collect(Collectors.toList());
+            .map(Invocation::getMethod)
+            .map(Method::getName)
+            .collect(Collectors.toList());
 
         long amountOfPropertiesChecked = listOfMethodInvoked.stream()
-                .filter("containsKey"::equalsIgnoreCase)
-                .count();
+            .filter("containsKey"::equalsIgnoreCase)
+            .count();
         long amountOfPropertiesRetrieved = listOfMethodInvoked.stream()
-                .filter("get"::equalsIgnoreCase)
-                .count();
+            .filter("get"::equalsIgnoreCase)
+            .count();
 
         assertThat("Properties should be checked before they are retrieved",
-                amountOfPropertiesChecked,
-                equalTo(amountOfPropertiesRetrieved));
+            amountOfPropertiesChecked,
+            equalTo(amountOfPropertiesRetrieved));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceivedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceivedTest.java
@@ -1,35 +1,44 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
 import com.google.common.collect.ImmutableMap;
-import org.joda.time.DateTimeUtils;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.stereotype.Component;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+
 @Component
+@RunWith(MockitoJUnitRunner.class)
 public class SetCoRespondentAnswerReceivedTest {
 
     private static final String CURRENT_DATE = "2018-01-01";
+    private static final LocalDateTime FIXED_DATE_TIME = LocalDateTime.of(2018, 01, 01, 00, 00);
 
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
     private SetCoRespondentAnswerReceived classToTest;
 
     @Before
     public void setUp() {
-        classToTest = new SetCoRespondentAnswerReceived();
-        DateTimeUtils.setCurrentMillisFixed(new org.joda.time.LocalDate(CURRENT_DATE).toDate().getTime());
-    }
-
-    @After
-    public void tearDown() {
-        DateTimeUtils.setCurrentMillisSystem();
+        when(clock.instant()).thenReturn(FIXED_DATE_TIME.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceivedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceivedTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
@@ -27,7 +28,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class SetCoRespondentAnswerReceivedTest {
 
     private static final String CURRENT_DATE = "2018-01-01";
-    private static final LocalDateTime FIXED_DATE_TIME = LocalDateTime.of(2018, 01, 01, 00, 00);
+    private static final LocalDateTime FIXED_DATE_TIME = LocalDate.parse(CURRENT_DATE).atStartOfDay();
 
     @Mock
     private Clock clock;
@@ -46,7 +47,7 @@ public class SetCoRespondentAnswerReceivedTest {
         Map<String, Object> caseDataResponse = classToTest.execute(null, new HashMap<>());
 
         Map<String, Object> expectedCaseData = ImmutableMap.of(CO_RESPONDENT_ANSWER_RECEIVED, YES_VALUE,
-                CO_RESPONDENT_ANSWER_RECEIVED_DATE, CURRENT_DATE);
+            CO_RESPONDENT_ANSWER_RECEIVED_DATE, CURRENT_DATE);
         assertEquals(expectedCaseData, caseDataResponse);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceivedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCoRespondentAnswerReceivedTest.java
@@ -8,15 +8,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_ANSWER_RECEIVED;
@@ -28,18 +24,16 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class SetCoRespondentAnswerReceivedTest {
 
     private static final String CURRENT_DATE = "2018-01-01";
-    private static final LocalDateTime FIXED_DATE_TIME = LocalDate.parse(CURRENT_DATE).atStartOfDay();
 
     @Mock
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @InjectMocks
     private SetCoRespondentAnswerReceived classToTest;
 
     @Before
-    public void setUp() {
-        when(clock.instant()).thenReturn(FIXED_DATE_TIME.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
+    public void before() {
+        when(ccdUtil.getCurrentDateCcdFormat()).thenReturn(CURRENT_DATE);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetailsTest.java
@@ -9,18 +9,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_CENTRE_SITEID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
@@ -28,21 +23,20 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RunWith(MockitoJUnitRunner.class)
 public class SetCourtDetailsTest {
 
-    private final LocalDateTime today = LocalDateTime.now();
+    private static final String FIXED_DATE = "2019-05-11";
 
     @InjectMocks
     private SetCourtDetails setCourtDetails;
 
     @Mock
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     private Map<String, Object> testData;
     private TaskContext context;
 
     @Before
     public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
+        when(ccdUtil.getCurrentDateCcdFormat()).thenReturn(FIXED_DATE);
 
         testData = new HashMap<>();
         context = new DefaultTaskContext();
@@ -51,7 +45,7 @@ public class SetCourtDetailsTest {
     @Test
     public void executeShouldSetDateAndCourtDetailsOnPayload() {
         Map<String, Object> resultData = new HashMap<>();
-        resultData.put(CREATED_DATE_JSON_KEY, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        resultData.put(CREATED_DATE_JSON_KEY, FIXED_DATE);
         resultData.put(DIVORCE_UNIT_JSON_KEY, CourtEnum.EASTMIDLANDS.getId());
         resultData.put(DIVORCE_CENTRE_SITEID_JSON_KEY, CourtEnum.EASTMIDLANDS.getSiteId());
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtDetailsTest.java
@@ -4,16 +4,23 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtEnum;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_CENTRE_SITEID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
@@ -21,14 +28,22 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RunWith(MockitoJUnitRunner.class)
 public class SetCourtDetailsTest {
 
+    private final LocalDateTime today = LocalDateTime.now();
+
     @InjectMocks
     private SetCourtDetails setCourtDetails;
+
+    @Mock
+    private Clock clock;
 
     private Map<String, Object> testData;
     private TaskContext context;
 
     @Before
     public void setup() {
+        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
+
         testData = new HashMap<>();
         context = new DefaultTaskContext();
     }
@@ -36,7 +51,7 @@ public class SetCourtDetailsTest {
     @Test
     public void executeShouldSetDateAndCourtDetailsOnPayload() {
         Map<String, Object> resultData = new HashMap<>();
-        resultData.put(CREATED_DATE_JSON_KEY, CcdUtil.getCurrentDate());
+        resultData.put(CREATED_DATE_JSON_KEY, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
         resultData.put(DIVORCE_UNIT_JSON_KEY, CourtEnum.EASTMIDLANDS.getId());
         resultData.put(DIVORCE_CENTRE_SITEID_JSON_KEY, CourtEnum.EASTMIDLANDS.getSiteId());
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDateTest.java
@@ -6,34 +6,28 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 
-import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ISSUE_DATE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SetIssueDateTest {
 
-    private final LocalDateTime today = LocalDateTime.now();
+    private static final String EXPECTED_DATE = "2019-05-11";
 
     @InjectMocks
     private SetIssueDate setIssueDate;
 
     @Mock
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @Before
     public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
+        when(ccdUtil.getCurrentDateCcdFormat()).thenReturn(EXPECTED_DATE);
     }
 
     @Test
@@ -42,7 +36,6 @@ public class SetIssueDateTest {
 
         setIssueDate.execute(null, payload);
 
-        String expectedDate = today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT));
-        assertEquals(expectedDate, payload.get(ISSUE_DATE));
+        assertEquals(EXPECTED_DATE, payload.get(ISSUE_DATE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetIssueDateTest.java
@@ -1,16 +1,40 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
+import org.junit.Before;
 import org.junit.Test;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 
+import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ISSUE_DATE;
 
+@RunWith(MockitoJUnitRunner.class)
 public class SetIssueDateTest {
 
-    private final SetIssueDate setIssueDate = new SetIssueDate();
+    private final LocalDateTime today = LocalDateTime.now();
+
+    @InjectMocks
+    private SetIssueDate setIssueDate;
+
+    @Mock
+    private Clock clock;
+
+    @Before
+    public void setup() {
+        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
+    }
 
     @Test
     public void testGenerateIssueDateSetsDateToNow() {
@@ -18,7 +42,7 @@ public class SetIssueDateTest {
 
         setIssueDate.execute(null, payload);
 
-        String expectedDate = CcdUtil.getCurrentDate();
+        String expectedDate = today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT));
         assertEquals(expectedDate, payload.get(ISSUE_DATE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCaseUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCaseUTest.java
@@ -10,15 +10,11 @@ import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,7 +28,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DN_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.COMPLETED_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
@@ -49,21 +44,21 @@ public class SubmitRespondentAosCaseUTest {
     private static final Map<String, Object> EXPECTED_OUTPUT = emptyMap();
     private static final Map<String, Object> CASE_UPDATE_RESPONSE = new HashMap<>();
     private static final TaskContext TASK_CONTEXT = new DefaultTaskContext();
-    private final LocalDateTime today = LocalDateTime.now();
 
-    @Mock()
+    private static final String FIXED_DATE = "2019-05-10";
+
+    @Mock
     private CaseMaintenanceClient caseMaintenanceClient;
 
     @Mock
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @InjectMocks
     private SubmitRespondentAosCase classUnderTest;
 
     @Before
     public void before() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
+        when(ccdUtil.getCurrentDateCcdFormat()).thenReturn(FIXED_DATE);
         TASK_CONTEXT.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
         TASK_CONTEXT.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
         CASE_UPDATE_RESPONSE.put(CCD_CASE_DATA_FIELD, EXPECTED_OUTPUT);
@@ -82,7 +77,7 @@ public class SubmitRespondentAosCaseUTest {
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
-        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
@@ -103,7 +98,7 @@ public class SubmitRespondentAosCaseUTest {
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
-        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
@@ -126,7 +121,7 @@ public class SubmitRespondentAosCaseUTest {
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
-        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
@@ -150,7 +145,7 @@ public class SubmitRespondentAosCaseUTest {
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
-        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
@@ -173,7 +168,7 @@ public class SubmitRespondentAosCaseUTest {
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
-        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
         verify(caseMaintenanceClient).updateCase(AUTH_TOKEN, TEST_CASE_ID, COMPLETED_AOS_EVENT_ID, expectedData);
@@ -192,7 +187,7 @@ public class SubmitRespondentAosCaseUTest {
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
-        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT)));
+        expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCaseUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCaseUTest.java
@@ -74,10 +74,10 @@ public class SubmitRespondentAosCaseUTest {
         final Map<String, Object> divorceSession = getCaseData(true, true);
 
         when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
+            CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_ANSWER_AOS_EVENT_ID, divorceSession))
-                .thenReturn(CASE_UPDATE_RESPONSE);
+            .thenReturn(CASE_UPDATE_RESPONSE);
 
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
@@ -87,7 +87,7 @@ public class SubmitRespondentAosCaseUTest {
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
         verify(caseMaintenanceClient)
-                .updateCase(eq(AUTH_TOKEN), eq(TEST_CASE_ID), eq(AWAITING_ANSWER_AOS_EVENT_ID), eq(expectedData));
+            .updateCase(eq(AUTH_TOKEN), eq(TEST_CASE_ID), eq(AWAITING_ANSWER_AOS_EVENT_ID), eq(expectedData));
     }
 
     @Test
@@ -95,10 +95,10 @@ public class SubmitRespondentAosCaseUTest {
         final Map<String, Object> divorceSession = getCaseData(false, true);
 
         when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
+            CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_ANSWER_AOS_EVENT_ID, divorceSession))
-                .thenReturn(CASE_UPDATE_RESPONSE);
+            .thenReturn(CASE_UPDATE_RESPONSE);
 
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
@@ -108,7 +108,7 @@ public class SubmitRespondentAosCaseUTest {
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
         verify(caseMaintenanceClient)
-                .updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_ANSWER_AOS_EVENT_ID, expectedData);
+            .updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_ANSWER_AOS_EVENT_ID, expectedData);
     }
 
     @Test
@@ -119,10 +119,10 @@ public class SubmitRespondentAosCaseUTest {
         existingCaseData.put(D_8_REASON_FOR_DIVORCE, UNREASONABLE_BEHAVIOUR);
 
         when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
+            CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_DN_AOS_EVENT_ID, divorceSession))
-                .thenReturn(CASE_UPDATE_RESPONSE);
+            .thenReturn(CASE_UPDATE_RESPONSE);
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
@@ -142,10 +142,10 @@ public class SubmitRespondentAosCaseUTest {
         existingCaseData.put(D_8_REASON_FOR_DIVORCE, ADULTERY);
 
         when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).caseData(existingCaseData).build());
+            CaseDetails.builder().caseId(TEST_CASE_ID).caseData(existingCaseData).build());
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, COMPLETED_AOS_EVENT_ID, divorceSession))
-                .thenReturn(CASE_UPDATE_RESPONSE);
+            .thenReturn(CASE_UPDATE_RESPONSE);
 
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
@@ -165,10 +165,10 @@ public class SubmitRespondentAosCaseUTest {
         existingCaseData.put(D_8_REASON_FOR_DIVORCE, SEPARATION_2YRS);
 
         when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).caseData(existingCaseData).build());
+            CaseDetails.builder().caseId(TEST_CASE_ID).caseData(existingCaseData).build());
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, COMPLETED_AOS_EVENT_ID, divorceSession))
-                .thenReturn(CASE_UPDATE_RESPONSE);
+            .thenReturn(CASE_UPDATE_RESPONSE);
 
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);
@@ -184,10 +184,10 @@ public class SubmitRespondentAosCaseUTest {
         final Map<String, Object> divorceSession = getCaseData(true, false);
 
         when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
+            CaseDetails.builder().caseId(TEST_CASE_ID).caseData(emptyMap()).build());
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_DN_AOS_EVENT_ID, divorceSession))
-                .thenReturn(CASE_UPDATE_RESPONSE);
+            .thenReturn(CASE_UPDATE_RESPONSE);
 
         Map<String, Object> expectedData = new HashMap<>();
         expectedData.putAll(divorceSession);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
@@ -16,11 +16,15 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +43,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_REISSUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE_DATE;
@@ -52,11 +57,16 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateRespondentDetailsUTest {
 
+    private final LocalDateTime today = LocalDateTime.now();
+
     @Mock
     private CaseMaintenanceClient caseMaintenanceClient;
 
     @Mock
     private AuthUtil authUtil;
+
+    @Mock
+    private Clock clock;
 
     @Mock
     private IdamClient idamClient;
@@ -66,6 +76,8 @@ public class UpdateRespondentDetailsUTest {
 
     @Before
     public void setup() {
+        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
         when(authUtil.getBearToken(AUTH_TOKEN)).thenCallRealMethod();
     }
 
@@ -228,7 +240,7 @@ public class UpdateRespondentDetailsUTest {
             ImmutableMap.of(
                 CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
                 CO_RESP_LINKED_TO_CASE, YES_VALUE,
-                CO_RESP_LINKED_TO_CASE_DATE, CcdUtil.getCurrentDate()
+                CO_RESP_LINKED_TO_CASE_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
             );
 
         verify(idamClient).retrieveUserDetails(BEARER_AUTH_TOKEN);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
@@ -16,15 +16,11 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Map;
 
-import static java.time.ZoneOffset.UTC;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,7 +39,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_REISSUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_DATE_FORMAT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_LINKED_TO_CASE_DATE;
@@ -57,7 +52,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateRespondentDetailsUTest {
 
-    private final LocalDateTime today = LocalDateTime.now();
+    private static final String FIXED_DATE = "2018-01-01";
 
     @Mock
     private CaseMaintenanceClient caseMaintenanceClient;
@@ -66,7 +61,7 @@ public class UpdateRespondentDetailsUTest {
     private AuthUtil authUtil;
 
     @Mock
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @Mock
     private IdamClient idamClient;
@@ -76,8 +71,7 @@ public class UpdateRespondentDetailsUTest {
 
     @Before
     public void setup() {
-        when(clock.instant()).thenReturn(today.toInstant(ZoneOffset.UTC));
-        when(clock.getZone()).thenReturn(UTC);
+        when(ccdUtil.getCurrentDateCcdFormat()).thenReturn(FIXED_DATE);
         when(authUtil.getBearToken(AUTH_TOKEN)).thenCallRealMethod();
     }
 
@@ -240,7 +234,7 @@ public class UpdateRespondentDetailsUTest {
             ImmutableMap.of(
                 CO_RESP_EMAIL_ADDRESS, TEST_EMAIL,
                 CO_RESP_LINKED_TO_CASE, YES_VALUE,
-                CO_RESP_LINKED_TO_CASE_DATE, today.format(DateTimeFormatter.ofPattern(CCD_DATE_FORMAT))
+                CO_RESP_LINKED_TO_CASE_DATE, FIXED_DATE
             );
 
         verify(idamClient).retrieveUserDetails(BEARER_AUTH_TOKEN);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetailsUTest.java
@@ -93,11 +93,11 @@ public class UpdateRespondentDetailsUTest {
 
         final Map<String, Object> caseData = Collections.singletonMap(D_8_DIVORCE_UNIT, TEST_COURT);
         final CaseDetails caseDetails =
-                CaseDetails.builder()
-                        .caseId(TEST_CASE_ID)
-                        .state(AOS_AWAITING_STATE)
-                        .caseData(caseData)
-                        .build();
+            CaseDetails.builder()
+                .caseId(TEST_CASE_ID)
+                .state(AOS_AWAITING_STATE)
+                .caseData(caseData)
+                .build();
 
         final Map<String, Object> dataToUpdate =
             ImmutableMap.of(
@@ -176,7 +176,7 @@ public class UpdateRespondentDetailsUTest {
         taskContext.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
 
         when(idamClient.retrieveUserDetails(BEARER_AUTH_TOKEN))
-                .thenReturn(respondentDetails);
+            .thenReturn(respondentDetails);
 
         UserDetails result = classUnderTest.execute(taskContext, payload);
         Assert.assertEquals(payload, result);
@@ -250,23 +250,23 @@ public class UpdateRespondentDetailsUTest {
 
     private UserDetails createTestUserDetails() {
         return UserDetails.builder()
-                .id(TEST_USER_ID)
-                .email(TEST_EMAIL)
-                .build();
+            .id(TEST_USER_ID)
+            .email(TEST_EMAIL)
+            .build();
     }
 
     private CaseDetails createTestCaseDetails(String state) {
         Map<String, Object> caseData = Collections.singletonMap(D_8_DIVORCE_UNIT, TEST_COURT);
         return CaseDetails.builder()
-                        .caseId(TEST_CASE_ID)
-                        .state(state)
-                        .caseData(caseData)
-                        .build();
+            .caseId(TEST_CASE_ID)
+            .state(state)
+            .caseData(caseData)
+            .build();
     }
 
     private Map<String, Object> createDataToUpdate() {
         return ImmutableMap.of(
-                RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
+            RESPONDENT_EMAIL_ADDRESS, TEST_EMAIL
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
@@ -1,26 +1,65 @@
 package uk.gov.hmcts.reform.divorce.orchestration.util;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EXPECTED_DUE_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EXPECTED_DUE_DATE_FORMATTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_DUE_DATE;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CcdUtilUTest {
+
+    private static final String CURRENT_DATE = "2018-01-01";
+    private static final String PAYMENT_DATE = "01012018";
+    private static final LocalDateTime FIXED_DATE_TIME = LocalDate.parse(CURRENT_DATE).atStartOfDay();
+
+    @InjectMocks
+    private CcdUtil ccdUtil;
+
+    @Mock
+    private Clock clock;
+
+    @Before
+    public void before() {
+        when(clock.instant()).thenReturn(FIXED_DATE_TIME.toInstant(ZoneOffset.UTC));
+        when(clock.getZone()).thenReturn(UTC);
+    }
+
     @Test
     public void testConstructorPrivate() throws Exception {
-        Constructor<CcdUtil> constructor = CcdUtil.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Constructor<CcdUtil> constructor = CcdUtil.class.getDeclaredConstructor(Clock.class);
+        assertTrue(Modifier.isPublic(constructor.getModifiers()));
         constructor.setAccessible(true);
-        constructor.newInstance();
+        constructor.newInstance(clock);
+    }
+
+    @Test
+    public void whenGetCurrentDate_thenReturnExpectedDate() {
+        assertEquals(CURRENT_DATE, ccdUtil.getCurrentDateCcdFormat());
+    }
+
+    @Test
+    public void whenCurrentDatePaymentPattern_thenReturnExpectedDate() {
+        assertEquals(PAYMENT_DATE, ccdUtil.getCurrentDatePaymentFormat());
     }
 
     @Test
@@ -29,7 +68,7 @@ public class CcdUtilUTest {
         Map<String, Object> testCaseData = new HashMap<>();
         testCaseData.put(CO_RESPONDENT_DUE_DATE, TEST_EXPECTED_DUE_DATE);
 
-        assertEquals(TEST_EXPECTED_DUE_DATE_FORMATTED, CcdUtil.getFormattedDueDate(testCaseData, CO_RESPONDENT_DUE_DATE));
+        assertEquals(TEST_EXPECTED_DUE_DATE_FORMATTED, ccdUtil.getFormattedDueDate(testCaseData, CO_RESPONDENT_DUE_DATE));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
@@ -1,8 +1,5 @@
 package uk.gov.hmcts.reform.divorce.orchestration.util;
 
-import org.joda.time.DateTimeUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
@@ -18,36 +15,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EXPEC
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_DUE_DATE;
 
 public class CcdUtilUTest {
-    private static final String CURRENT_DATE = "2018-01-01";
-    private static final String EXPECTED_DATE = "2018-01-08";
-    private static final int DAYS_OFFSET = 7;
-
-    @Before
-    public void setup() {
-        DateTimeUtils.setCurrentMillisFixed(new org.joda.time.LocalDate(CURRENT_DATE).toDate().getTime());
-    }
-
-    @After
-    public void tearDown() {
-        DateTimeUtils.setCurrentMillisSystem();
-    }
-
     @Test
     public void testConstructorPrivate() throws Exception {
         Constructor<CcdUtil> constructor = CcdUtil.class.getDeclaredConstructor();
         assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
-    }
-
-    @Test
-    public void whenGetCurrentDate_thenReturnExpectedDate() {
-        assertEquals(CURRENT_DATE, CcdUtil.getCurrentDate());
-    }
-
-    @Test
-    public void whenGetCurrentDatePlusDays_thenReturnExpectedDate() {
-        assertEquals(EXPECTED_DATE, CcdUtil.getCurrentDatePlusDays(DAYS_OFFSET));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
@@ -8,8 +8,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,7 +17,6 @@ import java.util.Map;
 
 import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EXPECTED_DUE_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EXPECTED_DUE_DATE_FORMATTED;
@@ -42,14 +39,6 @@ public class CcdUtilUTest {
     public void before() {
         when(clock.instant()).thenReturn(FIXED_DATE_TIME.toInstant(ZoneOffset.UTC));
         when(clock.getZone()).thenReturn(UTC);
-    }
-
-    @Test
-    public void testConstructorPrivate() throws Exception {
-        Constructor<CcdUtil> constructor = CcdUtil.class.getDeclaredConstructor(Clock.class);
-        assertTrue(Modifier.isPublic(constructor.getModifiers()));
-        constructor.setAccessible(true);
-        constructor.newInstance(clock);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflowTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -75,13 +74,8 @@ public class SendCoRespondSubmissionNotificationWorkflowTest {
     @InjectMocks
     private SendCoRespondSubmissionNotificationWorkflow classToTest;
 
-    @Before
-    public void before() throws TaskException {
-        when(ccdUtil.getFormattedDueDate(any(), any())).thenReturn(TEST_EXPECTED_DUE_DATE_FORMATTED);
-    }
-
     @Test
-    public void givenUndefendedCoResp_whenSendEmail_thenSendUndefendedTemplate() throws WorkflowException {
+    public void givenUndefendedCoResp_whenSendEmail_thenSendUndefendedTemplate() throws WorkflowException, TaskException {
 
         CcdCallbackRequest ccdCallbackRequest = createSubmittedCoEvent(ImmutableMap.of(CO_RESPONDENT_DEFENDS_DIVORCE, "No"));
 
@@ -107,6 +101,9 @@ public class SendCoRespondSubmissionNotificationWorkflowTest {
         Court court = new Court();
         court.setDivorceCentreName(TEST_COURT);
         when(taskCommons.getCourt(TEST_COURT)).thenReturn(court);
+
+        when(ccdUtil.getFormattedDueDate(ccdCallbackRequest.getCaseDetails().getCaseData(),
+            CO_RESPONDENT_DUE_DATE)).thenReturn(TEST_EXPECTED_DUE_DATE_FORMATTED);
 
         classToTest.run(ccdCallbackRequest);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendCoRespondSubmissionNotificationWorkflowTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;


### PR DESCRIPTION
## DIV-4789: Replace Joda time by Java 8 time
- Removed dependency on the Joda-Time library
- Replaced with native Java 8 clock-based implementation, injected as a dependency where required.
- This approach allows an alternate clock e.g. one fixed at a desired date to be used during testing.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Ran the full functional test suite due to the great number of classes affected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
