### PR TITLE
Div 5238 search scheduler job improvements

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/DefaultTaskContext.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/DefaultTaskContext.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 
 import java.util.HashMap;
@@ -9,8 +7,6 @@ import java.util.Map;
 import java.util.Optional;
 
 @Data
-@Builder
-@AllArgsConstructor
 public class DefaultTaskContext implements TaskContext {
 
     private boolean taskFailed;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchDNPronouncedCasesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchDNPronouncedCasesTest.java
@@ -51,6 +51,10 @@ public class SearchDNPronouncedCasesTest {
 
     private int pageSize;
     private int start;
+
+    private static final String TWO_MINUTES = "2m";
+    private String timeSinceDNWasPronounced = TWO_MINUTES;
+
     private DefaultTaskContext contextBeingModified;
 
     @Before
@@ -62,13 +66,11 @@ public class SearchDNPronouncedCasesTest {
                 put("PAGE_SIZE", pageSize);
                 put("FROM", start);
                 put(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
-                put(AWAITING_DA_PERIOD_KEY, "2m");
+                put(AWAITING_DA_PERIOD_KEY, timeSinceDNWasPronounced);
             }};
 
-        contextBeingModified =
-            DefaultTaskContext.builder()
-                .transientObjects(searchSettings)
-                .build();
+        contextBeingModified = new DefaultTaskContext();
+        contextBeingModified.setTransientObjects(searchSettings);
     }
 
     @Test


### PR DESCRIPTION
-- use Awaitility to make the integration test 'MakeCaseEligibleForDAWorkflowTest' more reliable
-- removed annotations such as 'Builder' and 'AllArgsConstructor` for `DefaultTaskContext` as the object itself is not immutable by design 

# How Has This Been Tested?
-- unit tests
-- integration tests

**Test Configuration**:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
