### PR TITLE
Fix for bulk cases in a ElasticSearch stuck state

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/bulk/BulkWorkflowExecutionResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/bulk/BulkWorkflowExecutionResult.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Builder
+@Data
+public class BulkWorkflowExecutionResult {
+    private boolean successStatus;
+    private Set<String> removableCaseIds;
+    private List<Map<String, Object>> failedCases;
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
@@ -84,7 +84,7 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
     private BulkWorkflowExecutionResult executeWithRetriesResult(Map<String, Object> bulkCaseResponse, String bulkCaseId, String authToken) {
         Map<String, Object> bulkCaseData = (Map<String, Object>) bulkCaseResponse.getOrDefault(CCD_CASE_DATA_FIELD, Collections.emptyMap());
         List<Map<String, Object>> acceptedDivorceCaseList =
-                (List<Map<String, Object>>) bulkCaseData.getOrDefault(BULK_CASE_ACCEPTED_LIST_KEY, Collections.emptyList());
+            (List<Map<String, Object>>) bulkCaseData.getOrDefault(BULK_CASE_ACCEPTED_LIST_KEY, Collections.emptyList());
 
         if (acceptedDivorceCaseList.isEmpty()) {
             throw new BulkUpdateException("Accepted case list is empty. Not updating bulk case");
@@ -136,7 +136,7 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
                     | RetryableException e) {
                 String errorMessage = e.content() == null ? e.getMessage() : e.contentUTF8();
                 log.error("Case update failed, added to retry list: for bulk case id {} and caseId {}. Cause {}",
-                        bulkCaseId, caseId, errorMessage, e);
+                    bulkCaseId, caseId, errorMessage, e);
                 casesToRetry.add(caseElem);
             } catch (FeignException.UnprocessableEntity e) {
                 log.error("Case update failed with 422 error : for bulk case id {}  and caseId {}", bulkCaseId, caseId, e);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
@@ -4,12 +4,15 @@ import feign.FeignException;
 import feign.RetryableException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.BulkWorkflowExecutionResult;
 import uk.gov.hmcts.reform.divorce.orchestration.exception.BulkUpdateException;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.BULK_CASE_ACCEPTED_LIST_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.CASE_REFERENCE_FIELD;
@@ -51,9 +54,37 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
      * @return true if all the case have been updated successfully, false if any case failed.
      */
     public boolean executeWithRetries(Map<String, Object> bulkCaseResponse, String bulkCaseId, String authToken) {
+        BulkWorkflowExecutionResult result = executeWithRetriesResult(bulkCaseResponse, bulkCaseId, authToken);
+
+        return result.getFailedCases().isEmpty();
+    }
+
+    /**
+     *  Process accepted cases, CaseAcceptedList,  within the bulk case.
+     *  If updating any case fails with 5xx error in CCD the process will retry the case.
+     *  The process will not retry the case if CCD fails with 4xx error.
+     *
+     * @param bulkCaseResponse Bulk case data in CCD format
+     * @param bulkCaseId Bulk case id
+     * @param authToken Caseworker auth token
+     * @return result of the execution with a true status if all cases have updated successfully, or has a 422 error, false otherwise.
+     */
+    public BulkWorkflowExecutionResult executeWithRetriesForCreate(Map<String, Object> bulkCaseResponse, String bulkCaseId, String authToken) {
+        BulkWorkflowExecutionResult result = executeWithRetriesResult(bulkCaseResponse, bulkCaseId, authToken);
+
+        result.setSuccessStatus(true);
+        // If there are more failed cases than removable cases, that means there are some cases that failed for a reason other than 422
+        if (result.getFailedCases().size() > result.getRemovableCaseIds().size()) {
+            result.setSuccessStatus(false);
+        }
+
+        return result;
+    }
+
+    private BulkWorkflowExecutionResult executeWithRetriesResult(Map<String, Object> bulkCaseResponse, String bulkCaseId, String authToken) {
         Map<String, Object> bulkCaseData = (Map<String, Object>) bulkCaseResponse.getOrDefault(CCD_CASE_DATA_FIELD, Collections.emptyMap());
         List<Map<String, Object>> acceptedDivorceCaseList =
-            (List<Map<String, Object>>) bulkCaseData.getOrDefault(BULK_CASE_ACCEPTED_LIST_KEY, Collections.emptyList());
+                (List<Map<String, Object>>) bulkCaseData.getOrDefault(BULK_CASE_ACCEPTED_LIST_KEY, Collections.emptyList());
 
         if (acceptedDivorceCaseList.isEmpty()) {
             throw new BulkUpdateException("Accepted case list is empty. Not updating bulk case");
@@ -61,13 +92,14 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
 
         int retryCount = 0;
         List<Map<String, Object>> retryCases = acceptedDivorceCaseList;
+        final Set<String> caseIdsToRemove = new HashSet<>();
         final List<Map<String, Object>> failedCases = new ArrayList<>();
         try {
             while (!retryCases.isEmpty() && retryCount < maxRetries) {
                 if (retryCount > 0) {
                     exponentialWaitTime(retryCount);
                 }
-                retryCases = handleFailedCases(retryCases, bulkCaseId, authToken, failedCases, bulkCaseResponse);
+                retryCases = handleFailedCases(retryCases, bulkCaseId, authToken, caseIdsToRemove, failedCases, bulkCaseResponse);
                 retryCount ++;
             }
 
@@ -79,12 +111,14 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
                 this.notifyFailedCases(bulkCaseId, failedCases);
             }
         }
-        return failedCases.isEmpty();
+
+        return BulkWorkflowExecutionResult.builder().removableCaseIds(caseIdsToRemove).failedCases(failedCases).build();
     }
 
     private List<Map<String, Object>> handleFailedCases(List<Map<String, Object>> caseList,
                                                         String bulkCaseId,
                                                         String authToken,
+                                                        Set<String> caseIdsToRemove,
                                                         List<Map<String, Object>> nonRetryableCases,
                                                         Map<String, Object> bulkCaseData) {
         final List<Map<String, Object>> casesToRetry = new ArrayList<>();
@@ -96,14 +130,18 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
                 caseId = String.valueOf(caseLink.get(CASE_REFERENCE_FIELD));
                 this.run(bulkCaseData, caseId, authToken);
             } catch (FeignException.BadGateway
-                | FeignException.InternalServerError
-                | FeignException.GatewayTimeout
-                | FeignException.ServiceUnavailable
-                | RetryableException e) {
+                    | FeignException.InternalServerError
+                    | FeignException.GatewayTimeout
+                    | FeignException.ServiceUnavailable
+                    | RetryableException e) {
                 String errorMessage = e.content() == null ? e.getMessage() : e.contentUTF8();
                 log.error("Case update failed, added to retry list: for bulk case id {} and caseId {}. Cause {}",
-                    bulkCaseId, caseId, errorMessage, e);
+                        bulkCaseId, caseId, errorMessage, e);
                 casesToRetry.add(caseElem);
+            } catch (FeignException.UnprocessableEntity e) {
+                log.error("Case update failed with 422 error : for bulk case id {}  and caseId {}", bulkCaseId, caseId, e);
+                caseIdsToRemove.add(caseId);
+                nonRetryableCases.add(caseElem);
             } catch (Exception e) {
                 log.error("Case update failed : for bulk case id {}  and caseId {}", bulkCaseId, caseId, e);
                 nonRetryableCases.add(caseElem);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
@@ -136,7 +136,8 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
                 log.error("Case update failed, added to retry list: for bulk case id {} and caseId {}. Cause {}",
                     bulkCaseId, caseId, errorMessage, e);
                 casesToRetry.add(caseElem);
-            } catch (FeignException.UnprocessableEntity e) {
+            } catch (FeignException.UnprocessableEntity
+                     | FeignException.NotFound e) {
                 String errorMessage = e.content() == null ? e.getMessage() : e.contentUTF8();
                 log.error("Case update failed with 422 error : for bulk case id {}  and caseId {}. Cause {}",
                     bulkCaseId, caseId, errorMessage, e);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflow.java
@@ -44,7 +44,7 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
     public abstract Map<String, Object> run(Map<String, Object> bulkCaseData, String caseId, String authToken) throws WorkflowException;
 
     /**
-     *  Process accepted cases, CaseAcceptedList,  within the bulk case.
+     *  Process accepted cases, CaseAcceptedList, within the bulk case.
      *  If updating any case fails with 5xx error in CCD the process will retry the case.
      *  The process will not retry the case if CCD fails with 4xx error.
      *
@@ -60,7 +60,7 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
     }
 
     /**
-     *  Process accepted cases, CaseAcceptedList,  within the bulk case.
+     *  Process accepted cases, CaseAcceptedList, within the bulk case.
      *  If updating any case fails with 5xx error in CCD the process will retry the case.
      *  The process will not retry the case if CCD fails with 4xx error.
      *
@@ -72,12 +72,9 @@ public abstract class RetryableBulkCaseWorkflow extends DefaultWorkflow<Map<Stri
     public BulkWorkflowExecutionResult executeWithRetriesForCreate(Map<String, Object> bulkCaseResponse, String bulkCaseId, String authToken) {
         BulkWorkflowExecutionResult result = executeWithRetriesResult(bulkCaseResponse, bulkCaseId, authToken);
 
-        // If there are more failed cases than removable cases, that means there are some cases that failed for a reason other than 422
-        if (result.getFailedCases().size() > result.getRemovableCaseIds().size()) {
-            result.setSuccessStatus(false);
-        } else {
-            result.setSuccessStatus(true);
-        }
+        final boolean areThereCasesThatFailedForOtherReasonThan422 = result.getFailedCases().size() > result.getRemovableCaseIds().size();
+
+        result.setSuccessStatus(!areThereCasesThatFailedForOtherReasonThan422);
 
         return result;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImpl.java
@@ -50,12 +50,13 @@ public class BulkCaseServiceImpl implements BulkCaseService {
     @Override
     @EventListener
     public void handleBulkCaseCreateEvent(BulkCaseCreateEvent event) throws WorkflowException {
-        long startTime = Instant.now().toEpochMilli();
+        final long startTime = Instant.now().toEpochMilli();
         TaskContext context = (TaskContext) event.getSource();
         Map<String, Object> caseResponse = event.getCaseDetails();
         final String bulkCaseId = String.valueOf(caseResponse.get(OrchestrationConstants.ID));
 
-        BulkWorkflowExecutionResult result = linkBulkCaseWorkflow.executeWithRetriesForCreate(caseResponse, bulkCaseId, context.getTransientObject(AUTH_TOKEN_JSON_KEY));
+        BulkWorkflowExecutionResult result =
+            linkBulkCaseWorkflow.executeWithRetriesForCreate(caseResponse, bulkCaseId, context.getTransientObject(AUTH_TOKEN_JSON_KEY));
 
         if (!result.isSuccessStatus()) {
             throw new BulkUpdateException(String.format("Failed to updating bulk case link for some cases on bulk case id %s", bulkCaseId));
@@ -69,7 +70,7 @@ public class BulkCaseServiceImpl implements BulkCaseService {
             updatePayload.put(BULK_CASE_ACCEPTED_LIST_KEY, filterAcceptedCases(caseResponse, result.getRemovableCaseIds()));
         }
 
-        long endTime = Instant.now().toEpochMilli();
+        final long endTime = Instant.now().toEpochMilli();
         updateBulkCaseWorkflow.run(updatePayload, context.getTransientObject(AUTH_TOKEN_JSON_KEY), bulkCaseId, CREATE_EVENT);
         log.info("Completed bulk case process with bulk cased Id:{} in:{} millis", bulkCaseId, endTime - startTime);
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.BulkWorkflowExecutionResult;
 import uk.gov.hmcts.reform.divorce.orchestration.event.bulk.BulkCaseCreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.event.bulk.BulkCaseUpdateCourtHearingEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.event.bulk.BulkCaseUpdatePronouncementDateEvent;
@@ -19,12 +20,22 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdatePronouncementDa
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.BULK_CASE_ACCEPTED_LIST_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.CASE_LIST_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.CASE_REFERENCE_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.CREATE_EVENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.LISTED_EVENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.PRONOUNCED_EVENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.VALUE_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 
 @Service
 @RequiredArgsConstructor
@@ -44,14 +55,22 @@ public class BulkCaseServiceImpl implements BulkCaseService {
         Map<String, Object> caseResponse = event.getCaseDetails();
         final String bulkCaseId = String.valueOf(caseResponse.get(OrchestrationConstants.ID));
 
-        boolean success = linkBulkCaseWorkflow.executeWithRetries(caseResponse, bulkCaseId, context.getTransientObject(AUTH_TOKEN_JSON_KEY));
+        BulkWorkflowExecutionResult result = linkBulkCaseWorkflow.executeWithRetriesForCreate(caseResponse, bulkCaseId, context.getTransientObject(AUTH_TOKEN_JSON_KEY));
 
-        if (!success) {
+        if (!result.isSuccessStatus()) {
             throw new BulkUpdateException(String.format("Failed to updating bulk case link for some cases on bulk case id %s", bulkCaseId));
         }
 
+        Set<String> removableCaseIds = Optional.ofNullable(result.getRemovableCaseIds()).orElse(Collections.emptySet());
+        Map<String, Object> updatePayload = new HashMap<>();
+
+        if (removableCaseIds.size() > 0) {
+            updatePayload.put(CASE_LIST_KEY, filterBulkCases(caseResponse, result.getRemovableCaseIds()));
+            updatePayload.put(BULK_CASE_ACCEPTED_LIST_KEY, filterAcceptedCases(caseResponse, result.getRemovableCaseIds()));
+        }
+
         long endTime = Instant.now().toEpochMilli();
-        updateBulkCaseWorkflow.run(Collections.emptyMap(), context.getTransientObject(AUTH_TOKEN_JSON_KEY), bulkCaseId, CREATE_EVENT);
+        updateBulkCaseWorkflow.run(updatePayload, context.getTransientObject(AUTH_TOKEN_JSON_KEY), bulkCaseId, CREATE_EVENT);
         log.info("Completed bulk case process with bulk cased Id:{} in:{} millis", bulkCaseId, endTime - startTime);
     }
 
@@ -101,5 +120,28 @@ public class BulkCaseServiceImpl implements BulkCaseService {
         log.info("Updating bulk case id {} to Pronounced state", bulkCaseId);
         updateBulkCaseWorkflow.run(Collections.emptyMap(), context.getTransientObject(AUTH_TOKEN_JSON_KEY), bulkCaseId, PRONOUNCED_EVENT);
         log.info("Completed bulk case id {} pronounced state update", bulkCaseId);
+    }
+
+    private List<Map<String, Object>> filterBulkCases(Map<String, Object> bulkCaseDetails, Set<String> removableCaseIds) {
+        Map<String, Object> bulkCaseData = (Map<String, Object>) bulkCaseDetails.getOrDefault(CCD_CASE_DATA_FIELD, Collections.emptyMap());
+        List<Map<String, Object>> bulkCaseList =
+                (List<Map<String, Object>>) bulkCaseData.getOrDefault(CASE_LIST_KEY, Collections.emptyList());
+
+        return bulkCaseList.stream().filter(caseElem -> {
+            Map<String, Object> caseData = (Map<String, Object>) caseElem.get(VALUE_KEY);
+            Map<String, Object> caseLink = (Map<String, Object>) caseData.get(CASE_REFERENCE_FIELD);
+            return !removableCaseIds.contains(String.valueOf(caseLink.get(CASE_REFERENCE_FIELD)));
+        }).collect(Collectors.toList());
+    }
+
+    private List<Map<String, Object>> filterAcceptedCases(Map<String, Object> bulkCaseDetails, Set<String> removableCaseIds) {
+        Map<String, Object> bulkCaseData = (Map<String, Object>) bulkCaseDetails.getOrDefault(CCD_CASE_DATA_FIELD, Collections.emptyMap());
+        List<Map<String, Object>> acceptedDivorceCaseList =
+                (List<Map<String, Object>>) bulkCaseData.getOrDefault(BULK_CASE_ACCEPTED_LIST_KEY, Collections.emptyList());
+
+        return acceptedDivorceCaseList.stream().filter(caseElem -> {
+            Map<String, Object> caseLink = (Map<String, Object>) caseElem.get(VALUE_KEY);
+            return !removableCaseIds.contains(String.valueOf(caseLink.get(CASE_REFERENCE_FIELD)));
+        }).collect(Collectors.toList());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflowTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.BulkWorkflowExecutionResult;
 import uk.gov.hmcts.reform.divorce.orchestration.exception.BulkUpdateException;
 
 import java.util.Date;
@@ -132,6 +133,26 @@ public class RetryableBulkCaseWorkflowTest {
     }
 
     @Test
+    public void given422Exception_whenExecuteWithRetries_thenLogError() throws WorkflowException {
+        Map<String, Object> caseData1 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_1));
+        Map<String, Object> caseData2 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_2));
+        Map<String, Object> bulkCaseData = ImmutableMap.of(BULK_CASE_ACCEPTED_LIST_KEY, asList(caseData1, caseData2));
+        Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, bulkCaseData);
+
+        when(retryableBulkCaseWorkflow.run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN))
+                .thenThrow(new FeignException.UnprocessableEntity("Error", "Error".getBytes()));
+
+        boolean executionSuccessful = retryableBulkCaseWorkflow.executeWithRetries(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+
+        assertThat(executionSuccessful, is(false));
+
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+    }
+
+    @Test
     public void givenException_whenExecuteWithRetries_thenLogError() throws WorkflowException {
         Map<String, Object> caseData1 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_1));
         Map<String, Object> caseData2 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_2));
@@ -146,6 +167,99 @@ public class RetryableBulkCaseWorkflowTest {
         boolean executionSuccessful = retryableBulkCaseWorkflow.executeWithRetries(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
 
         assertThat(executionSuccessful, is(false));
+
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1, caseData2));
+    }
+
+    @Test(expected = BulkUpdateException.class)
+    public void givenEmptyCases_whenExecuteWithRetriesForCreate_thenThrowException() {
+        retryableBulkCaseWorkflow.executeWithRetriesForCreate(emptyMap(), TEST_CASE_ID, AUTH_TOKEN);
+    }
+
+    @Test
+    public void whenExecuteWithRetriesForCreate_thenAllCasesAreExecuted() throws WorkflowException {
+        Map<String, Object> caseData1 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_1));
+        Map<String, Object> caseData2 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_2));
+        Map<String, Object> bulkCaseData = ImmutableMap.of(BULK_CASE_ACCEPTED_LIST_KEY, asList(caseData1, caseData2));
+        Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, bulkCaseData);
+
+        BulkWorkflowExecutionResult result =
+                retryableBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+
+        assertThat(result.isSuccessStatus(), is(true));
+
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
+    }
+
+    @Test
+    public void given4xException_whenExecuteWithRetriesForCreate_thenLogError() throws WorkflowException {
+        Map<String, Object> caseData1 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_1));
+        Map<String, Object> caseData2 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_2));
+        Map<String, Object> bulkCaseData = ImmutableMap.of(BULK_CASE_ACCEPTED_LIST_KEY, asList(caseData1, caseData2));
+        Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, bulkCaseData);
+
+        when(retryableBulkCaseWorkflow.run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN))
+                .thenThrow(new FeignException.NotAcceptable("Error", "Error".getBytes()));
+
+        BulkWorkflowExecutionResult result =
+                retryableBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+
+        assertThat(result.isSuccessStatus(), is(false));
+        assertThat(result.getRemovableCaseIds().size(), is(0));
+        assertThat(result.getFailedCases().size(), is(1));
+
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+    }
+
+    @Test
+    public void given422Exception_whenExecuteWithRetriesForCreate_thenReturnRemovableCases() throws WorkflowException {
+        Map<String, Object> caseData1 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_1));
+        Map<String, Object> caseData2 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_2));
+        Map<String, Object> bulkCaseData = ImmutableMap.of(BULK_CASE_ACCEPTED_LIST_KEY, asList(caseData1, caseData2));
+        Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, bulkCaseData);
+
+        when(retryableBulkCaseWorkflow.run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN))
+                .thenThrow(new FeignException.UnprocessableEntity("Error", "Error".getBytes()));
+
+        BulkWorkflowExecutionResult result =
+                retryableBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+
+        assertThat(result.isSuccessStatus(), is(true));
+        assertThat(result.getRemovableCaseIds().size(), is(1));
+        assertThat(result.getFailedCases().size(), is(1));
+
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+    }
+
+    @Test
+    public void givenException_whenExecuteWithRetriesForCreate_thenLogError() throws WorkflowException {
+        Map<String, Object> caseData1 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_1));
+        Map<String, Object> caseData2 = ImmutableMap.of(VALUE_KEY, ImmutableMap.of(CASE_REFERENCE_FIELD, TEST_CASE_ID_2));
+        Map<String, Object> bulkCaseData = ImmutableMap.of(BULK_CASE_ACCEPTED_LIST_KEY, asList(caseData1, caseData2));
+        Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, bulkCaseData);
+
+        when(retryableBulkCaseWorkflow.run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN))
+                .thenThrow(new RuntimeException());
+        when(retryableBulkCaseWorkflow.run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN))
+                .thenThrow(new RuntimeException());
+
+        BulkWorkflowExecutionResult result =
+                retryableBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+
+        assertThat(result.isSuccessStatus(), is(false));
+        assertThat(result.getRemovableCaseIds().size(), is(0));
+        assertThat(result.getFailedCases().size(), is(2));
 
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessBulkCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessBulkCaseITest.java
@@ -231,6 +231,33 @@ public class ProcessBulkCaseITest extends IdamTestSupport {
         verifyCmsServerEndpoint(1, String.format(CMS_UPDATE_CASE, CASE_ID3), RequestMethod.POST, UPDATE_BODY);
     }
 
+    @Test
+    public void give422Error_whenUpdateDivorceCase_thenUpdateBulkCaseWithFilteredCaseList() throws Exception {
+        SearchResult result = SearchResult.builder()
+                .cases(Arrays.asList(prepareBulkCase(), prepareBulkCase(), prepareBulkCase()))
+                .build();
+
+        stubCmsServerEndpoint(CMS_SEARCH, HttpStatus.OK, convertObjectToJsonString(result), POST);
+        stubCmsServerEndpoint(CMS_BULK_CASE_SUBMIT, HttpStatus.OK, getCmsBulkCaseResponse(), POST);
+        stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, CASE_ID1), HttpStatus.UNPROCESSABLE_ENTITY, getCmsBulkCaseResponse(), POST);
+        stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, CASE_ID2), HttpStatus.OK, getCmsBulkCaseResponse(), POST);
+        stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, CASE_ID3), HttpStatus.OK, getCmsBulkCaseResponse(), POST);
+
+        stubSignInForCaseworker();
+
+        webClient.perform(post(API_URL)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        waitAsyncCompleted();
+
+        verifyCmsServerEndpoint(1, String.format(CMS_UPDATE_CASE, CASE_ID1), RequestMethod.POST, UPDATE_BODY);
+        verifyCmsServerEndpoint(1, String.format(CMS_UPDATE_CASE, CASE_ID2), RequestMethod.POST, UPDATE_BODY);
+        verifyCmsServerEndpoint(1, String.format(CMS_UPDATE_CASE, CASE_ID3), RequestMethod.POST, UPDATE_BODY);
+        verifyCmsServerEndpoint(1, String.format(CMS_UPDATE_BULK_CASE_PATH, BULK_CASE_ID, CREATE_EVENT), RequestMethod.POST);
+    }
+
     private void waitAsyncCompleted() {
         await().until(() -> asyncTaskExecutor.getThreadPoolExecutor().getActiveCount() == 0);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessBulkCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessBulkCaseITest.java
@@ -242,6 +242,7 @@ public class ProcessBulkCaseITest extends IdamTestSupport {
         stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, CASE_ID1), HttpStatus.UNPROCESSABLE_ENTITY, getCmsBulkCaseResponse(), POST);
         stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, CASE_ID2), HttpStatus.OK, getCmsBulkCaseResponse(), POST);
         stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, CASE_ID3), HttpStatus.OK, getCmsBulkCaseResponse(), POST);
+        stubCmsServerEndpoint(String.format(CMS_UPDATE_BULK_CASE_PATH, BULK_CASE_ID, CREATE_EVENT), HttpStatus.OK, getCmsBulkCaseResponse(), POST);
 
         stubSignInForCaseworker();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImplTest.java
@@ -1,12 +1,14 @@
 package uk.gov.hmcts.reform.divorce.orchestration.service.impl;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.BulkWorkflowExecutionResult;
 import uk.gov.hmcts.reform.divorce.orchestration.event.bulk.BulkCaseCreateEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.event.bulk.BulkCaseUpdateCourtHearingEvent;
 import uk.gov.hmcts.reform.divorce.orchestration.event.bulk.BulkCaseUpdatePronouncementDateEvent;
@@ -47,6 +49,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class BulkCaseServiceImplTest {
 
     private static final String FAILED_CASE_ID = "failedCaseId";
+    private static final String TEST_CASE_ID_ONE = "caseId1";
+    private static final String TEST_CASE_ID_TWO = "caseId2";
 
     @Mock
     private LinkBulkCaseWorkflow linkBulkCaseWorkflow;
@@ -71,24 +75,26 @@ public class BulkCaseServiceImplTest {
         Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
             CCD_CASE_DATA_FIELD, ImmutableMap.of(CASE_LIST_KEY, Arrays.asList(caseData, caseData)));
 
-        when(linkBulkCaseWorkflow.executeWithRetries(caseDetail, TEST_CASE_ID, AUTH_TOKEN)).thenReturn(true);
+        BulkWorkflowExecutionResult result = BulkWorkflowExecutionResult.builder().successStatus(true).build();
+        when(linkBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN)).thenReturn(result);
         BulkCaseCreateEvent event = new BulkCaseCreateEvent(taskContext, caseDetail);
 
         classToTest.handleBulkCaseCreateEvent(event);
 
-        verify(linkBulkCaseWorkflow, times(1)).executeWithRetries(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+        verify(linkBulkCaseWorkflow, times(1)).executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
         verify(updateBulkCaseWorkflow, times(1)).run(Collections.emptyMap(), AUTH_TOKEN, TEST_CASE_ID, CREATE_EVENT);
     }
 
     @Test
-    public void givenFailuresClases_whenHandleBulkCase_thenBulkCaseIsNotUpdated() throws WorkflowException {
+    public void givenFailuresClasses_whenHandleBulkCase_thenBulkCaseIsNotUpdated() throws WorkflowException {
         TaskContext taskContext = new DefaultTaskContext();
         taskContext.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
         Map<String, Object> caseData = ImmutableMap.of("SomeKey", "SomeValue");
         Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
             CCD_CASE_DATA_FIELD, ImmutableMap.of(CASE_LIST_KEY, Arrays.asList(caseData, caseData)));
 
-        when(linkBulkCaseWorkflow.executeWithRetries(caseDetail, TEST_CASE_ID, AUTH_TOKEN)).thenReturn(false);
+        BulkWorkflowExecutionResult result = BulkWorkflowExecutionResult.builder().successStatus(false).build();
+        when(linkBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN)).thenReturn(result);
         BulkCaseCreateEvent event = new BulkCaseCreateEvent(taskContext, caseDetail);
 
         try {
@@ -99,7 +105,86 @@ public class BulkCaseServiceImplTest {
                 containsString(String.format("Failed to updating bulk case link for some cases on bulk case id %s", TEST_CASE_ID)));
 
         }
-        verify(linkBulkCaseWorkflow, times(1)).executeWithRetries(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+        verify(linkBulkCaseWorkflow, times(1)).executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+        verify(updateBulkCaseWorkflow, never()).run(Collections.emptyMap(), AUTH_TOKEN, TEST_CASE_ID, CREATE_EVENT);
+    }
+
+    @Test
+    public void givenRemovableCases_whenHandleBulkCase_thenBulkCaseIsUpdated() throws WorkflowException {
+        TaskContext taskContext = new DefaultTaskContext();
+        taskContext.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        Map<String, Object> caseReferenceOne = Collections.singletonMap(CASE_REFERENCE_FIELD, TEST_CASE_ID_ONE);
+        Map<String, Object> caseReferenceTwo = Collections.singletonMap(CASE_REFERENCE_FIELD, TEST_CASE_ID_TWO);
+        Map<String, Object> caseDataOne = ImmutableMap.of(CASE_REFERENCE_FIELD, caseReferenceOne);
+        Map<String, Object> caseDataTwo = ImmutableMap.of(CASE_REFERENCE_FIELD, caseReferenceTwo);
+        Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, ImmutableMap.of(
+                        CASE_LIST_KEY, Arrays.asList(
+                                Collections.singletonMap(VALUE_KEY, caseDataOne),
+                                Collections.singletonMap(VALUE_KEY, caseDataTwo)
+                        ),
+                        BULK_CASE_ACCEPTED_LIST_KEY, Arrays.asList(
+                                Collections.singletonMap(VALUE_KEY, caseReferenceOne),
+                                Collections.singletonMap(VALUE_KEY, caseReferenceTwo)
+                        )
+                ));
+
+        BulkWorkflowExecutionResult result = BulkWorkflowExecutionResult.builder()
+                .successStatus(true)
+                .failedCases(Arrays.asList(caseDataOne))
+                .removableCaseIds(ImmutableSet.of(TEST_CASE_ID_ONE))
+                .build();
+        when(linkBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN)).thenReturn(result);
+        BulkCaseCreateEvent event = new BulkCaseCreateEvent(taskContext, caseDetail);
+
+        classToTest.handleBulkCaseCreateEvent(event);
+
+        Map<String, Object> expectedUpdatePayload = ImmutableMap.of(
+                CASE_LIST_KEY, Arrays.asList(Collections.singletonMap(VALUE_KEY, caseDataTwo)),
+                BULK_CASE_ACCEPTED_LIST_KEY, Arrays.asList(Collections.singletonMap(VALUE_KEY, caseReferenceTwo))
+        );
+
+        verify(linkBulkCaseWorkflow, times(1)).executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
+        verify(updateBulkCaseWorkflow, times(1)).run(expectedUpdatePayload, AUTH_TOKEN, TEST_CASE_ID, CREATE_EVENT);
+    }
+
+    @Test
+    public void givenBothFailedAndRemovableCases_whenHandleBulkCase_thenBulkCaseIsNotUpdated() throws WorkflowException {
+        TaskContext taskContext = new DefaultTaskContext();
+        taskContext.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        Map<String, Object> caseReferenceOne = Collections.singletonMap(CASE_REFERENCE_FIELD, TEST_CASE_ID_ONE);
+        Map<String, Object> caseReferenceTwo = Collections.singletonMap(CASE_REFERENCE_FIELD, TEST_CASE_ID_TWO);
+        Map<String, Object> caseDataOne = ImmutableMap.of(CASE_REFERENCE_FIELD, caseReferenceOne);
+        Map<String, Object> caseDataTwo = ImmutableMap.of(CASE_REFERENCE_FIELD, caseReferenceTwo);
+        Map<String, Object> caseDetail = ImmutableMap.of(ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, ImmutableMap.of(
+                        CASE_LIST_KEY, Arrays.asList(
+                                Collections.singletonMap(VALUE_KEY, caseDataOne),
+                                Collections.singletonMap(VALUE_KEY, caseDataTwo)
+                        ),
+                        BULK_CASE_ACCEPTED_LIST_KEY, Arrays.asList(
+                                Collections.singletonMap(VALUE_KEY, caseReferenceOne),
+                                Collections.singletonMap(VALUE_KEY, caseReferenceTwo)
+                        )
+                ));
+
+        BulkWorkflowExecutionResult result = BulkWorkflowExecutionResult.builder()
+                .successStatus(false)
+                .failedCases(Arrays.asList(caseDataOne, caseDataTwo))
+                .removableCaseIds(ImmutableSet.of(TEST_CASE_ID_ONE))
+                .build();
+        when(linkBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN)).thenReturn(result);
+        BulkCaseCreateEvent event = new BulkCaseCreateEvent(taskContext, caseDetail);
+
+        try {
+            classToTest.handleBulkCaseCreateEvent(event);
+            Assert.fail("Expected bulkUpdateException");
+        } catch (BulkUpdateException e) {
+            assertThat(e.getMessage(),
+                    containsString(String.format("Failed to updating bulk case link for some cases on bulk case id %s", TEST_CASE_ID)));
+
+        }
+        verify(linkBulkCaseWorkflow, times(1)).executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);
         verify(updateBulkCaseWorkflow, never()).run(Collections.emptyMap(), AUTH_TOKEN, TEST_CASE_ID, CREATE_EVENT);
     }
 


### PR DESCRIPTION
# Description

[DIV-5346](https://tools.hmcts.net/jira/browse/DIV-5346)

There is an elastic search issue where sometimes a change to the case does not propagate to ES. This means a case already linked to a Bulk Case is sometimes retrieved in the search and there is an attempt to update the Bulk Link, which is not allowed, throwing an error.

This drops cases with a 422 error from the CaseList and CaseAcceptedList.
In case of 422 and missing Bulk Link, the next scheduled query should pick up the case to retry.
In case of 422 and existing Bulk Link, it will be removed from the extra Bulk Link, so that case will only be associated with one Bulk Case.

This does mean a bulk case can potentially end up with less cases than the minimum however.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
