### PR TITLE
Retrieve case before update so HearingDateAndTime can be populated co…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/CreateBulkCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/CreateBulkCaseTest.java
@@ -49,7 +49,7 @@ public class CreateBulkCaseTest extends CcdSubmissionSupport {
 
         List<String> casesList = response.jsonPath().get("BulkCases.case_data.CaseAcceptedList[0].value.CaseReference");
         final UserDetails caseworker = createCaseWorkerUser();
-        casesList.forEach( caseId ->{
+        casesList.forEach( caseId -> {
             validateWithAwaitingTime(caseworker, caseId);
         });
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdSubmissionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdSubmissionSupport.java
@@ -70,7 +70,7 @@ public abstract class CcdSubmissionSupport extends IntegrationTest {
         final Map caseData = loadJsonToObject(BULK_PAYLOAD_CONTEXT_PATH + fileName, Map.class);
 
         Arrays.stream(additionalCaseData).forEach(
-                caseField -> caseData.put(caseField.getKey(), caseField.getValue())
+            caseField -> caseData.put(caseField.getKey(), caseField.getValue())
         );
 
         return ccdClientSupport.submitBulkCase(caseData, createCaseWorkerUser());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetCaseWithIdMapFlow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetCaseWithIdMapFlow.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@Component
+public class GetCaseWithIdMapFlow implements Task<Map<String, Object>> {
+    private final CaseMaintenanceClient caseMaintenanceClient;
+
+    private final AuthUtil authUtil;
+
+    @Autowired
+    public GetCaseWithIdMapFlow(CaseMaintenanceClient caseMaintenanceClient, AuthUtil authUtil) {
+        this.caseMaintenanceClient = caseMaintenanceClient;
+        this.authUtil = authUtil;
+    }
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> payload) throws TaskException {
+        final String caseWorkerToken = authUtil.getCaseworkerToken();
+        final String caseId = context.getTransientObject(CASE_ID_JSON_KEY);
+
+        CaseDetails caseDetails = caseMaintenanceClient.retrievePetitionById(
+                caseWorkerToken,
+                caseId
+        );
+
+        if (caseDetails == null) {
+            throw new TaskException(
+                    new CaseNotFoundException(String.format("No case found with ID [%s]", caseId))
+            );
+        }
+
+        context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
+
+        return payload;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCase.java
@@ -28,8 +28,6 @@ public class SetCourtHearingDetailsFromBulkCase implements Task<Map<String,Objec
     public Map<String, Object> execute(TaskContext context, Map<String, Object> bulkCaseData) throws TaskException {
         Map<String, Object> courtHearingDetails = new HashMap<>();
 
-        System.out.println(bulkCaseData);
-
         courtHearingDetails.put(COURT_NAME, bulkCaseData.get(COURT_NAME));
 
         Map<String, Object> dateAndTimeOfHearing = new HashMap<>();
@@ -44,8 +42,6 @@ public class SetCourtHearingDetailsFromBulkCase implements Task<Map<String,Objec
 
         CaseDetails caseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
         Map<String, Object> caseData = caseDetails.getCaseData();
-
-        System.out.println(caseData);
 
         List<CollectionMember> courtHearingCollection =
                 (ArrayList) caseData.getOrDefault(DATETIME_OF_HEARING_CCD_FIELD, new ArrayList<>());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCase.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
@@ -8,12 +9,14 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskExc
 import uk.gov.hmcts.reform.divorce.orchestration.util.DateUtils;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.COURT_HEARING_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.COURT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATETIME_OF_HEARING_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATE_OF_HEARING_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TIME_OF_HEARING_CCD_FIELD;
@@ -22,14 +25,16 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class SetCourtHearingDetailsFromBulkCase implements Task<Map<String,Object>> {
 
     @Override
-    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> bulkCaseData) throws TaskException {
         Map<String, Object> courtHearingDetails = new HashMap<>();
 
-        courtHearingDetails.put(COURT_NAME, caseData.get(COURT_NAME));
+        System.out.println(bulkCaseData);
+
+        courtHearingDetails.put(COURT_NAME, bulkCaseData.get(COURT_NAME));
 
         Map<String, Object> dateAndTimeOfHearing = new HashMap<>();
 
-        LocalDateTime hearingDateTime = LocalDateTime.parse((String) caseData.get(COURT_HEARING_DATE));
+        LocalDateTime hearingDateTime = LocalDateTime.parse((String) bulkCaseData.get(COURT_HEARING_DATE));
 
         dateAndTimeOfHearing.put(DATE_OF_HEARING_CCD_FIELD, DateUtils.formatLetterDateFromDateTime(hearingDateTime));
         dateAndTimeOfHearing.put(TIME_OF_HEARING_CCD_FIELD, DateUtils.formatLetterTimeFromDateTime(hearingDateTime));
@@ -37,7 +42,16 @@ public class SetCourtHearingDetailsFromBulkCase implements Task<Map<String,Objec
         CollectionMember<Map<String, Object>> dateAndTimeOfHearingItem = new CollectionMember<>();
         dateAndTimeOfHearingItem.setValue(dateAndTimeOfHearing);
 
-        courtHearingDetails.put(DATETIME_OF_HEARING_CCD_FIELD, Collections.singletonList(dateAndTimeOfHearingItem));
+        CaseDetails caseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
+        Map<String, Object> caseData = caseDetails.getCaseData();
+
+        System.out.println(caseData);
+
+        List<CollectionMember> courtHearingCollection =
+                (ArrayList) caseData.getOrDefault(DATETIME_OF_HEARING_CCD_FIELD, new ArrayList<>());
+        courtHearingCollection.add(dateAndTimeOfHearingItem);
+
+        courtHearingDetails.put(DATETIME_OF_HEARING_CCD_FIELD, courtHearingCollection);
 
         return courtHearingDetails;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflow.java
@@ -3,15 +3,21 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithId;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetCourtHearingDetailsFromBulkCase;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.UPDATE_COURT_HEARING_DETAILS_EVENT;
@@ -20,12 +26,25 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @AllArgsConstructor
 public class UpdateCourtHearingDetailsWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
+    private final GetCaseWithId getCaseWithId;
     private final SetCourtHearingDetailsFromBulkCase setCourtHearingDetailsFromBulkCase;
     private final UpdateCaseInCCD updateCaseInCCD;
 
     public Map<String, Object> run(Map<String, Object> bulkCaseData,
                                    String caseId,
                                    String authToken) throws WorkflowException {
+
+        UserDetails userDetails = UserDetails.builder().authToken(authToken).build();
+
+        TaskContext retrieveCaseContext = new DefaultTaskContext();
+
+        try {
+            retrieveCaseContext.setTransientObject(CASE_ID_JSON_KEY, caseId);
+            getCaseWithId.execute(retrieveCaseContext, userDetails);
+        } catch (TaskException exception) {
+            throw new WorkflowException(String.format(
+                    "Unable to retrieve case for court hearing updates with case id %s", caseId), exception);
+        }
 
         return this.execute(
                 new Task[] {
@@ -35,7 +54,8 @@ public class UpdateCourtHearingDetailsWorkflow extends DefaultWorkflow<Map<Strin
                 bulkCaseData,
                 ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
                 ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, UPDATE_COURT_HEARING_DETAILS_EVENT),
-                ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
+                ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
+                ImmutablePair.of(CASE_DETAILS_JSON_KEY, retrieveCaseContext.getTransientObject(CASE_DETAILS_JSON_KEY))
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflow.java
@@ -3,21 +3,16 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithId;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithIdMapFlow;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetCourtHearingDetailsFromBulkCase;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.UPDATE_COURT_HEARING_DETAILS_EVENT;
@@ -26,7 +21,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @AllArgsConstructor
 public class UpdateCourtHearingDetailsWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
-    private final GetCaseWithId getCaseWithId;
+    private final GetCaseWithIdMapFlow getCaseWithIdMapFlow;
     private final SetCourtHearingDetailsFromBulkCase setCourtHearingDetailsFromBulkCase;
     private final UpdateCaseInCCD updateCaseInCCD;
 
@@ -34,28 +29,16 @@ public class UpdateCourtHearingDetailsWorkflow extends DefaultWorkflow<Map<Strin
                                    String caseId,
                                    String authToken) throws WorkflowException {
 
-        UserDetails userDetails = UserDetails.builder().authToken(authToken).build();
-
-        TaskContext retrieveCaseContext = new DefaultTaskContext();
-
-        try {
-            retrieveCaseContext.setTransientObject(CASE_ID_JSON_KEY, caseId);
-            getCaseWithId.execute(retrieveCaseContext, userDetails);
-        } catch (TaskException exception) {
-            throw new WorkflowException(String.format(
-                    "Unable to retrieve case for court hearing updates with case id %s", caseId), exception);
-        }
-
         return this.execute(
                 new Task[] {
+                    getCaseWithIdMapFlow,
                     setCourtHearingDetailsFromBulkCase,
                     updateCaseInCCD
                 },
                 bulkCaseData,
                 ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
                 ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, UPDATE_COURT_HEARING_DETAILS_EVENT),
-                ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
-                ImmutablePair.of(CASE_DETAILS_JSON_KEY, retrieveCaseContext.getTransientObject(CASE_DETAILS_JSON_KEY))
+                ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseHearingDetailsITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseHearingDetailsITest.java
@@ -66,7 +66,7 @@ public class UpdateBulkCaseHearingDetailsITest extends IdamTestSupport {
 
     private static final String REQUEST_JSON_PATH = "jsonExamples/payloads/bulkCaseCcdCallbackRequest.json";
     private static final String EXPECTED_CASE_UPDATE_JSON_PATH = "jsonExamples/payloads/bulkCaseUpdateCourtHearingDetails.json";
-    private static final String EXPECTED_CASE_UPDATE_EXISTING_HEARING_JSON_PATH= "jsonExamples/payloads/bulkCaseUpdateExistingHearingDetails.json";
+    private static final String EXPECTED_CASE_UPDATE_EXISTING_HEARING_JSON_PATH = "jsonExamples/payloads/bulkCaseUpdateExistingHearingDetails.json";
     private static final String BULK_CASE_ID = "1505150515051550";
     private static final String CASE_ID_FIRST = "1558711395612316";
     private static final String CASE_ID_SECOND = "1558711407435839";
@@ -92,23 +92,25 @@ public class UpdateBulkCaseHearingDetailsITest extends IdamTestSupport {
         stubSignInForCaseworker();
 
         String retrieveCaseOnePath = String.format(CMS_RETRIEVE_CASE_PATH, CASE_ID_FIRST);
-        String retrieveCaseTwoPath = String.format(CMS_RETRIEVE_CASE_PATH, CASE_ID_SECOND);
-
-        String updateCaseOnePath = String.format(CMS_UPDATE_CASE_PATH, CASE_ID_FIRST, UPDATE_COURT_HEARING_DETAILS_EVENT);
-        String updateCaseTwoPath = String.format(CMS_UPDATE_CASE_PATH, CASE_ID_SECOND, UPDATE_COURT_HEARING_DETAILS_EVENT);
-        String updateBulkCasePath = String.format(CMS_UPDATE_BULK_CASE_PATH, BULK_CASE_ID, LISTED_EVENT);
 
         stubCmsServerEndpoint(retrieveCaseOnePath, HttpStatus.OK, caseDataToCaseDetailsJson(Collections.emptyMap()), GET);
 
         CollectionMember<Map<String, Object>> existingCourtHearing = new CollectionMember<>();
         existingCourtHearing.setId("someRandomId");
         existingCourtHearing.setValue(ImmutableMap.of(
-            DATE_OF_HEARING_CCD_FIELD, "2011-11-11",
-            TIME_OF_HEARING_CCD_FIELD, "11:11"
+                DATE_OF_HEARING_CCD_FIELD, "2011-11-11",
+                TIME_OF_HEARING_CCD_FIELD, "11:11"
         ));
         List<CollectionMember> courtHearings = Collections.singletonList(existingCourtHearing);
+
+        String retrieveCaseTwoPath = String.format(CMS_RETRIEVE_CASE_PATH, CASE_ID_SECOND);
+
         stubCmsServerEndpoint(retrieveCaseTwoPath, HttpStatus.OK,
                 caseDataToCaseDetailsJson(Collections.singletonMap(DATETIME_OF_HEARING_CCD_FIELD, courtHearings)), GET);
+
+        String updateCaseOnePath = String.format(CMS_UPDATE_CASE_PATH, CASE_ID_FIRST, UPDATE_COURT_HEARING_DETAILS_EVENT);
+        String updateCaseTwoPath = String.format(CMS_UPDATE_CASE_PATH, CASE_ID_SECOND, UPDATE_COURT_HEARING_DETAILS_EVENT);
+        String updateBulkCasePath = String.format(CMS_UPDATE_BULK_CASE_PATH, BULK_CASE_ID, LISTED_EVENT);
 
         stubCmsServerEndpoint(updateCaseOnePath, HttpStatus.OK, "{}", POST);
         stubCmsServerEndpoint(updateCaseTwoPath, HttpStatus.OK, "{}", POST);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseHearingDetailsITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseHearingDetailsITest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -22,6 +23,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
+import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -30,11 +38,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.awaitility.Awaitility.await;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.LISTED_EVENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATETIME_OF_HEARING_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATE_OF_HEARING_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TIME_OF_HEARING_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.UPDATE_COURT_HEARING_DETAILS_EVENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ResourceLoader.loadResourceAsString;
 
@@ -48,11 +60,13 @@ public class UpdateBulkCaseHearingDetailsITest extends IdamTestSupport {
 
     private static final String API_URL = "/bulk/schedule/listing";
 
+    private static final String CMS_RETRIEVE_CASE_PATH = "/casemaintenance/version/1/case/%s";
     private static final String CMS_UPDATE_CASE_PATH = "/casemaintenance/version/1/updateCase/%s/%s";
     private static final String CMS_UPDATE_BULK_CASE_PATH = "/casemaintenance/version/1/bulk/updateCase/%s/%s";
 
     private static final String REQUEST_JSON_PATH = "jsonExamples/payloads/bulkCaseCcdCallbackRequest.json";
     private static final String EXPECTED_CASE_UPDATE_JSON_PATH = "jsonExamples/payloads/bulkCaseUpdateCourtHearingDetails.json";
+    private static final String EXPECTED_CASE_UPDATE_EXISTING_HEARING_JSON_PATH= "jsonExamples/payloads/bulkCaseUpdateExistingHearingDetails.json";
     private static final String BULK_CASE_ID = "1505150515051550";
     private static final String CASE_ID_FIRST = "1558711395612316";
     private static final String CASE_ID_SECOND = "1558711407435839";
@@ -75,9 +89,26 @@ public class UpdateBulkCaseHearingDetailsITest extends IdamTestSupport {
 
     @Test
     public void givenCallbackRequestWithTwoCaseLinks_thenTriggerBulkCaseUpdateEvent() throws Exception {
+        stubSignInForCaseworker();
+
+        String retrieveCaseOnePath = String.format(CMS_RETRIEVE_CASE_PATH, CASE_ID_FIRST);
+        String retrieveCaseTwoPath = String.format(CMS_RETRIEVE_CASE_PATH, CASE_ID_SECOND);
+
         String updateCaseOnePath = String.format(CMS_UPDATE_CASE_PATH, CASE_ID_FIRST, UPDATE_COURT_HEARING_DETAILS_EVENT);
         String updateCaseTwoPath = String.format(CMS_UPDATE_CASE_PATH, CASE_ID_SECOND, UPDATE_COURT_HEARING_DETAILS_EVENT);
         String updateBulkCasePath = String.format(CMS_UPDATE_BULK_CASE_PATH, BULK_CASE_ID, LISTED_EVENT);
+
+        stubCmsServerEndpoint(retrieveCaseOnePath, HttpStatus.OK, caseDataToCaseDetailsJson(Collections.emptyMap()), GET);
+
+        CollectionMember<Map<String, Object>> existingCourtHearing = new CollectionMember<>();
+        existingCourtHearing.setId("someRandomId");
+        existingCourtHearing.setValue(ImmutableMap.of(
+            DATE_OF_HEARING_CCD_FIELD, "2011-11-11",
+            TIME_OF_HEARING_CCD_FIELD, "11:11"
+        ));
+        List<CollectionMember> courtHearings = Collections.singletonList(existingCourtHearing);
+        stubCmsServerEndpoint(retrieveCaseTwoPath, HttpStatus.OK,
+                caseDataToCaseDetailsJson(Collections.singletonMap(DATETIME_OF_HEARING_CCD_FIELD, courtHearings)), GET);
 
         stubCmsServerEndpoint(updateCaseOnePath, HttpStatus.OK, "{}", POST);
         stubCmsServerEndpoint(updateCaseTwoPath, HttpStatus.OK, "{}", POST);
@@ -93,7 +124,8 @@ public class UpdateBulkCaseHearingDetailsITest extends IdamTestSupport {
         waitAsyncCompleted();
 
         verifyCmsServerEndpoint(1, updateCaseOnePath, RequestMethod.POST, loadResourceAsString(EXPECTED_CASE_UPDATE_JSON_PATH));
-        verifyCmsServerEndpoint(1, updateCaseTwoPath, RequestMethod.POST, loadResourceAsString(EXPECTED_CASE_UPDATE_JSON_PATH));
+        verifyCmsServerEndpoint(1, updateCaseTwoPath, RequestMethod.POST,
+                loadResourceAsString(EXPECTED_CASE_UPDATE_EXISTING_HEARING_JSON_PATH));
         verifyCmsServerEndpoint(1, updateBulkCasePath, RequestMethod.POST, "{}");
     }
 
@@ -113,5 +145,11 @@ public class UpdateBulkCaseHearingDetailsITest extends IdamTestSupport {
         cmsServiceServer.verify(times, new RequestPatternBuilder(method, urlEqualTo(path))
                 .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE))
                 .withRequestBody(equalToJson(body)));
+    }
+
+    private String caseDataToCaseDetailsJson(Map<String, Object> caseData) {
+        return ObjectMapperTestUtil.convertObjectToJsonString(
+            CaseDetails.builder().caseData(caseData).build()
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetCaseWithIdMapFlowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetCaseWithIdMapFlowTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.CASEWORKER_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_COURT;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_DIVORCE_UNIT;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetCaseWithIdMapFlowTest {
+    @Mock
+    private CaseMaintenanceClient caseMaintenanceClient;
+    @Mock
+    private AuthUtil authUtil;
+
+    @InjectMocks
+    private GetCaseWithIdMapFlow classUnderTest;
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void givenNoCaseExists_whenGetCase_thenReturnThrowException() throws TaskException {
+
+        final DefaultTaskContext context = new DefaultTaskContext();
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+
+        Mockito.when(authUtil.getCaseworkerToken()).thenReturn(CASEWORKER_AUTH_TOKEN);
+        Mockito.when(caseMaintenanceClient.retrievePetitionById(CASEWORKER_AUTH_TOKEN, TEST_CASE_ID))
+                .thenReturn(null);
+        final String exceptionMessage = String.format("No case found with ID [%s]", TEST_CASE_ID);
+
+        thrown.expect(TaskException.class);
+        thrown.expectCause(IsInstanceOf.instanceOf(CaseNotFoundException.class));
+        thrown.expectMessage(exceptionMessage);
+
+        classUnderTest.execute(context, Collections.emptyMap());
+
+        verify(caseMaintenanceClient).retrievePetitionById(CASEWORKER_AUTH_TOKEN, TEST_CASE_ID);
+    }
+
+    @Test
+    public void givenCaseExists_whenGetCase_thenReturnExpectedOutput() throws TaskException {
+        final DefaultTaskContext context = new DefaultTaskContext();
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        final CaseDetails cmsResponse =
+                CaseDetails.builder()
+                        .caseData(Collections.singletonMap(D_8_DIVORCE_UNIT, TEST_COURT))
+                        .caseId(TEST_CASE_ID)
+                        .state(TEST_STATE)
+                        .build();
+
+        Mockito.when(caseMaintenanceClient.retrievePetitionById(CASEWORKER_AUTH_TOKEN, TEST_CASE_ID))
+                .thenReturn(cmsResponse);
+        Mockito.when(authUtil.getCaseworkerToken()).thenReturn(CASEWORKER_AUTH_TOKEN);
+
+        classUnderTest.execute(context, Collections.emptyMap());
+
+        assertEquals(cmsResponse, context.getTransientObject(CASE_DETAILS_JSON_KEY));
+
+        verify(caseMaintenanceClient).retrievePetitionById(CASEWORKER_AUTH_TOKEN, TEST_CASE_ID);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCaseTest.java
@@ -1,21 +1,26 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.COURT_HEARING_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.COURT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATETIME_OF_HEARING_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATE_OF_HEARING_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TIME_OF_HEARING_CCD_FIELD;
@@ -31,12 +36,23 @@ public class SetCourtHearingDetailsFromBulkCaseTest {
     @InjectMocks
     private SetCourtHearingDetailsFromBulkCase classUnderTest;
 
+    private TaskContext context;
+
+    @Before
+    public void setup() {
+        context = new DefaultTaskContext();
+    }
+
     @Test
     public void givenCourtHearingDetailsFromBulkCase_whenSetCourtHearingDetailsOnCcdCase_thenReturnFormattedData() throws TaskException {
         Map<String, Object> caseData = ImmutableMap.of(
             COURT_NAME, courtName,
             COURT_HEARING_DATE, courtHearingDateTime
         );
+
+        CaseDetails caseDetails = CaseDetails.builder()
+                .caseData(Collections.emptyMap())
+                .build();
 
         CollectionMember<Map<String, Object>> expectedDateTimeCollection = new CollectionMember<>();
         expectedDateTimeCollection.setValue(ImmutableMap.of(
@@ -49,7 +65,45 @@ public class SetCourtHearingDetailsFromBulkCaseTest {
             DATETIME_OF_HEARING_CCD_FIELD, Collections.singletonList(expectedDateTimeCollection)
         );
 
-        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
+
+        assertEquals(expectedResult, classUnderTest.execute(context, caseData));
+    }
+
+    @Test
+    public void givenCourtHearingDetailsFromBulkCase_whenSetCourtHearingDetailsOnCcdCaseWithExistingHearing_thenReturnFormattedData() throws TaskException {
+        Map<String, Object> caseData = ImmutableMap.of(
+                COURT_NAME, courtName,
+                COURT_HEARING_DATE, courtHearingDateTime
+        );
+
+        CollectionMember<Map<String, Object>> existingDateTimeCollection = new CollectionMember<>();
+        existingDateTimeCollection.setValue(ImmutableMap.of(
+                DATE_OF_HEARING_CCD_FIELD, "1999-10-10",
+                TIME_OF_HEARING_CCD_FIELD, "12:55"
+        ));
+
+        List<CollectionMember> courtHearings = new ArrayList<>();
+        courtHearings.add(existingDateTimeCollection);
+
+        CaseDetails caseDetails = CaseDetails.builder()
+                .caseData(Collections.singletonMap(DATETIME_OF_HEARING_CCD_FIELD, courtHearings))
+                .build();
+
+        CollectionMember<Map<String, Object>> newDateTimeCollection = new CollectionMember<>();
+        newDateTimeCollection.setValue(ImmutableMap.of(
+                DATE_OF_HEARING_CCD_FIELD, courtHearingDate,
+                TIME_OF_HEARING_CCD_FIELD, courtHearingTime
+        ));
+
+        courtHearings.add(newDateTimeCollection);
+
+        Map<String, Object> expectedResult = ImmutableMap.of(
+                COURT_NAME, courtName,
+                DATETIME_OF_HEARING_CCD_FIELD, courtHearings
+        );
+
+        context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
 
         assertEquals(expectedResult, classUnderTest.execute(context, caseData));
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflowTest.java
@@ -6,7 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithId;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetCourtHearingDetailsFromBulkCase;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 
@@ -35,16 +34,8 @@ public class UpdateCourtHearingDetailsWorkflowTest {
     private UpdateCourtHearingDetailsWorkflow classUnderTest;
 
     @Test
-    public void setCourtHearingDetailsFromBulkCase_thenProceedAsExpected() throws WorkflowException {
-        final Task[] tasks = new Task[] {
-            getCaseWithId,
-            setCourtHearingDetailsFromBulkCase,
-            updateCaseInCCD
-        };
-
+    public void setCourtHearingDetailsFromBulkCase_thenProceedAsExpected() throws TaskException, WorkflowException {
         Map<String, Object> expected = Collections.emptyMap();
-
-        when(classUnderTest.execute(tasks, Collections.emptyMap())).thenReturn(expected);
 
         Map<String, Object> actual = classUnderTest.run(Collections.emptyMap(), TEST_CASE_ID, AUTH_TOKEN);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflowTest.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithId;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetCourtHearingDetailsFromBulkCase;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateCourtHearingDetailsWorkflowTest {
+
+    @Mock
+    private GetCaseWithId getCaseWithId;
+
+    @Mock
+    private SetCourtHearingDetailsFromBulkCase setCourtHearingDetailsFromBulkCase;
+
+    @Mock
+    private UpdateCaseInCCD updateCaseInCCD;
+
+    @InjectMocks
+    private UpdateCourtHearingDetailsWorkflow classUnderTest;
+
+    @Test
+    public void setCourtHearingDetailsFromBulkCase_thenProceedAsExpected() throws WorkflowException {
+        final Task[] tasks = new Task[] {
+            getCaseWithId,
+            setCourtHearingDetailsFromBulkCase,
+            updateCaseInCCD
+        };
+
+        Map<String, Object> expected = Collections.emptyMap();
+
+        when(classUnderTest.execute(tasks, Collections.emptyMap())).thenReturn(expected);
+
+        Map<String, Object> actual = classUnderTest.run(Collections.emptyMap(), TEST_CASE_ID, AUTH_TOKEN);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateCourtHearingDetailsWorkflowTest.java
@@ -7,7 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithId;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithIdMapFlow;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetCourtHearingDetailsFromBulkCase;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_
 public class UpdateCourtHearingDetailsWorkflowTest {
 
     @Mock
-    private GetCaseWithId getCaseWithId;
+    private GetCaseWithIdMapFlow getCaseWithIdMapFlow;
 
     @Mock
     private SetCourtHearingDetailsFromBulkCase setCourtHearingDetailsFromBulkCase;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ValidateBulkCaseListingWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ValidateBulkCaseListingWorkflowTest.java
@@ -25,7 +25,7 @@ public class ValidateBulkCaseListingWorkflowTest {
     private ValidateBulkCaseListingWorkflow classUnderTest;
 
     @Test
-    public void whenvalidateBulkCaseListingData_thenProcessAsExpected() throws WorkflowException {
+    public void whenValidateBulkCaseListingData_thenProcessAsExpected() throws WorkflowException {
         final Task[] tasks = new Task[]{
             validateBulkCourtHearingDate
         };

--- a/src/test/resources/jsonExamples/payloads/bulkCaseUpdateExistingHearingDetails.json
+++ b/src/test/resources/jsonExamples/payloads/bulkCaseUpdateExistingHearingDetails.json
@@ -1,0 +1,19 @@
+{
+  "CourtName": "Name of Court",
+  "DateAndTimeOfHearing": [
+    {
+      "id": "someRandomId",
+      "value": {
+        "DateOfHearing": "2011-11-11",
+        "TimeOfHearing": "11:11"
+      }
+    },
+    {
+      "id": null,
+      "value": {
+        "DateOfHearing": "2000-01-01",
+        "TimeOfHearing": "10:20"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
…rrectly

# Description

Fixes a bug in the workflow where if a case had an existing DateAndTimeOfHearing field, the old values would be overridden, but then CCD would throw an error due to a missing DELETE permission.
This change appends new Court Hearing Date Times to the existing field if it already exists.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
