### PR TITLE
DIV-4835 Fix PMD/checkstyle warnings on gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -338,6 +338,7 @@ pmd {
     sourceSets = [sourceSets.main, sourceSets.test]
     reportsDir = file("$project.buildDir/reports/pmd")
     ruleSetFiles = files("ruleset.xml")
+    ruleSets = []
 }
 
 def sonarExclusions = [

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -4,28 +4,24 @@
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
     <description>
-        Ruleset for PDF Service
+        Ruleset for Case Orchestration Service
     </description>
-    <rule ref="rulesets/java/basic.xml"/>
-    <rule ref="rulesets/java/braces.xml"/>
-    <rule ref="rulesets/java/design.xml">
-        <exclude name="UseUtilityClass"/>
-        <exclude name="ConfusingTernary"/>
-    </rule>
-    <rule ref="rulesets/java/empty.xml"/>
-    <rule ref="rulesets/java/imports.xml">
-        <exclude name="TooManyStaticImports"/>
-    </rule>
-    <rule ref="rulesets/java/optimizations.xml">
-        <exclude name="MethodArgumentCouldBeFinal"/>
-        <exclude name="LocalVariableCouldBeFinal"/>
-    </rule>
-    <rule ref="rulesets/java/typeresolution.xml"/>
-    <rule ref="rulesets/java/typeresolution.xml/SignatureDeclareThrowsException">
-        <properties>
-            <property name="IgnoreJUnitCompletely" value="true"/>
-        </properties>
-    </rule>
-    <rule ref="rulesets/java/unnecessary.xml"/>
-    <rule ref="rulesets/java/unusedcode.xml"/>
+  <rule ref="category/java/errorprone.xml"/>
+  <rule ref="category/java/multithreading.xml"/>
+  <rule ref="category/java/bestpractices.xml"/>
+  <rule ref="category/java/codestyle.xml">
+    <exclude name="TooManyStaticImports"/>
+    <exclude name="MethodArgumentCouldBeFinal"/>
+    <exclude name="LocalVariableCouldBeFinal"/>
+    <exclude name="ConfusingTernary"/>
+  </rule>
+  <rule ref="category/java/performance.xml"/>
+  <rule ref="category/java/design.xml">
+    <exclude name="UseUtilityClass"/>
+  </rule>
+  <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
+    <properties>
+      <property name="IgnoreJUnitCompletely" value="true"/>
+    </properties>
+  </rule>
 </ruleset>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/AosReceivedCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/AosReceivedCallbackTest.java
@@ -6,16 +6,12 @@ import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
 import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_RESPONDENT_ANSWERS;
 import static uk.gov.hmcts.reform.divorce.util.ResourceLoader.objectToJson;
 


### PR DESCRIPTION
# Description
Previously the Gradle build would be polluted with hundreds of lines of warnings about migration of rulesets to new files. This change migrates to the new rulesets and also carries over the rule exclusions that we have. This makes the build output far more readable.

Fixes # 
[DIV-4835 Fix PMD/checkstyle warnings](https://tools.hmcts.net/jira/browse/DIV-4835)

## Type of change
Reduce log pollution

# How Has This Been Tested?
Run command 
```bash
./gradlew clean build
```
from project directory and check build output for occurrence of ruleset migration messages.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
