### PR TITLE
Run wiremock functional tests in the after block of the unit test sec…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -40,7 +40,12 @@ withPipeline(type, product, component) {
     setVaultName('div')
 
     after('checkout') {
-       echo 'divorce-case-orchestration-service checked out'
+        echo 'divorce-case-orchestration-service checked out'
+    }
+
+    after('test') {
+        echo 'Starting WireMock Functional Tests'
+        sh './gradlew wiremockFunctional'
     }
 
     after('functionalTest:aat') {

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ API documentation is provided with Swagger:
 
 **Unit tests**
 
-To run all unit tests please execute following command:
+To run all unit tests and local functional tests respectively please execute following commands:
 
 ```bash
     ./gradlew test
+    ./gradlew wiremockFunctional
 ```
 
 **Coding style tests**

--- a/build.gradle
+++ b/build.gradle
@@ -398,6 +398,14 @@ dependencies {
     integrationTestCompile(sourceSets.test.output)
 }
 
+test {
+    exclude '**/functionaltest/**/*'
+}
+
+task wiremockFunctional(type: Test, description: 'Executes wiremock functional tests', group: 'Verification') {
+    include '**/functionaltest/**/*'
+}
+
 task smoke(type: Test, description: 'Runs the smoke tests.', group: 'Verification') {
     useJUnit {
         includeCategories 'uk.gov.hmcts.reform.divorce.orchestration.category.SmokeTest'


### PR DESCRIPTION
…tion, so it isn't wrapped by a 20 minute timeout

# Description

[DIV-5278](https://tools.hmcts.net/jira/browse/DIV-5278)

Based on https://github.com/hmcts/cnp-jenkins-library/blob/master/vars/sectionBuildAndTest.groovy#L65, we have a 20 minute timeout for unit tests to complete. The wiremock functional tests can take longer than this.
This PR moves it to the after block, which will run by `pcr.callAround('test')`, which isn't wrapped by the 20 minute timeout block, thus shouldn't be affected.

NOTE: This will mean running `./gradlew clean test` locally will no longer run the wiremock functionals by default. Developers should take care to run both `test` and `wiremockFunctional` as required locally. The pipelines should still run both, no different to now.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
