### PR TITLE
Override Spring's management endpoint cache to 30 seconds in AAT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ def versions = [
         ccdStoreClient                  : '4.6.2',
         javaxWsRs                       : '2.1.1',
         jsonPathAssert                  : '2.2.0',
-        jacksonDatabind                 : '2.9.8',
+        jacksonDatabind                 : '2.9.9',
         guava                           : '27.1-jre',
         bcpkixJdk15on                   : '1.60',
         springSecurityRsa               : '1.0.8.RELEASE',

--- a/charts/div-cos/values.aat.template.yaml
+++ b/charts/div-cos/values.aat.template.yaml
@@ -19,7 +19,7 @@ java:
         UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS: "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
         DOCUMENT_GENERATOR_SERVICE_API_BASEURL: "http://div-dgs-aat.service.core-compute-aat.internal"
         FEES_AND_PAYMENTS_SERVICE_API_BASEURL: "http://div-fps-aat.service.core-compute-aat.internal"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cos/values.aat.template.yaml
+++ b/charts/div-cos/values.aat.template.yaml
@@ -19,6 +19,7 @@ java:
         UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS: "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
         DOCUMENT_GENERATOR_SERVICE_API_BASEURL: "http://div-dgs-aat.service.core-compute-aat.internal"
         FEES_AND_PAYMENTS_SERVICE_API_BASEURL: "http://div-fps-aat.service.core-compute-aat.internal"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cos/values.preview.template.yaml
+++ b/charts/div-cos/values.preview.template.yaml
@@ -19,6 +19,7 @@ java:
     UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS: "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
     DOCUMENT_GENERATOR_SERVICE_API_BASEURL: "http://div-dgs-aat.service.core-compute-aat.internal"
     FEES_AND_PAYMENTS_SERVICE_API_BASEURL: "http://div-fps-aat.service.core-compute-aat.internal"
+    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
   # Don't modify below here
   image: ${IMAGE_NAME}

--- a/charts/div-cos/values.preview.template.yaml
+++ b/charts/div-cos/values.preview.template.yaml
@@ -19,7 +19,7 @@ java:
     UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS: "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
     DOCUMENT_GENERATOR_SERVICE_API_BASEURL: "http://div-dgs-aat.service.core-compute-aat.internal"
     FEES_AND_PAYMENTS_SERVICE_API_BASEURL: "http://div-fps-aat.service.core-compute-aat.internal"
-    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+    MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
   # Don't modify below here
   image: ${IMAGE_NAME}

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -5,3 +5,5 @@ idam_strategic_enabled = "true"
 capacity = "2"
 
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
+
+health_check_ttl = 30000

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -69,7 +69,7 @@ module "div-cos" {
     UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS               = "${var.uk_gov_notify_email_template_vars}"
     AOS_RESPONDED_DAYS_TO_COMPLETE                  = "${var.aos_responded_days_to_complete}"
     AOS_RESPONDED_AWAITING_ANSWER_DAYS_TO_RESPOND   = "${var.aos_responded_awaiting_answer_days_to_respond}"
-    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE          = "${var.health_check_ttl}"
+    MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE          = "${var.health_check_ttl}"
 
     FEATURE_TOGGLE_SERVICE_API_BASEURL             = "${local.feature_toggle_baseurl}"
     SEND_LETTER_SERIVCE_BASEURL                    = "${local.send_letter_service_baseurl}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -17,7 +17,7 @@ locals {
   petitioner_fe_baseurl             = "https://div-pfe-${local.local_env}.service.core-compute-${local.local_env}.internal"
   feature_toggle_baseurl            = "http://rpe-feature-toggle-api-${local.local_env}.service.core-compute-${local.local_env}.internal"
   send_letter_service_baseurl       = "http://rpe-send-letter-service-${local.local_env}.service.core-compute-${local.local_env}.internal"
-  
+
   uk_gov_notify_email_templates     = "{APPLIC_SUBMISSION: 'c323844c-5fb9-4ba4-8290-b84139eb033c', APPLICANT_CO_RESPONDENT_RESPONDS_AOS_NOT_SUBMITTED: 'e07cbeb8-c2e0-4ba5-84ba-b9bd1ab04b0a', APPLICANT_CO_RESPONDENT_RESPONDS_AOS_SUBMITTED_NO_DEFEND: '369169ef-c6cb-428c-abbd-427aaa50c2a3', AOS_RECEIVED_NO_ADMIT_ADULTERY: '015fb73a-3be2-49d8-8ed8-a4078025dae3', AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED: 'bc6ee2ec-f62b-4321-b19f-65e868f849eb', AOS_RECEIVED_NO_CONSENT_2_YEARS: '845d0114-0f74-43a4-b11c-8ebeceb01c5b', CO_RESPONDENT_DEFENDED_AOS_SUBMISSION_NOTIFICATION: '19a8844e-8112-4578-aa4c-dea6c054ab35', CO_RESPONDENT_UNDEFENDED_AOS_SUBMISSION_NOTIFICATION: '486c86ff-a0e2-4eb1-a84c-687641d746de', DN_SUBMISSION: 'edf3bce9-f63a-4be0-93a9-d0c80dff7983', GENERIC_UPDATE: '6ee6ec29-5e88-4516-99cb-2edc30256575', SAVE_DRAFT:'14074c06-87f1-4678-9238-4d71e741eb57', RESPONDENT_DEFENDED_AOS_SUBMISSION_NOTIFICATION: 'eac41143-b296-4879-ba60-a0ea6f97c757', RESPONDENT_SUBMISSION_CONSENT: '594dc500-93ca-4f4b-931b-acbf9ee83d25', RESPONDENT_SUBMISSION_CONSENT_CORESP_NOT_REPLIED: '44e2dd30-4303-4f4c-a394-ce0b54af81dd', RESPONDENT_UNDEFENDED_AOS_SUBMISSION_NOTIFICATION: '277fd3f3-2fdb-4c79-9354-1b3db8d44cca', PETITIONER_CERTIFICATE_OF_ENTITLEMENT_NOTIFICATION: '9937c8bc-dc7a-4210-a25b-20aceb82d48d', PETITIONER_CLARIFICATION_REQUEST_EMAIL_NOTIFICATION: '686ce418-6d76-48ce-b903-a87d2b832125', RESPONDENT_CERTIFICATE_OF_ENTITLEMENT_NOTIFICATION: '80b986e1-056b-4577-a343-bb2e72e2a3f0'}"
 
   previewVaultName = "${var.raw_product}-aat"
@@ -69,6 +69,7 @@ module "div-cos" {
     UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS               = "${var.uk_gov_notify_email_template_vars}"
     AOS_RESPONDED_DAYS_TO_COMPLETE                  = "${var.aos_responded_days_to_complete}"
     AOS_RESPONDED_AWAITING_ANSWER_DAYS_TO_RESPOND   = "${var.aos_responded_awaiting_answer_days_to_respond}"
+    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE          = "${var.health_check_ttl}"
 
     FEATURE_TOGGLE_SERVICE_API_BASEURL             = "${local.feature_toggle_baseurl}"
     SEND_LETTER_SERIVCE_BASEURL                    = "${local.send_letter_service_baseurl}"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -3,3 +3,5 @@ idam_api_baseurl = "https://idam-api.aat.platform.hmcts.net"
 idam_strategic_enabled = "true"
 
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
+
+health_check_ttl = 30000

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -70,3 +70,7 @@ variable "aos_responded_awaiting_answer_days_to_respond" {
 variable "idam_strategic_enabled" {
   default = "true"
 }
+
+variable "health_check_ttl" {
+  default = 4000
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -72,5 +72,6 @@ variable "idam_strategic_enabled" {
 }
 
 variable "health_check_ttl" {
-  default = 4000
+  type = "string"
+  default = "4000"
 }


### PR DESCRIPTION
# Description

To prevent hammering AAT, as every `/health` call checks _every_ dependent service, generating sometimes ~30 subsequent calls (e.g COS)

Tested locally via
`MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE=60000 ./gradlew clean bootrun`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
