### PR TITLE
Fix 500 error on Production due to missing mandatory field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
@@ -54,7 +54,7 @@ public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, 
         String petitionerLastName = getMandatoryPropertyValueAsString(caseData, D_8_PETITIONER_LAST_NAME);
         String ccdReference = getMandatoryPropertyValueAsString(caseData, D_8_CASE_REFERENCE);
         String reasonForDivorce = getMandatoryPropertyValueAsString(caseData, D_8_REASON_FOR_DIVORCE);
-        String respAdmitOrConsentToFact = getMandatoryPropertyValueAsString(caseData, RESP_ADMIT_OR_CONSENT_TO_FACT);
+        String respAdmitOrConsentToFact = (String) caseData.get(RESP_ADMIT_OR_CONSENT_TO_FACT);
         String relationship = getMandatoryPropertyValueAsString(caseData, D_8_DIVORCED_WHO);
         String isCoRespNamed = (String) caseData.get(D_8_CO_RESPONDENT_NAMED);
         String receivedAosFromCoResp = (String) caseData.get(RECEIVED_AOS_FROM_CO_RESP);


### PR DESCRIPTION
Fixes all the 500 errors we're getting on production for http://div-cos-prod.service.core-compute-prod.internal/petition-updated

We were trying to use getMandatoryPropertyValueAsString() on a field that is not always populated with data