### PR TITLE
Disable local test caching and show standard test logs

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -45,7 +45,11 @@ withPipeline(type, product, component) {
 
     after('test') {
         echo 'Starting WireMock Functional Tests'
-        sh './gradlew wiremockFunctional'
+        try {
+            sh './gradlew wiremockFunctional'
+        } finally {
+            steps.junit '**/test-results/**/*.xml'
+        }
     }
 
     after('functionalTest:aat') {

--- a/build.gradle
+++ b/build.gradle
@@ -403,6 +403,8 @@ test {
 }
 
 task wiremockFunctional(type: Test, description: 'Executes wiremock functional tests', group: 'Verification') {
+    test.outputs.upToDateWhen {false}
+    testLogging.showStandardStreams = true
     include '**/functionaltest/**/*'
 }
 


### PR DESCRIPTION
# Description

[DIV-5278](https://tools.hmcts.net/jira/browse/DIV-5278)

This PR adds two configurations to the wiremockFunctional task so up to date test results won't prevent re-run of the tests, and to also display the full standard logs.

Also exposes the Junit Test Results to Jenkins.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
