### PR TITLE
DIV-4906: Updated COE workflow to trigger generic email to Coresp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ def versions = [
         ccdStoreClient                  : '4.6.2',
         javaxWsRs                       : '2.1.1',
         jsonPathAssert                  : '2.2.0',
-        jacksonDatabind                 : '2.9.8',
+        jacksonDatabind                 : '2.9.9',
         guava                           : '27.1-jre',
         bcpkixJdk15on                   : '1.60',
         springSecurityRsa               : '1.0.8.RELEASE',

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentGenericUpdateNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentGenericUpdateNotificationEmail.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
+
+@Component
+public class SendCoRespondentGenericUpdateNotificationEmail implements Task<Map<String, Object>> {
+
+    private static final String EMAIL_DESC = "Generic Update Notification - CoRespondent";
+
+    private final EmailService emailService;
+
+    @Autowired
+    public SendCoRespondentGenericUpdateNotificationEmail(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
+
+        String coRespEmail = (String) caseData.get(CO_RESP_EMAIL_ADDRESS);
+        String coRespFirstName = (String) caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME);
+        String coRespLastName = (String)  caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME);
+        String caseNumber = (String) caseData.get(D_8_CASE_REFERENCE);
+
+        if (StringUtils.isNotBlank(coRespEmail)) {
+
+            Map<String, String> templateVars = new HashMap<>();
+
+            templateVars.put("email address", coRespEmail);
+            templateVars.put("first name", coRespFirstName);
+            templateVars.put("last name", coRespLastName);
+            templateVars.put("CCD reference", caseNumber);
+
+            emailService.sendEmail(coRespEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, EMAIL_DESC);
+        }
+
+        return caseData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentGenericUpdateNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentGenericUpdateNotificationEmail.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 
 import java.util.HashMap;
@@ -15,6 +16,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getMandatoryPropertyValueAsString;
 
 @Component
 public class SendCoRespondentGenericUpdateNotificationEmail implements Task<Map<String, Object>> {
@@ -29,14 +31,15 @@ public class SendCoRespondentGenericUpdateNotificationEmail implements Task<Map<
     }
 
     @Override
-    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {
 
         String coRespEmail = (String) caseData.get(CO_RESP_EMAIL_ADDRESS);
-        String coRespFirstName = (String) caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME);
-        String coRespLastName = (String)  caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME);
-        String caseNumber = (String) caseData.get(D_8_CASE_REFERENCE);
 
         if (StringUtils.isNotBlank(coRespEmail)) {
+
+            String coRespFirstName = getMandatoryPropertyValueAsString(caseData, D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME);
+            String coRespLastName =  getMandatoryPropertyValueAsString(caseData, D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME);
+            String caseNumber =  getMandatoryPropertyValueAsString(caseData, D_8_CASE_REFERENCE);
 
             Map<String, String> templateVars = new HashMap<>();
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ADMIT_OR_CONSENT_TO_FACT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SEPARATION_2YRS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getMandatoryPropertyValueAsString;
 
 @Component
 public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, Object>> {
@@ -45,15 +47,15 @@ public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, 
     }
 
     @Override
-    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {
 
-        String petitionerEmail = (String) caseData.get(D_8_PETITIONER_EMAIL);
-        String petitionerFirstName = (String) caseData.get(D_8_PETITIONER_FIRST_NAME);
-        String petitionerLastName = (String) caseData.get(D_8_PETITIONER_LAST_NAME);
-        String ccdReference = (String) caseData.get(D_8_CASE_REFERENCE);
-        String reasonForDivorce = (String) caseData.get(D_8_REASON_FOR_DIVORCE);
-        String respAdmitOrConsentToFact = (String) caseData.get(RESP_ADMIT_OR_CONSENT_TO_FACT);
-        String relationship = (String) caseData.get(D_8_DIVORCED_WHO);
+        String petitionerEmail = getMandatoryPropertyValueAsString(caseData, D_8_PETITIONER_EMAIL);
+        String petitionerFirstName = getMandatoryPropertyValueAsString(caseData, D_8_PETITIONER_FIRST_NAME);
+        String petitionerLastName = getMandatoryPropertyValueAsString(caseData, D_8_PETITIONER_LAST_NAME);
+        String ccdReference = getMandatoryPropertyValueAsString(caseData, D_8_CASE_REFERENCE);
+        String reasonForDivorce = getMandatoryPropertyValueAsString(caseData, D_8_REASON_FOR_DIVORCE);
+        String respAdmitOrConsentToFact = getMandatoryPropertyValueAsString(caseData, RESP_ADMIT_OR_CONSENT_TO_FACT);
+        String relationship = getMandatoryPropertyValueAsString(caseData, D_8_DIVORCED_WHO);
         String isCoRespNamed = (String) caseData.get(D_8_CO_RESPONDENT_NAMED);
         String receivedAosFromCoResp = (String) caseData.get(RECEIVED_AOS_FROM_CO_RESP);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
@@ -19,6 +19,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RELATIONSHIP_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ADMIT_OR_CONSENT_TO_FACT;
@@ -27,6 +28,14 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @Component
 public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, Object>> {
+
+    private static final String GENERIC_UPDATE_EMAIL_DESC = "Generic Update Notification - Petitioner";
+    private static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_EMAIL_DESC =
+            "Resp does not admit adultery update notification";
+    private static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED_EMAIL_DESC =
+            "Resp does not admit adultery update notification - no reply from co-resp";
+    private static final String AOS_RECEIVED_NO_CONSENT_2_YEARS_EMAIL_DESC =
+            "Resp does not consent to 2 year separation update notification";
 
     private final EmailService emailService;
 
@@ -39,6 +48,9 @@ public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, 
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
 
         String petitionerEmail = (String) caseData.get(D_8_PETITIONER_EMAIL);
+        String petitionerFirstName = (String) caseData.get(D_8_PETITIONER_FIRST_NAME);
+        String petitionerLastName = (String) caseData.get(D_8_PETITIONER_LAST_NAME);
+        String ccdReference = (String) caseData.get(D_8_CASE_REFERENCE);
         String reasonForDivorce = (String) caseData.get(D_8_REASON_FOR_DIVORCE);
         String respAdmitOrConsentToFact = (String) caseData.get(RESP_ADMIT_OR_CONSENT_TO_FACT);
         String relationship = (String) caseData.get(D_8_DIVORCED_WHO);
@@ -48,35 +60,34 @@ public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, 
         Map<String, String> templateVars = new HashMap<>();
 
         templateVars.put("email address", petitionerEmail);
-        templateVars.put("first name", (String) caseData.get(D_8_PETITIONER_FIRST_NAME));
-        templateVars.put("last name", (String) caseData.get(D_8_PETITIONER_LAST_NAME));
-        templateVars.put("CCD reference", (String) caseData.get(D_8_CASE_REFERENCE));
+        templateVars.put("first name", petitionerFirstName);
+        templateVars.put("last name", petitionerLastName);
+        templateVars.put("CCD reference", ccdReference);
 
         if (StringUtils.isNotBlank(petitionerEmail)) {
             if (reasonForDivorce.equals(ADULTERY) && NO_VALUE.equalsIgnoreCase(respAdmitOrConsentToFact)) {
-                templateVars.put("relationship", relationship);
+                templateVars.put(NOTIFICATION_RELATIONSHIP_KEY, relationship);
 
                 if (StringUtils.equalsIgnoreCase(isCoRespNamed, YES_VALUE) && !StringUtils.equalsIgnoreCase(receivedAosFromCoResp, YES_VALUE)) {
                     emailService.sendEmail(petitionerEmail,
                             EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
-                            templateVars, "resp does not admit adultery update notification - no reply from co-resp");
+                            templateVars, AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED_EMAIL_DESC);
                 } else {
                     emailService.sendEmail(petitionerEmail,
                             EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
-                            templateVars, "resp does not admit adultery update notification");
+                            templateVars, AOS_RECEIVED_NO_ADMIT_ADULTERY_EMAIL_DESC);
                 }
 
             } else if (reasonForDivorce.equals(SEPARATION_2YRS)
                     && NO_VALUE.equalsIgnoreCase(respAdmitOrConsentToFact)) {
-                templateVars.put("relationship", relationship);
+                templateVars.put(NOTIFICATION_RELATIONSHIP_KEY, relationship);
 
                 emailService.sendEmail(petitionerEmail,
                         EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
-                        templateVars,
-                        "resp does not consent to 2 year separation update notification");
+                        templateVars, AOS_RECEIVED_NO_CONSENT_2_YEARS_EMAIL_DESC);
 
             } else {
-                emailService.sendEmail(petitionerEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, "generic update notification");
+                emailService.sendEmail(petitionerEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, GENERIC_UPDATE_EMAIL_DESC);
             }
         }
         return caseData;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflow.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendCoRespondentGenericUpdateNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerCertificateOfEntitlementNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendRespondentCertificateOfEntitlementNotificationEmail;
 
@@ -25,12 +26,16 @@ public class CaseLinkedForHearingWorkflow extends DefaultWorkflow<Map<String, Ob
     @Autowired
     private SendRespondentCertificateOfEntitlementNotificationEmail sendRespondentCertificateOfEntitlementNotificationEmail;
 
+    @Autowired
+    SendCoRespondentGenericUpdateNotificationEmail sendCoRespondentGenericUpdateNotificationEmail;
+
     public Map<String, Object> run(CaseDetails caseDetails) throws WorkflowException {
 
         Map<String, Object> returnedPayload = this.execute(
                 new Task[]{
                     sendPetitionerCertificateOfEntitlementNotificationEmail,
-                    sendRespondentCertificateOfEntitlementNotificationEmail
+                    sendRespondentCertificateOfEntitlementNotificationEmail,
+                    sendCoRespondentGenericUpdateNotificationEmail
                 },
             caseDetails.getCaseData(),
             ImmutablePair.of(CASE_ID_KEY, caseDetails.getCaseId()));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 
 import java.util.HashMap;
@@ -64,7 +65,7 @@ public class SendCoRespondentNotificationEmailTest {
     }
 
     @Test
-    public void shouldCallEmailServiceForGenericUpdateIfCoRespEmailExists() {
+    public void shouldCallEmailServiceForGenericUpdateIfCoRespEmailExists() throws TaskException {
 
         testData.put(CO_RESP_EMAIL_ADDRESS, TEST_USER_EMAIL);
 
@@ -84,7 +85,7 @@ public class SendCoRespondentNotificationEmailTest {
 
 
     @Test
-    public void shouldNotCallEmailServiceForCoRespGenericUpdateIfCoRespEmailDoesNotExist() {
+    public void shouldNotCallEmailServiceForCoRespGenericUpdateIfCoRespEmailDoesNotExist() throws TaskException {
         // make sure it isn't triggered
         when(emailService.sendEmail(TEST_USER_EMAIL,
                 EmailTemplateNames.GENERIC_UPDATE.name(),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
+
+@RunWith(SpringRunner.class)
+public class SendCoRespondentNotificationEmailTest {
+
+    private static final String D8_CASE_ID = "LV17D80101";
+    private static final String UNFORMATTED_CASE_ID = "0123456789";
+
+    private TaskContext context;
+    private Map<String, Object> testData;
+    private Map<String, String> expectedTemplateVars;
+
+    @Mock
+    EmailService emailService;
+
+    @InjectMocks
+    SendCoRespondentGenericUpdateNotificationEmail sendCoRespondentGenericUpdateNotificationEmail;
+
+
+    @Before
+    public void setup() {
+        testData = new HashMap<>();
+        testData.put(D_8_CASE_REFERENCE, D8_CASE_ID);
+        testData.put(CASE_ID_JSON_KEY, UNFORMATTED_CASE_ID);
+        testData.put(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME, TEST_USER_FIRST_NAME);
+        testData.put(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME, TEST_USER_LAST_NAME);
+
+        context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, UNFORMATTED_CASE_ID);
+
+        expectedTemplateVars = new HashMap<>();
+
+        expectedTemplateVars.put("CCD reference", D8_CASE_ID);
+        expectedTemplateVars.put("email address", TEST_USER_EMAIL);
+        expectedTemplateVars.put("first name", TEST_USER_FIRST_NAME);
+        expectedTemplateVars.put("last name", TEST_USER_LAST_NAME);
+    }
+
+    @Test
+    public void shouldCallEmailServiceForGenericUpdateIfCoRespEmailExists() {
+
+        testData.put(CO_RESP_EMAIL_ADDRESS, TEST_USER_EMAIL);
+
+        when(emailService.sendEmail(TEST_USER_EMAIL,
+            EmailTemplateNames.GENERIC_UPDATE.name(),
+            expectedTemplateVars,
+            "Generic Update Notification - CoRespondent"))
+                .thenReturn(null);
+
+        assertEquals(testData, sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData));
+
+        verify(emailService).sendEmail(TEST_USER_EMAIL,
+            EmailTemplateNames.GENERIC_UPDATE.name(),
+            expectedTemplateVars,
+            "Generic Update Notification - CoRespondent");
+    }
+
+
+    @Test
+    public void shouldNotCallEmailServiceForCoRespGenericUpdateIfCoRespEmailDoesNotExist() {
+        // make sure it isn't triggered
+        when(emailService.sendEmail(TEST_USER_EMAIL,
+                EmailTemplateNames.GENERIC_UPDATE.name(),
+                expectedTemplateVars,
+                "Generic Update Notification - CoRespondent"))
+                .thenReturn(null);
+
+        assertEquals(testData, sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData));
+
+        verifyZeroInteractions(emailService);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
@@ -16,9 +16,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_LAST_NAME;
@@ -69,31 +70,25 @@ public class SendCoRespondentNotificationEmailTest {
 
         testData.put(CO_RESP_EMAIL_ADDRESS, TEST_USER_EMAIL);
 
-        when(emailService.sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.GENERIC_UPDATE.name(),
-            expectedTemplateVars,
-            "Generic Update Notification - CoRespondent"))
-                .thenReturn(null);
+        Map returnPayload = sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData);
 
-        assertEquals(testData, sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
-        verify(emailService).sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.GENERIC_UPDATE.name(),
-            expectedTemplateVars,
-            "Generic Update Notification - CoRespondent");
+        verify(emailService).sendEmail(
+            eq(TEST_USER_EMAIL),
+            eq(EmailTemplateNames.GENERIC_UPDATE.name()),
+            eq(expectedTemplateVars),
+            any());
     }
 
 
     @Test
     public void shouldNotCallEmailServiceForCoRespGenericUpdateIfCoRespEmailDoesNotExist() throws TaskException {
         // make sure it isn't triggered
-        when(emailService.sendEmail(TEST_USER_EMAIL,
-                EmailTemplateNames.GENERIC_UPDATE.name(),
-                expectedTemplateVars,
-                "Generic Update Notification - CoRespondent"))
-                .thenReturn(null);
 
-        assertEquals(testData, sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData));
+        Map returnPayload = sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData);
+
+        assertEquals(testData, returnPayload);
 
         verifyZeroInteractions(emailService);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
@@ -104,7 +104,7 @@ public class SendPetitionerNotificationEmailTest {
     }
 
     @Test
-    public void shouldCallEmailServiceForGenericUpdate() {
+    public void shouldCallEmailServiceForGenericUpdate() throws TaskException {
         when(emailService.sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
@@ -120,7 +120,7 @@ public class SendPetitionerNotificationEmailTest {
     }
 
     @Test
-    public void shouldCallAppropriateEmailServiceWhenRespDoesNotAdmitAdultery() {
+    public void shouldCallAppropriateEmailServiceWhenRespDoesNotAdmitAdultery() throws TaskException {
         testData.replace(D_8_REASON_FOR_DIVORCE, TEST_REASON_ADULTERY);
         testData.replace(RESP_ADMIT_OR_CONSENT_TO_FACT, NO_VALUE);
 
@@ -143,7 +143,7 @@ public class SendPetitionerNotificationEmailTest {
     }
 
     @Test
-    public void shouldCallAppropriateEmailServiceWhenRespDoesNotAdmitAdulteryCoRespNoReply() {
+    public void shouldCallAppropriateEmailServiceWhenRespDoesNotAdmitAdulteryCoRespNoReply() throws TaskException {
         testData.replace(D_8_REASON_FOR_DIVORCE, TEST_REASON_ADULTERY);
         testData.replace(RESP_ADMIT_OR_CONSENT_TO_FACT, NO_VALUE);
         testData.put(D_8_CO_RESPONDENT_NAMED, YES_VALUE);
@@ -168,7 +168,7 @@ public class SendPetitionerNotificationEmailTest {
     }
 
     @Test
-    public void shouldCallAppropriateEmailServiceWhenRespDoesNotConsentTo2YrsSeparation() {
+    public void shouldCallAppropriateEmailServiceWhenRespDoesNotConsentTo2YrsSeparation() throws TaskException {
         testData.replace(D_8_REASON_FOR_DIVORCE, TEST_REASON_2_YEAR_SEP);
         testData.replace(RESP_ADMIT_OR_CONSENT_TO_FACT, NO_VALUE);
 
@@ -191,7 +191,7 @@ public class SendPetitionerNotificationEmailTest {
     }
 
     @Test
-    public void shouldCallEmailServiceWithNoCaseIdFormatWhenNoUnableToFormatIdForGenericUpdate() {
+    public void shouldCallEmailServiceWithNoCaseIdFormatWhenNoUnableToFormatIdForGenericUpdate() throws TaskException {
         expectedTemplateVars.replace("CCD reference", D8_CASE_ID);
 
         when(emailService.sendEmail(TEST_USER_EMAIL,

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
@@ -108,7 +108,7 @@ public class SendPetitionerNotificationEmailTest {
         when(emailService.sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification"))
+            "Generic Update Notification - Petitioner"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -116,7 +116,7 @@ public class SendPetitionerNotificationEmailTest {
         verify(emailService).sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification");
+            "Generic Update Notification - Petitioner");
     }
 
     @Test
@@ -130,7 +130,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
                 expectedTemplateVars,
-                "resp does not admit adultery update notification"))
+                "Resp does not admit adultery update notification"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -139,7 +139,7 @@ public class SendPetitionerNotificationEmailTest {
             TEST_USER_EMAIL,
             EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
             expectedTemplateVars,
-            "resp does not admit adultery update notification");
+            "Resp does not admit adultery update notification");
     }
 
     @Test
@@ -155,7 +155,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
                 expectedTemplateVars,
-                "resp does not admit adultery update notification - no reply from co-resp"))
+                "Resp does not admit adultery update notification - no reply from co-resp"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -164,7 +164,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
                 expectedTemplateVars,
-                "resp does not admit adultery update notification - no reply from co-resp");
+                "Resp does not admit adultery update notification - no reply from co-resp");
     }
 
     @Test
@@ -178,7 +178,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
                 expectedTemplateVars,
-                "resp does not consent to 2 year separation update notification"))
+                "Resp does not consent to 2 year separation update notification"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -187,7 +187,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
                 expectedTemplateVars,
-                "resp does not consent to 2 year separation update notification");
+                "Resp does not consent to 2 year separation update notification");
     }
 
     @Test
@@ -197,7 +197,7 @@ public class SendPetitionerNotificationEmailTest {
         when(emailService.sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification"))
+            "Generic Update Notification - Petitioner"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -205,7 +205,7 @@ public class SendPetitionerNotificationEmailTest {
         verify(emailService).sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification");
+            "Generic Update Notification - Petitioner");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
@@ -35,6 +37,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RDC_NAME_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RELATIONSHIP_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP;
@@ -105,18 +108,15 @@ public class SendPetitionerNotificationEmailTest {
 
     @Test
     public void shouldCallEmailServiceForGenericUpdate() throws TaskException {
-        when(emailService.sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.GENERIC_UPDATE.name(),
-            expectedTemplateVars,
-            "Generic Update Notification - Petitioner"))
-                .thenReturn(null);
+        Map returnPayload = sendPetitionerUpdateNotificationsEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
-        verify(emailService).sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.GENERIC_UPDATE.name(),
-            expectedTemplateVars,
-            "Generic Update Notification - Petitioner");
+        verify(emailService).sendEmail(
+                eq(TEST_USER_EMAIL),
+                eq(EmailTemplateNames.GENERIC_UPDATE.name()),
+                eq(expectedTemplateVars),
+                any());
     }
 
     @Test
@@ -124,22 +124,17 @@ public class SendPetitionerNotificationEmailTest {
         testData.replace(D_8_REASON_FOR_DIVORCE, TEST_REASON_ADULTERY);
         testData.replace(RESP_ADMIT_OR_CONSENT_TO_FACT, NO_VALUE);
 
-        expectedTemplateVars.put("relationship", TEST_RELATIONSHIP);
+        expectedTemplateVars.put(NOTIFICATION_RELATIONSHIP_KEY, TEST_RELATIONSHIP);
 
-        when(emailService.sendEmail(
-                TEST_USER_EMAIL,
-                EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
-                expectedTemplateVars,
-                "Resp does not admit adultery update notification"))
-                .thenReturn(null);
+        Map returnPayload = sendPetitionerUpdateNotificationsEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
         verify(emailService).sendEmail(
-            TEST_USER_EMAIL,
-            EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
-            expectedTemplateVars,
-            "Resp does not admit adultery update notification");
+                eq(TEST_USER_EMAIL),
+                eq(EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name()),
+                eq(expectedTemplateVars),
+                any());
     }
 
     @Test
@@ -149,22 +144,17 @@ public class SendPetitionerNotificationEmailTest {
         testData.put(D_8_CO_RESPONDENT_NAMED, YES_VALUE);
         testData.put(RECEIVED_AOS_FROM_CO_RESP, NO_VALUE);
 
-        expectedTemplateVars.put("relationship", TEST_RELATIONSHIP);
+        expectedTemplateVars.put(NOTIFICATION_RELATIONSHIP_KEY, TEST_RELATIONSHIP);
 
-        when(emailService.sendEmail(
-                TEST_USER_EMAIL,
-                EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
-                expectedTemplateVars,
-                "Resp does not admit adultery update notification - no reply from co-resp"))
-                .thenReturn(null);
+        Map returnPayload = sendPetitionerUpdateNotificationsEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
         verify(emailService).sendEmail(
-                TEST_USER_EMAIL,
-                EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
-                expectedTemplateVars,
-                "Resp does not admit adultery update notification - no reply from co-resp");
+                eq(TEST_USER_EMAIL),
+                eq(EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name()),
+                eq(expectedTemplateVars),
+                any());
     }
 
     @Test
@@ -172,97 +162,80 @@ public class SendPetitionerNotificationEmailTest {
         testData.replace(D_8_REASON_FOR_DIVORCE, TEST_REASON_2_YEAR_SEP);
         testData.replace(RESP_ADMIT_OR_CONSENT_TO_FACT, NO_VALUE);
 
-        expectedTemplateVars.put("relationship", TEST_RELATIONSHIP);
+        expectedTemplateVars.put(NOTIFICATION_RELATIONSHIP_KEY, TEST_RELATIONSHIP);
 
-        when(emailService.sendEmail(
-                TEST_USER_EMAIL,
-                EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
-                expectedTemplateVars,
-                "Resp does not consent to 2 year separation update notification"))
-                .thenReturn(null);
+        Map returnPayload = sendPetitionerUpdateNotificationsEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
         verify(emailService).sendEmail(
-                TEST_USER_EMAIL,
-                EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
-                expectedTemplateVars,
-                "Resp does not consent to 2 year separation update notification");
+                eq(TEST_USER_EMAIL),
+                eq(EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name()),
+                eq(expectedTemplateVars),
+                any());
     }
 
     @Test
     public void shouldCallEmailServiceWithNoCaseIdFormatWhenNoUnableToFormatIdForGenericUpdate() throws TaskException {
         expectedTemplateVars.replace("CCD reference", D8_CASE_ID);
 
-        when(emailService.sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.GENERIC_UPDATE.name(),
-            expectedTemplateVars,
-            "Generic Update Notification - Petitioner"))
-                .thenReturn(null);
+        Map returnPayload = sendPetitionerUpdateNotificationsEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
-        verify(emailService).sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.GENERIC_UPDATE.name(),
-            expectedTemplateVars,
-            "Generic Update Notification - Petitioner");
+        verify(emailService).sendEmail(
+                eq(TEST_USER_EMAIL),
+                eq(EmailTemplateNames.GENERIC_UPDATE.name()),
+                eq(expectedTemplateVars),
+                any());
     }
 
     @Test
     public void shouldCallEmailService_WithCourtName_WhenCaseIsAssignedToCourt() throws TaskException {
-        expectedTemplateVars.put("RDC name", TEST_COURT_DISPLAY_NAME);
+        expectedTemplateVars.put(NOTIFICATION_RDC_NAME_KEY, TEST_COURT_DISPLAY_NAME);
         expectedTemplateVars.replace("CCD reference", UNFORMATTED_CASE_ID);
 
-        when(emailService.sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.APPLIC_SUBMISSION.name(),
-            expectedTemplateVars,
-            "submission notification"))
-                .thenReturn(null);
+        Map returnPayload = sendPetitionerSubmissionNotificationEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerSubmissionNotificationEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
-        verify(emailService).sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.APPLIC_SUBMISSION.name(),
-            expectedTemplateVars,
-            "submission notification");
+        verify(emailService).sendEmail(
+                eq(TEST_USER_EMAIL),
+                eq(EmailTemplateNames.APPLIC_SUBMISSION.name()),
+                eq(expectedTemplateVars),
+                any());
     }
 
     @Test
     public void shouldCallEmailService_WithServiceCentreName_WhenCaseIsAssignedToServiceCentre() throws TaskException {
         testData.put(DIVORCE_UNIT_JSON_KEY, SERVICE_CENTRE_KEY);
         expectedTemplateVars.replace("CCD reference", UNFORMATTED_CASE_ID);
-        expectedTemplateVars.put("RDC name", SERVICE_CENTRE_DISPLAY_NAME);
+        expectedTemplateVars.put(NOTIFICATION_RDC_NAME_KEY, SERVICE_CENTRE_DISPLAY_NAME);
 
-        when(emailService.sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.APPLIC_SUBMISSION.name(),
-            expectedTemplateVars,
-            "submission notification"))
-            .thenReturn(null);
+        Map returnPayload = sendPetitionerSubmissionNotificationEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerSubmissionNotificationEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
-        verify(emailService).sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.APPLIC_SUBMISSION.name(),
-            expectedTemplateVars,
-            "submission notification");
+        verify(emailService).sendEmail(
+                eq(TEST_USER_EMAIL),
+                eq(EmailTemplateNames.APPLIC_SUBMISSION.name()),
+                eq(expectedTemplateVars),
+                any());
     }
 
     @Test
     public void shouldCallEmailServiceWithNoCaseIdFormatWhenNoUnableToFormatIdForSubmission() throws TaskException {
         expectedTemplateVars.replace("CCD reference", UNFORMATTED_CASE_ID);
-        expectedTemplateVars.put("RDC name", TEST_COURT_DISPLAY_NAME);
+        expectedTemplateVars.put(NOTIFICATION_RDC_NAME_KEY, TEST_COURT_DISPLAY_NAME);
 
-        when(emailService.sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.APPLIC_SUBMISSION.name(),
-            expectedTemplateVars,
-            "submission notification"))
-            .thenReturn(null);
+        Map returnPayload = sendPetitionerSubmissionNotificationEmail.execute(context, testData);
 
-        assertEquals(testData, sendPetitionerSubmissionNotificationEmail.execute(context, testData));
+        assertEquals(testData, returnPayload);
 
-        verify(emailService).sendEmail(TEST_USER_EMAIL,
-            EmailTemplateNames.APPLIC_SUBMISSION.name(),
-            expectedTemplateVars,
-            "submission notification");
+        verify(emailService).sendEmail(
+            eq(TEST_USER_EMAIL),
+            eq(EmailTemplateNames.APPLIC_SUBMISSION.name()),
+            eq(expectedTemplateVars),
+            any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflowTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendCoRespondentGenericUpdateNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerCertificateOfEntitlementNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendRespondentCertificateOfEntitlementNotificationEmail;
 
@@ -36,6 +37,9 @@ public class CaseLinkedForHearingWorkflowTest {
     @Mock
     private SendRespondentCertificateOfEntitlementNotificationEmail sendRespondentCertificateOfEntitlementNotificationEmail;
 
+    @Mock
+    private SendCoRespondentGenericUpdateNotificationEmail sendCoRespondentGenericUpdateNotificationEmail;
+
     @InjectMocks
     private CaseLinkedForHearingWorkflow caseLinkedForHearingWorkflow;
 
@@ -51,6 +55,9 @@ public class CaseLinkedForHearingWorkflowTest {
 
         when(sendRespondentCertificateOfEntitlementNotificationEmail.execute(notNull(), eq(testPayload)))
                 .thenReturn(testPayload);
+
+        when(sendCoRespondentGenericUpdateNotificationEmail.execute(notNull(), eq(testPayload)))
+                .thenReturn(testPayload);
     }
 
     @Test
@@ -62,10 +69,16 @@ public class CaseLinkedForHearingWorkflowTest {
 
         Map<String, Object> returnedPayload = caseLinkedForHearingWorkflow.run(caseDetails);
 
-        verify(sendPetitionerCertificateOfEntitlementNotificationEmail).execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
-        verify(sendRespondentCertificateOfEntitlementNotificationEmail).execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
-
         assertThat(returnedPayload, is(equalTo(testPayload)));
+
+        verify(sendPetitionerCertificateOfEntitlementNotificationEmail)
+                .execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
+        verify(sendRespondentCertificateOfEntitlementNotificationEmail)
+                .execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
+        verify(sendCoRespondentGenericUpdateNotificationEmail)
+                .execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
+
         assertThat(contextCaptor.getValue().getTransientObject(CASE_ID_KEY), is(equalTo("testCaseId")));
+
     }
 }


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-4906

Simply triggers a generic email to the co-resp (if they exist) when a case is listed for hearing (COE) telling them that something has changed with the relevant divorce case

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested using swagger at http://div-cos-pr-276.service.core-compute-preview.internal/swagger-ui.html#!/callback45controller/caseLinkedForHearingUsingPOST

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
