### PR TITLE
DIV-4828: Send Pet & Resp email when DN has been pronounced

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ def versions = [
         ccdStoreClient                  : '4.6.2',
         javaxWsRs                       : '2.1.1',
         jsonPathAssert                  : '2.2.0',
-        jacksonDatabind                 : '2.9.8',
+        jacksonDatabind                 : '2.9.9',
         guava                           : '27.1-jre',
         bcpkixJdk15on                   : '1.60',
         springSecurityRsa               : '1.0.8.RELEASE',

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -60,7 +60,7 @@ public class CallbackController {
     }
 
     @PostMapping(path = "/dn-submitted")
-    @ApiOperation(value = "Decree nisi submitted confirmation notification ")
+    @ApiOperation(value = "Decree Nisi submitted confirmation notification ")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Notification sent successful"),
         @ApiResponse(code = 401, message = "User Not Authenticated"),
@@ -70,6 +70,23 @@ public class CallbackController {
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(caseOrchestrationService.dnSubmitted(ccdCallbackRequest, authorizationToken));
+    }
+
+    @PostMapping(path = "/dn-pronounced",
+            consumes = MediaType.APPLICATION_JSON,
+            produces = MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Generate/dispatch a notification email to the petitioner and respondent when the Decree Nisi has been pronounced")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "An email notification has been generated and dispatched",
+                    response = CcdCallbackResponse.class),
+            @ApiResponse(code = 400, message = "Bad Request")})
+    public ResponseEntity<CcdCallbackResponse> dnPronounced(
+            @RequestHeader(value = "Authorization", required = false) String authorizationToken,
+            @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        caseOrchestrationService.sendDnPronouncedNotificationEmail(ccdCallbackRequest);
+        return ResponseEntity.ok(CcdCallbackResponse.builder()
+                .data(ccdCallbackRequest.getCaseDetails().getCaseData())
+                .build());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -144,6 +144,7 @@ public class OrchestrationConstants {
 
     // Notification
     public static final String NOTIFICATION_EMAIL = "email_address";
+    public static final String NOTIFICATION_EMAIL_WITH_SPACE = "email address";
     public static final String NOTIFICATION_SEND_EMAIL = "send_email";
     public static final String NOTIFICATION_TEMPLATE = "notification_template";
     public static final String NOTIFICATION_TEMPLATE_VARS = "notification_template_vars";
@@ -153,6 +154,7 @@ public class OrchestrationConstants {
     public static final String NOTIFICATION_RELATIONSHIP_KEY = "relationship";
     public static final String NOTIFICATION_REFERENCE_KEY = "ref";
     public static final String NOTIFICATION_CASE_NUMBER_KEY = "case number";
+    public static final String NOTIFICATION_CCD_REFERENCE = "CCD reference";
     public static final String NOTIFICATION_RDC_NAME_KEY = "RDC name";
     public static final String NOTIFICATION_COURT_ADDRESS_KEY = "court address";
     public static final String NOTIFICATION_FORM_SUBMISSION_DATE_LIMIT_KEY = "form submission date limit";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -77,6 +77,8 @@ public interface CaseOrchestrationService {
 
     CcdCallbackResponse sendCoRespReceivedNotificationEmail(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;
 
+    Map<String, Object> sendDnPronouncedNotificationEmail(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;
+
     Map<String, Object> processCaseLinkedForHearingEvent(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException;
 
     Map<String, Object> coRespondentAnswerReceived(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -19,8 +19,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.AuthenticateResponden
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.CaseLinkedForHearingWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.CcdCallbackBulkPrintWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.CoRespondentAnswerReceivedWorkflow;
-import uk.gov.hmcts.reform.divorce.orchestration.workflows.DNSubmittedWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.DeleteDraftWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.DNSubmittedWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.GenerateCoRespondentAnswersWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.GetCaseWithIdWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.GetCaseWorkflow;
@@ -33,8 +33,9 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.RetrieveAosCaseWorkfl
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.RetrieveDraftWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SaveDraftWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendCoRespondSubmissionNotificationWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendDnPronouncedNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerClarificationRequestNotificationWorkflow;
-import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerGenericEmailNotificationWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerEmailNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerSubmissionNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendRespondentSubmissionNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SetOrderSummaryWorkflow;
@@ -82,7 +83,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     private final ProcessPbaPaymentWorkflow processPbaPaymentWorkflow;
     private final SolicitorCreateWorkflow solicitorCreateWorkflow;
     private final SendPetitionerSubmissionNotificationWorkflow sendPetitionerSubmissionNotificationWorkflow;
-    private final SendPetitionerGenericEmailNotificationWorkflow sendPetitionerGenericEmailNotificationWorkflow;
+    private final SendPetitionerEmailNotificationWorkflow sendPetitionerEmailNotificationWorkflow;
     private final SendPetitionerClarificationRequestNotificationWorkflow sendPetitionerClarificationRequestNotificationWorkflow;
     private final SendRespondentSubmissionNotificationWorkflow sendRespondentSubmissionNotificationWorkflow;
     private final SendCoRespondSubmissionNotificationWorkflow sendCoRespondSubmissionNotificationWorkflow;
@@ -91,6 +92,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     private final SubmitCoRespondentAosWorkflow submitCoRespondentAosWorkflow;
     private final SubmitDnCaseWorkflow submitDnCaseWorkflow;
     private final DNSubmittedWorkflow dnSubmittedWorkflow;
+    private final SendDnPronouncedNotificationWorkflow sendDnPronouncedNotificationWorkflow;
     private final GetCaseWorkflow getCaseWorkflow;
     private final AuthUtil authUtil;
     private final AmendPetitionWorkflow amendPetitionWorkflow;
@@ -308,6 +310,12 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
         }
     }
 
+    @Override
+    public Map<String, Object> sendRespondentSubmissionNotificationEmail(CcdCallbackRequest ccdCallbackRequest)
+            throws WorkflowException {
+        return sendRespondentSubmissionNotificationWorkflow.run(ccdCallbackRequest);
+    }
+
     private List<String> getNotificationErrors(Map<String, Object> notificationErrors) {
         return notificationErrors.entrySet()
             .stream()
@@ -324,7 +332,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     @Override
     public Map<String, Object> sendPetitionerGenericUpdateNotificationEmail(
         CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
-        return sendPetitionerGenericEmailNotificationWorkflow.run(ccdCallbackRequest);
+        return sendPetitionerEmailNotificationWorkflow.run(ccdCallbackRequest);
     }
 
     @Override
@@ -333,9 +341,9 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     }
 
     @Override
-    public Map<String, Object> sendRespondentSubmissionNotificationEmail(CcdCallbackRequest ccdCallbackRequest)
+    public Map<String, Object> sendDnPronouncedNotificationEmail(CcdCallbackRequest ccdCallbackRequest)
         throws WorkflowException {
-        return sendRespondentSubmissionNotificationWorkflow.run(ccdCallbackRequest);
+        return sendDnPronouncedNotificationWorkflow.run(ccdCallbackRequest);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentGenericUpdateNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentGenericUpdateNotificationEmail.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
+
+@Component
+public class SendCoRespondentGenericUpdateNotificationEmail implements Task<Map<String, Object>> {
+
+    private static final String EMAIL_DESC = "Generic Update Notification - CoRespondent";
+
+    private final EmailService emailService;
+
+    @Autowired
+    public SendCoRespondentGenericUpdateNotificationEmail(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
+
+        String coRespEmail = (String) caseData.get(CO_RESP_EMAIL_ADDRESS);
+        String coRespFirstName = (String) caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME);
+        String coRespLastName = (String)  caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME);
+        String caseNumber = (String) caseData.get(D_8_CASE_REFERENCE);
+
+        if (StringUtils.isNotBlank(coRespEmail)) {
+
+            Map<String, String> templateVars = new HashMap<>();
+
+            templateVars.put("email address", coRespEmail);
+            templateVars.put("first name", coRespFirstName);
+            templateVars.put("last name", coRespLastName);
+            templateVars.put("CCD reference", caseNumber);
+
+            emailService.sendEmail(coRespEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, EMAIL_DESC);
+        }
+
+        return caseData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerGenericUpdateNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerGenericUpdateNotificationEmail.java
@@ -11,45 +11,45 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 import java.util.HashMap;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_LAST_NAME_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CCD_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL_WITH_SPACE;
 
 @Component
-public class SendCoRespondentGenericUpdateNotificationEmail implements Task<Map<String, Object>> {
+public class SendPetitionerGenericUpdateNotificationEmail implements Task<Map<String, Object>> {
 
-    private static final String EMAIL_DESC = "Generic Update Notification - CoRespondent";
+    private static final String EMAIL_DESC = "Generic Update Notification - Petitioner";
 
     private final EmailService emailService;
 
     @Autowired
-    public SendCoRespondentGenericUpdateNotificationEmail(EmailService emailService) {
+    public SendPetitionerGenericUpdateNotificationEmail(EmailService emailService) {
         this.emailService = emailService;
     }
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
 
-        String coRespEmail = (String) caseData.get(CO_RESP_EMAIL_ADDRESS);
-        String coRespFirstName = (String) caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME);
-        String coRespLastName = (String)  caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME);
-        String caseNumber = (String) caseData.get(D_8_CASE_REFERENCE);
+        String petitionerEmail = (String) caseData.get(D_8_PETITIONER_EMAIL);
+        String petitionerFirstName = (String) caseData.get(D_8_PETITIONER_FIRST_NAME);
+        String petitionerLastName = (String) caseData.get(D_8_PETITIONER_LAST_NAME);
+        String ccdReference = (String) caseData.get(D_8_CASE_REFERENCE);
 
-        if (StringUtils.isNotBlank(coRespEmail)) {
+        if (StringUtils.isNotBlank(petitionerEmail)) {
 
             Map<String, String> templateVars = new HashMap<>();
 
-            templateVars.put(NOTIFICATION_EMAIL_WITH_SPACE, coRespEmail);
-            templateVars.put(NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY, coRespFirstName);
-            templateVars.put(NOTIFICATION_ADDRESSEE_LAST_NAME_KEY, coRespLastName);
-            templateVars.put(NOTIFICATION_CCD_REFERENCE, caseNumber);
+            templateVars.put(NOTIFICATION_EMAIL_WITH_SPACE, petitionerEmail);
+            templateVars.put(NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY, petitionerFirstName);
+            templateVars.put(NOTIFICATION_ADDRESSEE_LAST_NAME_KEY, petitionerLastName);
+            templateVars.put(NOTIFICATION_CCD_REFERENCE, ccdReference);
 
-            emailService.sendEmail(coRespEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, EMAIL_DESC);
+            emailService.sendEmail(petitionerEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, EMAIL_DESC);
         }
 
         return caseData;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
@@ -19,6 +19,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RELATIONSHIP_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RECEIVED_AOS_FROM_CO_RESP;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ADMIT_OR_CONSENT_TO_FACT;
@@ -27,6 +28,14 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @Component
 public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, Object>> {
+
+    private static final String GENERIC_UPDATE_EMAIL_DESC = "Generic Update Notification - Petitioner";
+    private static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_EMAIL_DESC =
+            "Resp does not admit adultery update notification";
+    private static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED_EMAIL_DESC =
+            "Resp does not admit adultery update notification - no reply from co-resp";
+    private static final String AOS_RECEIVED_NO_CONSENT_2_YEARS_EMAIL_DESC =
+            "Resp does not consent to 2 year separation update notification";
 
     private final EmailService emailService;
 
@@ -39,6 +48,9 @@ public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, 
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
 
         String petitionerEmail = (String) caseData.get(D_8_PETITIONER_EMAIL);
+        String petitionerFirstName = (String) caseData.get(D_8_PETITIONER_FIRST_NAME);
+        String petitionerLastName = (String) caseData.get(D_8_PETITIONER_LAST_NAME);
+        String ccdReference = (String) caseData.get(D_8_CASE_REFERENCE);
         String reasonForDivorce = (String) caseData.get(D_8_REASON_FOR_DIVORCE);
         String respAdmitOrConsentToFact = (String) caseData.get(RESP_ADMIT_OR_CONSENT_TO_FACT);
         String relationship = (String) caseData.get(D_8_DIVORCED_WHO);
@@ -48,35 +60,34 @@ public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, 
         Map<String, String> templateVars = new HashMap<>();
 
         templateVars.put("email address", petitionerEmail);
-        templateVars.put("first name", (String) caseData.get(D_8_PETITIONER_FIRST_NAME));
-        templateVars.put("last name", (String) caseData.get(D_8_PETITIONER_LAST_NAME));
-        templateVars.put("CCD reference", (String) caseData.get(D_8_CASE_REFERENCE));
+        templateVars.put("first name", petitionerFirstName);
+        templateVars.put("last name", petitionerLastName);
+        templateVars.put("CCD reference", ccdReference);
 
         if (StringUtils.isNotBlank(petitionerEmail)) {
             if (reasonForDivorce.equals(ADULTERY) && NO_VALUE.equalsIgnoreCase(respAdmitOrConsentToFact)) {
-                templateVars.put("relationship", relationship);
+                templateVars.put(NOTIFICATION_RELATIONSHIP_KEY, relationship);
 
                 if (StringUtils.equalsIgnoreCase(isCoRespNamed, YES_VALUE) && !StringUtils.equalsIgnoreCase(receivedAosFromCoResp, YES_VALUE)) {
                     emailService.sendEmail(petitionerEmail,
                             EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
-                            templateVars, "resp does not admit adultery update notification - no reply from co-resp");
+                            templateVars, AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED_EMAIL_DESC);
                 } else {
                     emailService.sendEmail(petitionerEmail,
                             EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
-                            templateVars, "resp does not admit adultery update notification");
+                            templateVars, AOS_RECEIVED_NO_ADMIT_ADULTERY_EMAIL_DESC);
                 }
 
             } else if (reasonForDivorce.equals(SEPARATION_2YRS)
                     && NO_VALUE.equalsIgnoreCase(respAdmitOrConsentToFact)) {
-                templateVars.put("relationship", relationship);
+                templateVars.put(NOTIFICATION_RELATIONSHIP_KEY, relationship);
 
                 emailService.sendEmail(petitionerEmail,
                         EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
-                        templateVars,
-                        "resp does not consent to 2 year separation update notification");
+                        templateVars, AOS_RECEIVED_NO_CONSENT_2_YEARS_EMAIL_DESC);
 
             } else {
-                emailService.sendEmail(petitionerEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, "generic update notification");
+                emailService.sendEmail(petitionerEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, GENERIC_UPDATE_EMAIL_DESC);
             }
         }
         return caseData;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentGenericUpdateNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentGenericUpdateNotificationEmail.java
@@ -11,45 +11,45 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 import java.util.HashMap;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_LAST_NAME_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CCD_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_EMAIL_WITH_SPACE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_FIRST_NAME_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_LAST_NAME_CCD_FIELD;
 
 @Component
-public class SendCoRespondentGenericUpdateNotificationEmail implements Task<Map<String, Object>> {
+public class SendRespondentGenericUpdateNotificationEmail implements Task<Map<String, Object>> {
 
-    private static final String EMAIL_DESC = "Generic Update Notification - CoRespondent";
+    private static final String EMAIL_DESC = "Generic Update Notification - Respondent";
 
     private final EmailService emailService;
 
     @Autowired
-    public SendCoRespondentGenericUpdateNotificationEmail(EmailService emailService) {
+    public SendRespondentGenericUpdateNotificationEmail(EmailService emailService) {
         this.emailService = emailService;
     }
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
 
-        String coRespEmail = (String) caseData.get(CO_RESP_EMAIL_ADDRESS);
-        String coRespFirstName = (String) caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME);
-        String coRespLastName = (String)  caseData.get(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME);
+        String respEmail = (String) caseData.get(RESPONDENT_EMAIL_ADDRESS);
+        String respFirstName = (String) caseData.get(RESP_FIRST_NAME_CCD_FIELD);
+        String respLastName = (String)  caseData.get(RESP_LAST_NAME_CCD_FIELD);
         String caseNumber = (String) caseData.get(D_8_CASE_REFERENCE);
 
-        if (StringUtils.isNotBlank(coRespEmail)) {
+        if (StringUtils.isNotBlank(respEmail)) {
 
             Map<String, String> templateVars = new HashMap<>();
 
-            templateVars.put(NOTIFICATION_EMAIL_WITH_SPACE, coRespEmail);
-            templateVars.put(NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY, coRespFirstName);
-            templateVars.put(NOTIFICATION_ADDRESSEE_LAST_NAME_KEY, coRespLastName);
+            templateVars.put(NOTIFICATION_EMAIL_WITH_SPACE, respEmail);
+            templateVars.put(NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY, respFirstName);
+            templateVars.put(NOTIFICATION_ADDRESSEE_LAST_NAME_KEY, respLastName);
             templateVars.put(NOTIFICATION_CCD_REFERENCE, caseNumber);
 
-            emailService.sendEmail(coRespEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, EMAIL_DESC);
+            emailService.sendEmail(respEmail, EmailTemplateNames.GENERIC_UPDATE.name(), templateVars, EMAIL_DESC);
         }
 
         return caseData;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflow.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendCoRespondentGenericUpdateNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerCertificateOfEntitlementNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendRespondentCertificateOfEntitlementNotificationEmail;
 
@@ -25,12 +26,16 @@ public class CaseLinkedForHearingWorkflow extends DefaultWorkflow<Map<String, Ob
     @Autowired
     private SendRespondentCertificateOfEntitlementNotificationEmail sendRespondentCertificateOfEntitlementNotificationEmail;
 
+    @Autowired
+    SendCoRespondentGenericUpdateNotificationEmail sendCoRespondentGenericUpdateNotificationEmail;
+
     public Map<String, Object> run(CaseDetails caseDetails) throws WorkflowException {
 
         Map<String, Object> returnedPayload = this.execute(
                 new Task[]{
                     sendPetitionerCertificateOfEntitlementNotificationEmail,
-                    sendRespondentCertificateOfEntitlementNotificationEmail
+                    sendRespondentCertificateOfEntitlementNotificationEmail,
+                    sendCoRespondentGenericUpdateNotificationEmail
                 },
             caseDetails.getCaseData(),
             ImmutablePair.of(CASE_ID_KEY, caseDetails.getCaseId()));

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflow.java
@@ -40,7 +40,7 @@ public class CaseLinkedForHearingWorkflow extends DefaultWorkflow<Map<String, Ob
             caseDetails.getCaseData(),
             ImmutablePair.of(CASE_ID_KEY, caseDetails.getCaseId()));
 
-        log.info("Running workflow for case id {}.", caseDetails.getCaseId());
+        log.info("Running CaseLinkedForHearingWorkflow for case id {}.", caseDetails.getCaseId());
 
         return returnedPayload;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflow.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerGenericUpdateNotificationEmail;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendRespondentGenericUpdateNotificationEmail;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@Component
+public class SendDnPronouncedNotificationWorkflow extends DefaultWorkflow<Map<String, Object>> {
+
+    @Autowired
+    SendPetitionerGenericUpdateNotificationEmail sendPetitionerGenericUpdateNotificationEmail;
+
+    @Autowired
+    SendRespondentGenericUpdateNotificationEmail sendRespondentGenericUpdateNotificationEmail;
+
+    public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+
+        String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
+
+        return this.execute(
+                new Task[] {
+                    sendPetitionerGenericUpdateNotificationEmail,
+                    sendRespondentGenericUpdateNotificationEmail
+                },
+                ccdCallbackRequest.getCaseDetails().getCaseData(),
+                ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
+        );
+    }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerEmailNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerEmailNotificationWorkflow.java
@@ -14,12 +14,12 @@ import java.util.Map;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
 @Component
-public class SendPetitionerGenericEmailNotificationWorkflow extends DefaultWorkflow<Map<String, Object>> {
+public class SendPetitionerEmailNotificationWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     private final SendPetitionerUpdateNotificationsEmail sendPetitionerUpdateNotificationsEmail;
 
     @Autowired
-    public SendPetitionerGenericEmailNotificationWorkflow(
+    public SendPetitionerEmailNotificationWorkflow(
             SendPetitionerUpdateNotificationsEmail sendPetitionerUpdateNotificationsEmail) {
         this.sendPetitionerUpdateNotificationsEmail = sendPetitionerUpdateNotificationsEmail;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
@@ -157,9 +157,13 @@ public class CallbackControllerTest {
             .build();
         final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
         ccdCallbackRequest.setCaseDetails(caseDetails);
+
         when(caseOrchestrationService.sendPetitionerGenericUpdateNotificationEmail(ccdCallbackRequest)).thenReturn(caseData);
+
         ResponseEntity<CcdCallbackResponse> response = classUnderTest.petitionUpdated(null, ccdCallbackRequest);
+
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
+
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(expectedResponse, response.getBody());
     }
@@ -172,6 +176,7 @@ public class CallbackControllerTest {
             .build();
         final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
         ccdCallbackRequest.setCaseDetails(caseDetails);
+
         when(caseOrchestrationService.sendRespondentSubmissionNotificationEmail(ccdCallbackRequest)).thenReturn(caseData);
 
         ResponseEntity<CcdCallbackResponse> response = classUnderTest.respondentAOSSubmitted(null, ccdCallbackRequest);
@@ -194,6 +199,25 @@ public class CallbackControllerTest {
         when(caseOrchestrationService.sendPetitionerSubmissionNotificationEmail(ccdCallbackRequest)).thenReturn(caseData);
 
         ResponseEntity<CcdCallbackResponse> response = classUnderTest.petitionSubmitted(null, ccdCallbackRequest);
+
+        CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(expectedResponse, response.getBody());
+    }
+
+    @Test
+    public void whenDnPronouncedCallback_thenReturnCcdResponse() throws Exception {
+        final Map<String, Object> caseData = Collections.emptyMap();
+        final CaseDetails caseDetails = CaseDetails.builder()
+                .caseData(caseData)
+                .build();
+        final CcdCallbackRequest ccdCallbackRequest = new CcdCallbackRequest();
+        ccdCallbackRequest.setCaseDetails(caseDetails);
+
+        when(caseOrchestrationService.sendDnPronouncedNotificationEmail(ccdCallbackRequest)).thenReturn(caseData);
+
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.dnPronounced(null, ccdCallbackRequest);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -24,8 +24,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.AmendPetitionWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.AuthenticateRespondentWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.CaseLinkedForHearingWorkflow;
-import uk.gov.hmcts.reform.divorce.orchestration.workflows.DNSubmittedWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.DeleteDraftWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.DNSubmittedWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.GenerateCoRespondentAnswersWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.GetCaseWithIdWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.GetCaseWorkflow;
@@ -38,7 +38,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.RetrieveDraftWorkflow
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SaveDraftWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendCoRespondSubmissionNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerClarificationRequestNotificationWorkflow;
-import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerGenericEmailNotificationWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerEmailNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendPetitionerSubmissionNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SendRespondentSubmissionNotificationWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SetOrderSummaryWorkflow;
@@ -112,7 +112,7 @@ public class CaseOrchestrationServiceImplTest {
     private SendPetitionerSubmissionNotificationWorkflow sendPetitionerSubmissionNotificationWorkflow;
 
     @Mock
-    private SendPetitionerGenericEmailNotificationWorkflow sendPetitionerGenericEmailNotificationWorkflow;
+    private SendPetitionerEmailNotificationWorkflow sendPetitionerEmailNotificationWorkflow;
 
     @Mock
     private SendPetitionerClarificationRequestNotificationWorkflow sendPetitionerClarificationRequestNotificationWorkflow;
@@ -543,13 +543,13 @@ public class CaseOrchestrationServiceImplTest {
     @Test
     public void givenCaseData_whenSendPetitionerGenericEmailNotification_thenReturnPayload() throws Exception {
         // given
-        when(sendPetitionerGenericEmailNotificationWorkflow.run(ccdCallbackRequest))
+        when(sendPetitionerEmailNotificationWorkflow.run(ccdCallbackRequest))
                 .thenReturn(requestPayload);
         // when
         Map<String, Object> actual = classUnderTest.sendPetitionerGenericUpdateNotificationEmail(ccdCallbackRequest);
         // then
         assertEquals(requestPayload, actual);
-        verify(sendPetitionerGenericEmailNotificationWorkflow).run(ccdCallbackRequest);
+        verify(sendPetitionerEmailNotificationWorkflow).run(ccdCallbackRequest);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendCoRespondentNotificationEmailTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
+
+@RunWith(SpringRunner.class)
+public class SendCoRespondentNotificationEmailTest {
+
+    private static final String D8_CASE_ID = "LV17D80101";
+    private static final String UNFORMATTED_CASE_ID = "0123456789";
+
+    private TaskContext context;
+    private Map<String, Object> testData;
+    private Map<String, String> expectedTemplateVars;
+
+    @Mock
+    EmailService emailService;
+
+    @InjectMocks
+    SendCoRespondentGenericUpdateNotificationEmail sendCoRespondentGenericUpdateNotificationEmail;
+
+
+    @Before
+    public void setup() {
+        testData = new HashMap<>();
+        testData.put(D_8_CASE_REFERENCE, D8_CASE_ID);
+        testData.put(CASE_ID_JSON_KEY, UNFORMATTED_CASE_ID);
+        testData.put(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_FNAME, TEST_USER_FIRST_NAME);
+        testData.put(D8_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_LNAME, TEST_USER_LAST_NAME);
+
+        context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, UNFORMATTED_CASE_ID);
+
+        expectedTemplateVars = new HashMap<>();
+
+        expectedTemplateVars.put("CCD reference", D8_CASE_ID);
+        expectedTemplateVars.put("email address", TEST_USER_EMAIL);
+        expectedTemplateVars.put("first name", TEST_USER_FIRST_NAME);
+        expectedTemplateVars.put("last name", TEST_USER_LAST_NAME);
+    }
+
+    @Test
+    public void shouldCallEmailServiceForGenericUpdateIfCoRespEmailExists() {
+
+        testData.put(CO_RESP_EMAIL_ADDRESS, TEST_USER_EMAIL);
+
+        when(emailService.sendEmail(TEST_USER_EMAIL,
+            EmailTemplateNames.GENERIC_UPDATE.name(),
+            expectedTemplateVars,
+            "Generic Update Notification - CoRespondent"))
+                .thenReturn(null);
+
+        assertEquals(testData, sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData));
+
+        verify(emailService).sendEmail(TEST_USER_EMAIL,
+            EmailTemplateNames.GENERIC_UPDATE.name(),
+            expectedTemplateVars,
+            "Generic Update Notification - CoRespondent");
+    }
+
+
+    @Test
+    public void shouldNotCallEmailServiceForCoRespGenericUpdateIfCoRespEmailDoesNotExist() {
+        // make sure it isn't triggered
+        when(emailService.sendEmail(TEST_USER_EMAIL,
+                EmailTemplateNames.GENERIC_UPDATE.name(),
+                expectedTemplateVars,
+                "Generic Update Notification - CoRespondent"))
+                .thenReturn(null);
+
+        assertEquals(testData, sendCoRespondentGenericUpdateNotificationEmail.execute(context, testData));
+
+        verifyZeroInteractions(emailService);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerNotificationEmailTest.java
@@ -108,7 +108,7 @@ public class SendPetitionerNotificationEmailTest {
         when(emailService.sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification"))
+            "Generic Update Notification - Petitioner"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -116,7 +116,7 @@ public class SendPetitionerNotificationEmailTest {
         verify(emailService).sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification");
+            "Generic Update Notification - Petitioner");
     }
 
     @Test
@@ -130,7 +130,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
                 expectedTemplateVars,
-                "resp does not admit adultery update notification"))
+                "Resp does not admit adultery update notification"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -139,7 +139,7 @@ public class SendPetitionerNotificationEmailTest {
             TEST_USER_EMAIL,
             EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY.name(),
             expectedTemplateVars,
-            "resp does not admit adultery update notification");
+            "Resp does not admit adultery update notification");
     }
 
     @Test
@@ -155,7 +155,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
                 expectedTemplateVars,
-                "resp does not admit adultery update notification - no reply from co-resp"))
+                "Resp does not admit adultery update notification - no reply from co-resp"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -164,7 +164,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED.name(),
                 expectedTemplateVars,
-                "resp does not admit adultery update notification - no reply from co-resp");
+                "Resp does not admit adultery update notification - no reply from co-resp");
     }
 
     @Test
@@ -178,7 +178,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
                 expectedTemplateVars,
-                "resp does not consent to 2 year separation update notification"))
+                "Resp does not consent to 2 year separation update notification"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -187,7 +187,7 @@ public class SendPetitionerNotificationEmailTest {
                 TEST_USER_EMAIL,
                 EmailTemplateNames.AOS_RECEIVED_NO_CONSENT_2_YEARS.name(),
                 expectedTemplateVars,
-                "resp does not consent to 2 year separation update notification");
+                "Resp does not consent to 2 year separation update notification");
     }
 
     @Test
@@ -197,7 +197,7 @@ public class SendPetitionerNotificationEmailTest {
         when(emailService.sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification"))
+            "Generic Update Notification - Petitioner"))
                 .thenReturn(null);
 
         assertEquals(testData, sendPetitionerUpdateNotificationsEmail.execute(context, testData));
@@ -205,7 +205,7 @@ public class SendPetitionerNotificationEmailTest {
         verify(emailService).sendEmail(TEST_USER_EMAIL,
             EmailTemplateNames.GENERIC_UPDATE.name(),
             expectedTemplateVars,
-            "generic update notification");
+            "Generic Update Notification - Petitioner");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CaseLinkedForHearingWorkflowTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendCoRespondentGenericUpdateNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerCertificateOfEntitlementNotificationEmail;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendRespondentCertificateOfEntitlementNotificationEmail;
 
@@ -36,6 +37,9 @@ public class CaseLinkedForHearingWorkflowTest {
     @Mock
     private SendRespondentCertificateOfEntitlementNotificationEmail sendRespondentCertificateOfEntitlementNotificationEmail;
 
+    @Mock
+    private SendCoRespondentGenericUpdateNotificationEmail sendCoRespondentGenericUpdateNotificationEmail;
+
     @InjectMocks
     private CaseLinkedForHearingWorkflow caseLinkedForHearingWorkflow;
 
@@ -51,6 +55,9 @@ public class CaseLinkedForHearingWorkflowTest {
 
         when(sendRespondentCertificateOfEntitlementNotificationEmail.execute(notNull(), eq(testPayload)))
                 .thenReturn(testPayload);
+
+        when(sendCoRespondentGenericUpdateNotificationEmail.execute(notNull(), eq(testPayload)))
+                .thenReturn(testPayload);
     }
 
     @Test
@@ -62,10 +69,16 @@ public class CaseLinkedForHearingWorkflowTest {
 
         Map<String, Object> returnedPayload = caseLinkedForHearingWorkflow.run(caseDetails);
 
-        verify(sendPetitionerCertificateOfEntitlementNotificationEmail).execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
-        verify(sendRespondentCertificateOfEntitlementNotificationEmail).execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
-
         assertThat(returnedPayload, is(equalTo(testPayload)));
+
+        verify(sendPetitionerCertificateOfEntitlementNotificationEmail)
+                .execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
+        verify(sendRespondentCertificateOfEntitlementNotificationEmail)
+                .execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
+        verify(sendCoRespondentGenericUpdateNotificationEmail)
+                .execute(contextCaptor.capture(), eq(caseDetails.getCaseData()));
+
         assertThat(contextCaptor.getValue().getTransientObject(CASE_ID_KEY), is(equalTo("testCaseId")));
+
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflowTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerGenericUpdateNotificationEmail;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendRespondentGenericUpdateNotificationEmail;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SendDnPronouncedNotificationWorkflowTest {
+
+    @Mock
+    private SendPetitionerGenericUpdateNotificationEmail sendPetitionerGenericUpdateNotificationEmail;
+
+    @Mock
+    private SendRespondentGenericUpdateNotificationEmail sendRespondentGenericUpdateNotificationEmail;
+
+    @InjectMocks
+    private SendDnPronouncedNotificationWorkflow sendDnPronouncedNotificationWorkflow;
+
+    private CcdCallbackRequest ccdCallbackRequestRequest;
+    private TaskContext context;
+    private Map<String, Object> testPayload = singletonMap("testKey", "testValue");
+
+    @Before
+    public void setup() {
+
+        CaseDetails caseDetails = CaseDetails.builder()
+                .caseId(TEST_CASE_ID)
+                .state(TEST_STATE)
+                .caseData(testPayload)
+                .build();
+        ccdCallbackRequestRequest =
+                CcdCallbackRequest.builder()
+                        .eventId(TEST_EVENT_ID)
+                        .token(TEST_TOKEN)
+                        .caseDetails(
+                                caseDetails
+                        )
+                        .build();
+
+        context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+
+        when(sendPetitionerGenericUpdateNotificationEmail.execute(notNull(), eq(testPayload)))
+                .thenReturn(testPayload);
+
+        when(sendRespondentGenericUpdateNotificationEmail.execute(notNull(), eq(testPayload)))
+                .thenReturn(testPayload);
+    }
+
+    @Test
+    public void genericEmailTaskShouldExecuteAndReturnPayload() throws Exception {
+
+        Map<String, Object> returnedPayload = sendDnPronouncedNotificationWorkflow.run(ccdCallbackRequestRequest);
+        assertThat(returnedPayload, is(equalTo(testPayload)));
+
+        verify(sendPetitionerGenericUpdateNotificationEmail).execute(context, testPayload);
+        verify(sendRespondentGenericUpdateNotificationEmail).execute(context, testPayload);
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerEmailNotificationWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendPetitionerEmailNotificationWorkflowTest.java
@@ -38,7 +38,7 @@ public class SendPetitionerEmailNotificationWorkflowTest {
     private SendPetitionerSubmissionNotificationWorkflow sendPetitionerSubmissionNotificationWorkflow;
 
     @InjectMocks
-    private SendPetitionerGenericEmailNotificationWorkflow sendPetitionerGenericEmailNotificationWorkflow;
+    private SendPetitionerEmailNotificationWorkflow sendPetitionerEmailNotificationWorkflow;
 
     private CcdCallbackRequest ccdCallbackRequestRequest;
     private Map<String, Object> testData;
@@ -70,7 +70,7 @@ public class SendPetitionerEmailNotificationWorkflowTest {
     public void genericEmailTaskShouldExecuteAndReturnPayload() throws Exception {
         when(sendPetitionerUpdateNotificationsEmail.execute(context, testData)).thenReturn(testData);
 
-        assertEquals(testData, sendPetitionerGenericEmailNotificationWorkflow.run(ccdCallbackRequestRequest));
+        assertEquals(testData, sendPetitionerEmailNotificationWorkflow.run(ccdCallbackRequestRequest));
 
         verify(sendPetitionerUpdateNotificationsEmail).execute(context, testData);
     }


### PR DESCRIPTION
# Description

Sends notification emails to both Petitioner & Respondent when DN has been pronounced and issued.

Fixes https://tools.hmcts.net/jira/browse/DIV-4828

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
