### PR TITLE
DIV-5111 Add Submit DA Endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDaCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDaCaseTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 public class SubmitDaCaseTest extends CcdSubmissionSupport {
@@ -29,6 +30,7 @@ public class SubmitDaCaseTest extends CcdSubmissionSupport {
     public void givenUserTokenIsNull_whenSubmitDa_thenReturnBadRequest() throws Exception {
         try {
             cosApiClient.submitDaCase(null, Collections.emptyMap(), TEST_CASE_ID);
+            fail();
         } catch (FeignException exception) {
             assertEquals(BAD_REQUEST.value(), exception.status());
         }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDaCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDaCaseTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.divorce.maintenance;
+
+import feign.FeignException;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
+import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class SubmitDaCaseTest extends CcdSubmissionSupport {
+
+    private static final String TEST_CASE_ID = "1234567890123456";
+    private static final String STATE_JSON_KEY = "state";
+    private static final String DA_REQUESTED_STATE = "DARequested";
+    private static final String UPDATE_TO_DN_PRONOUNCED_EVENT_ID = "testDNPronounced";
+    private static final String UPDATE_TO_AWAITING_DA_EVENT_ID = "MakeEligibleForDA_Petitioner";
+
+    @Autowired
+    private CosApiClient cosApiClient;
+
+    @Test
+    public void givenUserTokenIsNull_whenSubmitDa_thenReturnBadRequest() throws Exception {
+        try {
+            cosApiClient.submitDaCase(null, Collections.emptyMap(), TEST_CASE_ID);
+        } catch (FeignException exception) {
+            assertEquals(BAD_REQUEST.value(), exception.status());
+        }
+    }
+
+    @Test
+    public void whenSubmitDa_thenProceedAsExpected() throws Exception {
+        final UserDetails userDetails = createCitizenUser();
+
+        final CaseDetails caseDetails = submitCase("submit-complete-case.json", userDetails);
+
+        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, UPDATE_TO_DN_PRONOUNCED_EVENT_ID, userDetails);
+        updateCase(String.valueOf(caseDetails.getId()), null, UPDATE_TO_AWAITING_DA_EVENT_ID);
+
+        Map<String, Object> cosResponse = cosApiClient
+                .submitDaCase(userDetails.getAuthToken(), Collections.emptyMap(), String.valueOf(caseDetails.getId()));
+
+        assertEquals(DA_REQUESTED_STATE, cosResponse.get(STATE_JSON_KEY));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.divorce.support.cos;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -135,4 +136,13 @@ public interface CosApiClient {
         value = "/process-applicant-da-eligibility"
     )
     CcdCallbackResponse flagCaseAsEligibleForDAForApplicant(@RequestBody CcdCallbackRequest ccdCallbackRequest);
+
+    @RequestMapping(
+        method = RequestMethod.POST,
+        value = "/submit-da/{caseId}"
+    )
+    Map<String, Object> submitDaCase(@RequestHeader(AUTHORIZATION) String authorisation,
+                                     @RequestBody Map<String, Object> caseData,
+                                     @PathVariable("caseId") String caseId
+    );
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
@@ -61,4 +61,13 @@ public interface CaseFormatterClient {
     Map<String, Object> transformToDnCaseFormat(
             @RequestBody Map<String, Object> divorceSession
     );
+
+    @RequestMapping(
+            method = RequestMethod.POST,
+            value = "/caseformatter/version/1/to-da-submit-format",
+            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+    )
+    Map<String, Object> transformToDaCaseFormat(
+            @RequestBody Map<String, Object> divorceSession
+    );
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
@@ -322,6 +322,23 @@ public class OrchestrationController {
             orchestrationService.submitDnCase(divorceSession, authorizationToken, caseId));
     }
 
+    @PostMapping(path = "/submit-da/{caseId}",
+            consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Handles Decree Absolute update")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Update was successful and case was updated in CCD",
+                    response = CaseResponse.class),
+            @ApiResponse(code = 400, message = "Bad Request")})
+    public ResponseEntity<Map<String, Object>> submitDa(
+            @RequestHeader(value = "Authorization") String authorizationToken,
+            @PathVariable String caseId,
+            @RequestBody @ApiParam("Decree Absolute Data as required") Map<String, Object> divorceSession)
+            throws WorkflowException {
+
+        return ResponseEntity.ok(
+                orchestrationService.submitDaCase(divorceSession, authorizationToken, caseId));
+    }
+
     @PutMapping(path = "/amend-petition/{caseId}")
     @ApiOperation(
         value = "Creates a new draft copy of user's old case to be amended, updates old case to AmendPetition state")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -58,6 +58,7 @@ public class OrchestrationConstants {
     public static final String CO_RESPONDENT_SUBMISSION_AOS_COMPLETED_EVENT_ID = "co-RespAOSCompleted";
     public static final String CO_RESPONDENT_SUBMISSION_AWAITING_DN_EVENT_ID = "co-RespAwaitingDN";
     public static final String CO_RESPONDENT_SUBMISSION_AWAITING_LA_EVENT_ID = "co-RespAwaitingLAReferral";
+    public static final String DECREE_ABSOLUTE_REQUESTED_EVENT_ID = "RequestDA";
     public static final String RESP_ADMIT_OR_CONSENT_TO_FACT = "RespAdmitOrConsentToFact";
     public static final String RESP_WILL_DEFEND_DIVORCE = "RespWillDefendDivorce";
     public static final String RESP_FIRST_NAME_CCD_FIELD = "D8RespondentFirstName";
@@ -123,6 +124,7 @@ public class OrchestrationConstants {
     public static final String AWAITING_REISSUE = "AwaitingReissue";
     public static final String DEFENDED = "DefendedDivorce";
     public static final String DN_AWAITING = "DNAwaiting";
+    public static final String DN_PRONOUNCED = "DNPronounced";
 
     // CCD Co-Respondent Fields
     public static final String CO_RESP_LINKED_TO_CASE = "CoRespLinkedToCase";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -69,8 +69,10 @@ public interface CaseOrchestrationService {
 
     CcdCallbackResponse dnSubmitted(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException;
 
-
     Map<String, Object> submitDnCase(Map<String, Object> divorceSession, String authorizationToken, String caseId)
+            throws WorkflowException;
+
+    Map<String, Object> submitDaCase(Map<String, Object> divorceSession, String authorizationToken, String caseId)
             throws WorkflowException;
 
     Map<String, Object> amendPetition(String caseId, String authorisation) throws WorkflowException;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -51,6 +51,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.SetOrderSummaryWorkfl
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorCreateWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitCoRespondentAosWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDaCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDnCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitRespondentAosCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitToCCDWorkflow;
@@ -112,6 +113,7 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     private final SubmitRespondentAosCaseWorkflow submitRespondentAosCaseWorkflow;
     private final SubmitCoRespondentAosWorkflow submitCoRespondentAosWorkflow;
     private final SubmitDnCaseWorkflow submitDnCaseWorkflow;
+    private final SubmitDaCaseWorkflow submitDaCaseWorkflow;
     private final DNSubmittedWorkflow dnSubmittedWorkflow;
     private final SendDnPronouncedNotificationWorkflow sendDnPronouncedNotificationWorkflow;
     private final GetCaseWorkflow getCaseWorkflow;
@@ -428,6 +430,16 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
         Map<String, Object> payload = submitDnCaseWorkflow.run(divorceSession, authorizationToken, caseId);
 
         log.info("Submitted DN with CASE ID: {}.", payload.get(ID));
+        return payload;
+    }
+
+    @Override
+    public Map<String, Object> submitDaCase(Map<String, Object> divorceSession, String authorizationToken,
+                                            String caseId)
+            throws WorkflowException {
+        Map<String, Object> payload = submitDaCaseWorkflow.run(divorceSession, authorizationToken, caseId);
+
+        log.info("Submitted Decree Absolute with CASE ID: {}.", payload.get(ID));
         return payload;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDaCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDaCaseData.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseFormatterClient;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.Map;
+
+@Component
+public class FormatDivorceSessionToDaCaseData implements Task<Map<String, Object>> {
+
+    private final CaseFormatterClient caseFormatterClient;
+
+    @Autowired
+    public FormatDivorceSessionToDaCaseData(CaseFormatterClient caseFormatterClient) {
+        this.caseFormatterClient = caseFormatterClient;
+    }
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> sessionData) {
+        return caseFormatterClient.transformToDaCaseFormat(
+                sessionData
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflow.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_REQUESTED_EVENT_ID;
+
+@Component
+public class SubmitDaCaseWorkflow extends DefaultWorkflow<Map<String, Object>> {
+
+    @Autowired
+    private UpdateCaseInCCD updateCaseInCCD;
+
+    public Map<String, Object> run(Map<String, Object> payload,
+                                   String authToken,
+                                   String caseId) throws WorkflowException {
+        return this.execute(
+            new Task[] {
+                updateCaseInCCD
+            },
+            payload,
+            ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
+            ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
+            ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, DECREE_ABSOLUTE_REQUESTED_EVENT_ID)
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflow.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToDaCaseData;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
@@ -20,6 +20,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class SubmitDaCaseWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     @Autowired
+    private FormatDivorceSessionToDaCaseData formatDivorceSessionToDaCaseData;
+
+    @Autowired
     private UpdateCaseInCCD updateCaseInCCD;
 
     public Map<String, Object> run(Map<String, Object> payload,
@@ -27,9 +30,10 @@ public class SubmitDaCaseWorkflow extends DefaultWorkflow<Map<String, Object>> {
                                    String caseId) throws WorkflowException {
         return this.execute(
             new Task[] {
+                formatDivorceSessionToDaCaseData,
                 updateCaseInCCD
             },
-            Collections.emptyMap(), // Currently there is no requirement to update CCD with data.
+            payload,
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
             ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, DECREE_ABSOLUTE_REQUESTED_EVENT_ID)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflow.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
@@ -28,7 +29,7 @@ public class SubmitDaCaseWorkflow extends DefaultWorkflow<Map<String, Object>> {
             new Task[] {
                 updateCaseInCCD
             },
-            payload,
+            Collections.emptyMap(), // Currently there is no requirement to update CCD with data.
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
             ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, DECREE_ABSOLUTE_REQUESTED_EVENT_ID)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationControllerTest.java
@@ -302,6 +302,20 @@ public class OrchestrationControllerTest {
     }
 
     @Test
+    public void whenSubmitDa_thenProceedAsExpected() throws WorkflowException {
+        final Map<String, Object> daCase = Collections.emptyMap();
+
+        when(caseOrchestrationService.submitDaCase(daCase, AUTH_TOKEN, TEST_CASE_ID)).thenReturn(daCase);
+
+        ResponseEntity<Map<String, Object>> response = classUnderTest.submitDa(AUTH_TOKEN, TEST_CASE_ID, daCase);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(daCase, response.getBody());
+
+        verify(caseOrchestrationService).submitDaCase(daCase, AUTH_TOKEN, TEST_CASE_ID);
+    }
+
+    @Test
     public void whenAmendPetition_thenReturnDraftAndUpdateState() throws Exception {
         final String caseId = "test.id";
         final Map<String, Object> caseData = Collections.singletonMap(

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitDaCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitDaCaseITest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.google.common.collect.ImmutableMap;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_ERROR;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_REQUESTED_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_PRONOUNCED;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = OrchestrationServiceApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@PropertySource(value = "classpath:application.yml")
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class SubmitDaCaseITest {
+    private static final String API_URL = String.format("/submit-da/%s", TEST_CASE_ID);
+    private static final String UPDATE_CONTEXT_PATH = "/casemaintenance/version/1/updateCase/" + TEST_CASE_ID + "/";
+
+    @Autowired
+    private MockMvc webClient;
+
+    @ClassRule
+    public static WireMockClassRule maintenanceServiceServer = new WireMockClassRule(4010);
+
+    @Test
+    public void givenNoAuthToken_whenSubmitDa_thenReturnBadRequest() throws Exception {
+        webClient.perform(MockMvcRequestBuilders.post(API_URL)
+            .content(convertObjectToJsonString(getCaseData()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void givenNoPayload_whenSubmitDa_thenReturnBadRequest() throws Exception {
+        webClient.perform(MockMvcRequestBuilders.post(API_URL)
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void givenCaseUpdateFails_whenSubmitDa_thenPropagateTheException() throws Exception {
+        final Map<String, Object> caseData = new HashMap<>();
+        final Map<String, Object> caseDetails = new HashMap<>();
+
+        caseDetails.put(CASE_STATE_JSON_KEY, DN_PRONOUNCED);
+        caseDetails.put(CCD_CASE_DATA_FIELD, caseData);
+
+        stubMaintenanceServerEndpointForUpdate(BAD_REQUEST, DECREE_ABSOLUTE_REQUESTED_EVENT_ID, caseData, TEST_ERROR);
+
+        webClient.perform(MockMvcRequestBuilders.post(API_URL)
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(caseData))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(containsString(TEST_ERROR)));
+    }
+
+    @Test
+    public void givenDnReceivedAndAosCompleted_whenSubmitDa_thenProceedAsExpected() throws Exception {
+        final Map<String, Object> caseData = getCaseData();
+        final String caseDataString = convertObjectToJsonString(caseData);
+        final Map<String, Object> caseDetails = new HashMap<>();
+
+        caseDetails.put(CASE_STATE_JSON_KEY, DN_PRONOUNCED);
+        caseDetails.put(CCD_CASE_DATA_FIELD, caseData);
+
+        stubMaintenanceServerEndpointForUpdate(OK, DECREE_ABSOLUTE_REQUESTED_EVENT_ID, caseData, caseDataString);
+
+        webClient.perform(MockMvcRequestBuilders.post(API_URL)
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(caseData))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(caseDataString));
+    }
+
+    private void stubMaintenanceServerEndpointForUpdate(HttpStatus status, String caseEventId,
+                                                        Map<String, Object> caseData, String response) {
+        maintenanceServiceServer.stubFor(post(UPDATE_CONTEXT_PATH + caseEventId)
+            .withRequestBody(equalToJson(convertObjectToJsonString(caseData)))
+            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(response)));
+    }
+
+    private Map<String, Object> getCaseData() {
+        return ImmutableMap.of();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitDaCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitDaCaseITest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -96,7 +97,7 @@ public class SubmitDaCaseITest {
     }
 
     @Test
-    public void givenDnReceivedAndAosCompleted_whenSubmitDa_thenProceedAsExpected() throws Exception {
+    public void givenCaseUpdateIsSuccessful_whenSubmitDa_thenProceedAsExpected() throws Exception {
         final Map<String, Object> caseData = getCaseData();
         final String caseDataString = convertObjectToJsonString(caseData);
         final Map<String, Object> caseDetails = new HashMap<>();
@@ -104,7 +105,7 @@ public class SubmitDaCaseITest {
         caseDetails.put(CASE_STATE_JSON_KEY, DN_PRONOUNCED);
         caseDetails.put(CCD_CASE_DATA_FIELD, caseData);
 
-        stubMaintenanceServerEndpointForUpdate(OK, DECREE_ABSOLUTE_REQUESTED_EVENT_ID, caseData, caseDataString);
+        stubMaintenanceServerEndpointForUpdate(OK, DECREE_ABSOLUTE_REQUESTED_EVENT_ID, Collections.emptyMap(), caseDataString);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -54,6 +54,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.SeparationFieldsWorkf
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SetOrderSummaryWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorCreateWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitCoRespondentAosWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDaCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitDnCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitRespondentAosCaseWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.SubmitToCCDWorkflow;
@@ -167,6 +168,9 @@ public class CaseOrchestrationServiceImplTest {
 
     @Mock
     private SubmitDnCaseWorkflow submitDnCaseWorkflow;
+
+    @Mock
+    private SubmitDaCaseWorkflow submitDaCaseWorkflow;
 
     @Mock
     private GetCaseWorkflow getCaseWorkflow;
@@ -723,6 +727,15 @@ public class CaseOrchestrationServiceImplTest {
         assertEquals(requestPayload, classUnderTest.submitDnCase(requestPayload, AUTH_TOKEN, TEST_CASE_ID));
 
         verify(submitDnCaseWorkflow).run(requestPayload, AUTH_TOKEN, TEST_CASE_ID);
+    }
+
+    @Test
+    public void givenDaCaseData_whenSubmitDaCase_thenReturnPayload() throws Exception {
+        when(submitDaCaseWorkflow.run(requestPayload, AUTH_TOKEN, TEST_CASE_ID)).thenReturn(requestPayload);
+
+        assertEquals(requestPayload, classUnderTest.submitDaCase(requestPayload, AUTH_TOKEN, TEST_CASE_ID));
+
+        verify(submitDaCaseWorkflow).run(requestPayload, AUTH_TOKEN, TEST_CASE_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDaCaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDaCaseDataTest.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.client.CaseFormatterClient;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FormatDivorceSessionToDaCaseDataTest {
+
+    @Mock
+    private CaseFormatterClient caseFormatterClient;
+
+    @InjectMocks
+    private FormatDivorceSessionToDaCaseData classUnderTest;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void whenExecute_thenProceedAsExpected() {
+        final Map<String, Object> sessionData = mock(Map.class);
+        final Map<String, Object> expectedOutput = mock(Map.class);
+
+        when(caseFormatterClient.transformToDaCaseFormat(sessionData)).thenReturn(expectedOutput);
+
+        assertEquals(expectedOutput, classUnderTest.execute(null, sessionData));
+
+        verify(caseFormatterClient).transformToDaCaseFormat(sessionData);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflowUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflowUTest.java
@@ -8,9 +8,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToDaCaseData;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -26,6 +26,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RunWith(MockitoJUnitRunner.class)
 public class SubmitDaCaseWorkflowUTest {
     @Mock
+    private FormatDivorceSessionToDaCaseData formatDivorceSessionToDaCaseDataTest;
+
+    @Mock
     private UpdateCaseInCCD updateCaseInCCD;
 
     @InjectMocks
@@ -33,7 +36,7 @@ public class SubmitDaCaseWorkflowUTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void whenSubmitDnCase_thenProcessAsExpected() throws WorkflowException {
+    public void whenSubmitDaCase_thenProcessAsExpected() throws WorkflowException {
         final Map<String, Object> inputData = mock(Map.class);
         final Map<String, Object> expectedOutput = mock(Map.class);
 
@@ -42,10 +45,11 @@ public class SubmitDaCaseWorkflowUTest {
         final ImmutablePair<String, Object> eventIdPair = new ImmutablePair<>(CASE_EVENT_ID_JSON_KEY, DECREE_ABSOLUTE_REQUESTED_EVENT_ID);
 
         final Task[] tasks = new Task[]{
+            formatDivorceSessionToDaCaseDataTest,
             updateCaseInCCD
         };
 
-        when(classUnderTest.execute(tasks, Collections.emptyMap(), authTokenPair, caseIdPair, eventIdPair)).thenReturn(expectedOutput);
+        when(classUnderTest.execute(tasks, inputData, authTokenPair, caseIdPair, eventIdPair)).thenReturn(expectedOutput);
 
         assertEquals(expectedOutput, classUnderTest.run(inputData, AUTH_TOKEN, TEST_CASE_ID));
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflowUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflowUTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_REQUESTED_EVENT_ID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SubmitDaCaseWorkflowUTest {
+    @Mock
+    private UpdateCaseInCCD updateCaseInCCD;
+
+    @InjectMocks
+    private SubmitDaCaseWorkflow classUnderTest;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void whenSubmitDnCase_thenProcessAsExpected() throws WorkflowException {
+        final Map<String, Object> inputData = mock(Map.class);
+        final Map<String, Object> expectedOutput = mock(Map.class);
+
+        final ImmutablePair<String, Object> authTokenPair = new ImmutablePair<>(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        final ImmutablePair<String, Object> caseIdPair = new ImmutablePair<>(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        final ImmutablePair<String, Object> eventIdPair = new ImmutablePair<>(CASE_EVENT_ID_JSON_KEY, DECREE_ABSOLUTE_REQUESTED_EVENT_ID);
+
+        final Task[] tasks = new Task[]{
+            updateCaseInCCD
+        };
+
+        when(classUnderTest.execute(tasks, inputData, authTokenPair, caseIdPair, eventIdPair)).thenReturn(expectedOutput);
+
+        assertEquals(expectedOutput, classUnderTest.run(inputData, AUTH_TOKEN, TEST_CASE_ID));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflowUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDaCaseWorkflowUTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -44,7 +45,7 @@ public class SubmitDaCaseWorkflowUTest {
             updateCaseInCCD
         };
 
-        when(classUnderTest.execute(tasks, inputData, authTokenPair, caseIdPair, eventIdPair)).thenReturn(expectedOutput);
+        when(classUnderTest.execute(tasks, Collections.emptyMap(), authTokenPair, caseIdPair, eventIdPair)).thenReturn(expectedOutput);
 
         assertEquals(expectedOutput, classUnderTest.run(inputData, AUTH_TOKEN, TEST_CASE_ID));
     }


### PR DESCRIPTION
# Description

[DIV-5111](https://tools.hmcts.net/jira/browse/DIV-5111)

Adds a new endpoint `/submit-da` for Decree Absolute submissions in line with existing endpoints:

`/submit-aos` and `/submit-dn`

This one is more bare since we currently don't require adding any additional case data into the case, simply the case state needs to be progressed. However, the workflow means it can be updated with a formatter in the future as needs be.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Automated, Integration and Manual Testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
