### PR TITLE
Added required subscription param for cnp-module-postgres

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -105,6 +105,7 @@ module "div-scheduler-db" {
   sku_name           = "GP_Gen5_2"
   sku_tier           = "GeneralPurpose"
   common_tags        = "${var.common_tags}"
+  subscription       = "${var.subscription}"
 }
 
 resource "azurerm_key_vault_secret" "postgresql-user" {


### PR DESCRIPTION
# Description

> Next Monday we will be making a breaking change to cnp-module-postgres
https://github.com/hmcts/cnp-module-postgres/pull/41
> It is to make the `subscription` variable required
any team who have deployed their apps to the `ithc` or `perftest` will have already made this change
>see usage for a full example  of how to pass through the variable: https://github.com/hmcts/cnp-module-postgres#usage
> We are making this change because multiple teams weren't told they needed to do this as part of using new environments, and it gives an error message which is confusing (losing time and frustrating developers), making it a required variable gives a very clear error  message and a very easy update.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
