### PR TITLE
DIV-4860 - update the divorcecase contact email to contactdivorce@...

### DIFF
--- a/src/integrationTest/resources/draft/complete-case-response.json
+++ b/src/integrationTest/resources/draft/complete-case-response.json
@@ -101,7 +101,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/draft/complete-petition-draft.json
+++ b/src/integrationTest/resources/draft/complete-petition-draft.json
@@ -234,7 +234,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/retrieve-aos-case/aos-divorce-session.json
+++ b/src/integrationTest/resources/fixtures/retrieve-aos-case/aos-divorce-session.json
@@ -114,7 +114,7 @@
       "poBox": "PO Box 10447",
       "postCode": "NG2 9QN",
       "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
-      "email": "divorcecase@justice.gov.uk",
+      "email": "contactdivorce@justice.gov.uk",
       "phoneNumber": "0300 303 0642",
       "siteId": "AA07"
     }

--- a/src/integrationTest/resources/fixtures/retrieve-case/divorce-session.json
+++ b/src/integrationTest/resources/fixtures/retrieve-case/divorce-session.json
@@ -115,7 +115,7 @@
       "postCode":"NG2 9QN",
       "openingHours":"Telephone Enquiries from: 8.30am to 5pm",
       "courtCity":"Nottingham",
-      "email":"divorcecase@justice.gov.uk"
+      "email":"contactdivorce@justice.gov.uk"
     }
   },
   "reasonForDivorceShowFiveYearsSeparation":"true",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -207,7 +207,7 @@ court:
                 \"poBox\": \"PO Box 10447\",
                 \"postCode\": \"NG2 9QN\",
                 \"openingHours\": \"Telephone Enquiries from: 8.30am to 5pm\",
-                \"email\": \"divorcecase@justice.gov.uk\",
+                \"email\": \"contactdivorce@justice.gov.uk\",
                 \"phoneNumber\": \"0300 303 0642\",
                 \"siteId\": \"AA07\"
               }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -199,7 +199,7 @@ court:
                 \"poBox\": \"PO Box 10447\",
                 \"postCode\": \"NG2 9QN\",
                 \"openingHours\": \"Telephone Enquiries from: 8.30am to 5pm\",
-                \"email\": \"divorcecase@justice.gov.uk\",
+                \"email\": \"contactdivorce@justice.gov.uk\",
                 \"phoneNumber\": \"0300 303 0642\",
                 \"siteId\": \"AA07\"
               }


### PR DESCRIPTION
# Description

Now that all Divorce cases are being routed to the CTSC, the contact email address displayed in all notification email sent to citizens should be standardised.

This build should pass after https://github.com/hmcts/div-case-data-formatter/pull/132 is merged

Fixes #DIV-4860 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
