### PR TITLE
DIV-4827 DN Pronouncement Date Calculations

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/UpdateBulkCaseDnPronouncementDateTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/UpdateBulkCaseDnPronouncementDateTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.divorce.callback;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class UpdateBulkCaseDnPronouncementDateTest extends IntegrationTest {
+
+    @Autowired
+    private CosApiClient cosApiClient;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void whenCaseLinkedForHearingIsCalledBack_thenReturnAOSData() {
+        CaseDetails caseDetails = CaseDetails.builder()
+                .caseData(Collections.singletonMap("hearingDate", "2000-01-01T10:20:55.000"))
+                .build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
+        Map<String, Object> response = cosApiClient.bulkPronouncement(ccdCallbackRequest);
+
+        Map<String, Object> responseData = (Map<String, Object>) response.get(DATA);
+        assertEquals(responseData.get("DecreeNisiGrantedDate"), "2000-01-01");
+        assertEquals(responseData.get("DAEligibleFromDate"), "2000-02-13");
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -103,4 +103,10 @@ public interface CosApiClient {
     Map<String, Object> caseLinkedForHearing(@RequestHeader(AUTHORIZATION) String authorisation,
                                              @RequestBody Map<String, Object> caseDataContent);
 
+    @RequestMapping(
+            method = RequestMethod.POST,
+            value = "/bulk/pronounce/submit"
+    )
+    Map<String, Object> bulkPronouncement(@RequestBody CcdCallbackRequest ccdCallbackRequest);
+
 }

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -50,6 +50,7 @@ case.orchestration.retrieve-case.context-path=/retrieve-case
 case.orchestration.payment-update.context-path=/payment-update
 case.orchestration.amend-petition.context-path=/amend-petition
 case.orchestration.co-respondent-generate-answers.context-path=/co-respondent-generate-answers
+case.orchestration.update-bulk-pronouncement-date.context-path=/bulk/pronounce/submit
 
 ###############################################
 #  Case Maintenance                           #

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
@@ -77,4 +77,17 @@ public class BulkCaseController {
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
     }
+
+    @PostMapping(path = "/bulk/pronounce/submit")
+    @ApiOperation(value = "Callback to set required data on case when DN Pronounced")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Required pronouncement data has been set successfully"),
+            @ApiResponse(code = 400, message = "Bad Request")})
+    public ResponseEntity<CcdCallbackResponse> updateCaseDnPronounce(
+            @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+
+        return ResponseEntity.ok(CcdCallbackResponse.builder()
+                .data(orchestrationService.updateBulkCaseDnPronounce(ccdCallbackRequest.getCaseDetails().getCaseData()))
+                .build());
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -74,6 +74,8 @@ public class OrchestrationConstants {
     public static final String UPDATE_COURT_HEARING_DETAILS_EVENT = "updateBulkCaseHearingDetails";
     public static final String WHO_PAYS_COSTS_CCD_FIELD = "WhoPaysCosts";
     public static final String WHO_PAYS_CCD_CODE_FOR_RESPONDENT = "respondent";
+    public static final String DECREE_NISI_GRANTED_DATE_KEY = "DecreeNisiGrantedDate";
+    public static final String DECREE_ABSOLUTE_ELIGIBLE_DATE = "DAEligibleFromDate";
 
     //CCD DN fields
     public static final String DN_APPROVAL_DATE_CCD_FIELD = "DNApprovalDate";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -98,4 +98,6 @@ public interface CaseOrchestrationService {
     Map<String, Object> validateBulkCaseListingData(Map<String, Object> caseData) throws WorkflowException;
 
     Map<String, Object> processCaseBeforeDecreeNisiIsGranted(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException;
+
+    Map<String, Object> updateBulkCaseDnPronounce(Map<String, Object> caseData) throws WorkflowException;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -48,6 +48,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitCoRespondentAos
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDnCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitRespondentAosCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitToCCDWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdateBulkCaseDnPronounceWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdateToCCDWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.ValidateBulkCaseListingWorkflow;
 
@@ -110,6 +111,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     private final BulkCaseUpdateHearingDetailsEventWorkflow bulkCaseUpdateHearingDetailsEventWorkflow;
     private final ValidateBulkCaseListingWorkflow validateBulkCaseListingWorkflow;
     private final DecreeNisiAboutToBeGrantedWorkflow decreeNisiAboutToBeGrantedWorkflow;
+    private final UpdateBulkCaseDnPronounceWorkflow updateBulkCaseDnPronounceWorkflow;
 
     @Override
     public Map<String, Object> handleIssueEventCallback(CcdCallbackRequest ccdCallbackRequest,
@@ -517,6 +519,6 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
 
     @Override
     public Map<String, Object> updateBulkCaseDnPronounce(Map<String, Object> caseData) throws WorkflowException {
-        return validateBulkCaseListingWorkflow.run(caseData);
+        return updateBulkCaseDnPronounceWorkflow.run(caseData);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -515,4 +515,8 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
         }
     }
 
+    @Override
+    public Map<String, Object> updateBulkCaseDnPronounce(Map<String, Object> caseData) throws WorkflowException {
+        return validateBulkCaseListingWorkflow.run(caseData);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetCourtHearingDetailsFromBulkCase.java
@@ -34,8 +34,8 @@ public class SetCourtHearingDetailsFromBulkCase implements Task<Map<String,Objec
 
         LocalDateTime hearingDateTime = LocalDateTime.parse((String) bulkCaseData.get(COURT_HEARING_DATE));
 
-        dateAndTimeOfHearing.put(DATE_OF_HEARING_CCD_FIELD, DateUtils.formatLetterDateFromDateTime(hearingDateTime));
-        dateAndTimeOfHearing.put(TIME_OF_HEARING_CCD_FIELD, DateUtils.formatLetterTimeFromDateTime(hearingDateTime));
+        dateAndTimeOfHearing.put(DATE_OF_HEARING_CCD_FIELD, DateUtils.formatDateFromDateTime(hearingDateTime));
+        dateAndTimeOfHearing.put(TIME_OF_HEARING_CCD_FIELD, DateUtils.formatTimeFromDateTime(hearingDateTime));
 
         CollectionMember<Map<String, Object>> dateAndTimeOfHearingItem = new CollectionMember<>();
         dateAndTimeOfHearingItem.setValue(dateAndTimeOfHearing);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnGrantedDate.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnGrantedDate.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
+import uk.gov.hmcts.reform.divorce.orchestration.util.DateUtils;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.COURT_HEARING_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_ELIGIBLE_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_GRANTED_DATE_KEY;
+
+@Component
+public class SetDnGrantedDate implements Task<Map<String,Object>> {
+
+    @Autowired
+    CcdUtil ccdUtil;
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {
+
+        // Decree Nisi Granted Date is the same date as the Court Hearing Date at the time of Pronouncement
+        LocalDateTime hearingDateTime = LocalDateTime.parse((String) caseData.get(COURT_HEARING_DATE));
+        caseData.put(DECREE_NISI_GRANTED_DATE_KEY, DateUtils.formatDateFromDateTime(hearingDateTime));
+
+        // Decree Absolute Eligible Date is 6 weeks and 1 day from the Pronouncement date
+        caseData.put(DECREE_ABSOLUTE_ELIGIBLE_DATE, ccdUtil.parseDecreeAbsoluteEligibleDate(hearingDateTime.toLocalDate()));
+
+        return caseData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
@@ -47,4 +47,10 @@ public class CcdUtil {
     public boolean isCcdDateTimeInThePast(String date) {
         return LocalDateTime.parse(date).toLocalDate().isBefore(LocalDate.now(clock).plusDays(1));
     }
+
+    public String parseDecreeAbsoluteEligibleDate(LocalDate grantedDate) {
+        return DateUtils.formatDateFromLocalDate(
+                grantedDate.plusWeeks(6).plusDays(1)
+        );
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/DateUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/DateUtils.java
@@ -16,11 +16,15 @@ public class DateUtils {
         return date.format(CLIENT_FACING_DATE_FORMAT);
     }
 
-    public static String formatLetterDateFromDateTime(LocalDateTime dateTime) {
-        return dateTime.toLocalDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    public static String formatDateFromLocalDate(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 
-    public static String formatLetterTimeFromDateTime(LocalDateTime dateTime) {
+    public static String formatDateFromDateTime(LocalDateTime dateTime) {
+        return formatDateFromLocalDate(dateTime.toLocalDate());
+    }
+
+    public static String formatTimeFromDateTime(LocalDateTime dateTime) {
         return dateTime.toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateBulkCaseDnPronounceWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateBulkCaseDnPronounceWorkflow.java
@@ -1,38 +1,27 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateBulkCaseInCcd;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetDnGrantedDate;
 
 import java.util.Map;
-
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
 @Component
 public class UpdateBulkCaseDnPronounceWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     @Autowired
-    private UpdateBulkCaseInCcd updateBulkCaseInCcd;
+    private SetDnGrantedDate setDnGrantedDate;
 
-    public Map<String, Object> run(Map<String, Object> payload,
-                                   String authToken,
-                                   String caseId,
-                                   String eventId) throws WorkflowException {
+    public Map<String, Object> run(Map<String, Object> payload) throws WorkflowException {
 
         return this.execute(
                 new Task[] {
-                        updateBulkCaseInCcd
+                    setDnGrantedDate
                 },
-                payload,
-                ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
-                ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
-                ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, eventId)
+                payload
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateBulkCaseDnPronounceWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateBulkCaseDnPronounceWorkflow.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateBulkCaseInCcd;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+
+@Component
+public class UpdateBulkCaseDnPronounceWorkflow extends DefaultWorkflow<Map<String, Object>> {
+
+    @Autowired
+    private UpdateBulkCaseInCcd updateBulkCaseInCcd;
+
+    public Map<String, Object> run(Map<String, Object> payload,
+                                   String authToken,
+                                   String caseId,
+                                   String eventId) throws WorkflowException {
+
+        return this.execute(
+                new Task[] {
+                        updateBulkCaseInCcd
+                },
+                payload,
+                ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
+                ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
+                ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, eventId)
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseControllerTest.java
@@ -58,7 +58,7 @@ public class BulkCaseControllerTest {
     }
 
     @Test
-    public void whenvalidateBulkCaseListingData_thenReturnExpectedResponse() throws WorkflowException {
+    public void whenValidateBulkCaseListingData_thenReturnExpectedResponse() throws WorkflowException {
         CaseDetails caseDetails = CaseDetails.builder().caseData(Collections.emptyMap()).build();
         CcdCallbackRequest request = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
 
@@ -72,7 +72,7 @@ public class BulkCaseControllerTest {
     }
 
     @Test
-    public void whenvalidateBulkCaseListingDataThrowsError_thenReturnExpectedResponse() throws WorkflowException {
+    public void whenValidateBulkCaseListingDataThrowsError_thenReturnExpectedResponse() throws WorkflowException {
         CaseDetails caseDetails = CaseDetails.builder().caseData(Collections.emptyMap()).build();
         CcdCallbackRequest request = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
         String error = "error has occurred";
@@ -84,5 +84,19 @@ public class BulkCaseControllerTest {
 
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
         assertThat(response.getBody(), is(CcdCallbackResponse.builder().errors(Collections.singletonList(error)).build()));
+    }
+
+    @Test
+    public void whenUpdateBulkCasePronouncementDate_thenReturnExpectedResponse() throws WorkflowException {
+        CaseDetails caseDetails = CaseDetails.builder().caseData(Collections.emptyMap()).build();
+        CcdCallbackRequest request = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
+
+        when(caseOrchestrationService.updateBulkCaseDnPronounce(Collections.emptyMap()))
+                .thenReturn(Collections.emptyMap());
+
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.updateCaseDnPronounce(request);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(CcdCallbackResponse.builder().data(Collections.emptyMap()).build()));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseDnPronouncementDateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseDnPronouncementDateITest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ResourceLoader.loadResourceAsString;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = OrchestrationServiceApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@PropertySource(value = "classpath:application.yml")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@AutoConfigureMockMvc
+public class UpdateBulkCaseDnPronouncementDateITest extends IdamTestSupport {
+
+    private static final String API_URL = "/bulk/pronounce/submit";
+
+    private static final String REQUEST_JSON_PATH = "jsonExamples/payloads/bulkCaseCcdCallbackRequest.json";
+
+    private static final String TEST_AUTH_TOKEN = "testAuthToken";
+
+    @Autowired
+    private MockMvc webClient;
+
+    @Test
+    public void givenCallbackRequestWithCourtHearingBulkCaseData_thenReturnCallbackResponse() throws Exception {
+        // Matching request json
+        String courtHearingDate = "2000-01-01";
+        String eligibleDate = "2000-02-13";
+        webClient.perform(MockMvcRequestBuilders.post(API_URL)
+                .header(AUTHORIZATION, TEST_AUTH_TOKEN)
+                .content(loadResourceAsString(REQUEST_JSON_PATH))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.DecreeNisiGrantedDate", equalTo(courtHearingDate)))
+                .andExpect(jsonPath("$.data.DAEligibleFromDate", equalTo(eligibleDate)))
+                .andExpect(jsonPath("$.errors", nullValue()));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -51,6 +51,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitCoRespondentAos
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDnCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitRespondentAosCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitToCCDWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdateBulkCaseDnPronounceWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdateToCCDWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.ValidateBulkCaseListingWorkflow;
 
@@ -186,6 +187,9 @@ public class CaseOrchestrationServiceImplTest {
 
     @Mock
     private DecreeNisiAboutToBeGrantedWorkflow decreeNisiAboutToBeGrantedWorkflow;
+
+    @Mock
+    private UpdateBulkCaseDnPronounceWorkflow updateBulkCaseDnPronounceWorkflow;
 
     @InjectMocks
     private CaseOrchestrationServiceImpl classUnderTest;
@@ -894,6 +898,16 @@ public class CaseOrchestrationServiceImplTest {
         expectedException.expectCause(is(instanceOf(WorkflowException.class)));
 
         classUnderTest.processCaseBeforeDecreeNisiIsGranted(ccdCallbackRequest);
+    }
+
+    @Test
+    public void shouldCallWorkflow_ForBulkCaseUpdatePronouncementDate() throws WorkflowException, CaseOrchestrationServiceException {
+        when(updateBulkCaseDnPronounceWorkflow.run(ccdCallbackRequest.getCaseDetails().getCaseData()))
+                .thenReturn(singletonMap("returnedKey", "returnedValue"));
+
+        Map<String, Object> returnedPayload = classUnderTest.updateBulkCaseDnPronounce(ccdCallbackRequest.getCaseDetails().getCaseData());
+
+        assertThat(returnedPayload, hasEntry("returnedKey", "returnedValue"));
     }
 
     @After

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnGrantedDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnGrantedDateTest.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.COURT_HEARING_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_ELIGIBLE_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_GRANTED_DATE_KEY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetDnGrantedDateTest {
+
+    @Mock
+    private CcdUtil ccdUtil;
+
+    @InjectMocks
+    private SetDnGrantedDate setDnGrantedDate;
+
+    @Test
+    public void testGenerateIssueDateSetsDateToNow() throws TaskException {
+        HashMap<String, Object> payload = new HashMap<>();
+        payload.put(COURT_HEARING_DATE, "2000-01-01T10:20:55.000");
+
+        LocalDate courtHearingLocalDate = LocalDate.of(2000, 1, 1);
+        when(ccdUtil.parseDecreeAbsoluteEligibleDate(courtHearingLocalDate)).thenCallRealMethod();
+
+        setDnGrantedDate.execute(null, payload);
+
+        String expectedGrantedDate = "2000-01-01";
+        String expectedEligibleDate = "2000-02-13";
+
+        assertEquals(expectedGrantedDate, payload.get(DECREE_NISI_GRANTED_DATE_KEY));
+        assertEquals(expectedEligibleDate, payload.get(DECREE_ABSOLUTE_ELIGIBLE_DATE));
+        verify(ccdUtil).parseDecreeAbsoluteEligibleDate(courtHearingLocalDate);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
@@ -85,4 +85,13 @@ public class CcdUtilUTest {
         String futureDate = LocalDateTime.now(clock).plusMonths(1).toString();
         assertEquals(false, ccdUtil.isCcdDateTimeInThePast(futureDate));
     }
+
+    @Test
+    public void givenLocalDate_whenParseDecreeAbsoluteEligibleDate_thenReturnParsedDateString() {
+        LocalDate hearingDate = LocalDate.of(2000, 1, 1);
+        // 6 weeks and 1 day
+        String expectedDate = "2000-02-13";
+
+        assertEquals(expectedDate, ccdUtil.parseDecreeAbsoluteEligibleDate(hearingDate));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateBulkCaseDnPronounceWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/UpdateBulkCaseDnPronounceWorkflowTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetDnGrantedDate;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateBulkCaseDnPronounceWorkflowTest {
+
+    @Mock
+    SetDnGrantedDate setDnGrantedDate;
+
+    @InjectMocks
+    UpdateBulkCaseDnPronounceWorkflow updateBulkCaseDnPronounceWorkflow;
+
+    private TaskContext context;
+    private Map<String, Object> testData;
+
+    @Before
+    public void setup() {
+        context = new DefaultTaskContext();
+        testData = Collections.emptyMap();
+    }
+
+    @Test
+    public void runShouldExecuteTasksAndReturnPayload() throws Exception {
+        when(setDnGrantedDate.execute(context, testData)).thenReturn(testData);
+
+        assertEquals(testData, updateBulkCaseDnPronounceWorkflow.run(testData));
+
+        verify(setDnGrantedDate).execute(context, testData);
+    }
+}


### PR DESCRIPTION
# Description

[DIV-4827](https://tools.hmcts.net/jira/browse/DIV-4827)

When DN Pronouncement event is triggered on the bulk case, this will trigger a callback that sets the DecreeNisiGrantedDate field to be equal to the hearingDate filed (but only date component, ignoring the time).
It will also set the DAEligibleFromDate field (set six weeks and 1 day from the DecreeNisiGrantedDate) so it can be easily used by the next story to update all individual cases within the bulk case with the same data.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
