### PR TITLE
Improve MakeCaseEligibleForDATest to be more resilient

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/MakeCaseEligibleForDATest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/MakeCaseEligibleForDATest.java
@@ -1,35 +1,48 @@
 package uk.gov.hmcts.reform.divorce.maintenance;
 
+import io.restassured.internal.MapCreator;
 import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.entity.ContentType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.RetrieveCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DA;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_PRONOUNCED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_EMAIL;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.service.SearchSourceFactory.buildCMSBooleanSearchSource;
 
 @Slf4j
 public class MakeCaseEligibleForDATest extends RetrieveCaseSupport {
 
     private static final String TEST_DN_PRONOUNCED = "testDNPronounced";
+    private static final String CMS_URL_SEARCH = "/casemaintenance/version/1/search";
     private static final String STATE_KEY = "state";
 
     private static final String SUBMIT_COMPLETE_CASE_JSON_FILE_PATH = "submit-complete-case.json";
@@ -40,6 +53,9 @@ public class MakeCaseEligibleForDATest extends RetrieveCaseSupport {
 
     @Value("${case.orchestration.jobScheduler.make-case-eligible-for-da.context-path}")
     private String jobSchedulerContextPath;
+
+    @Value("${case_maintenance.api.url}")
+    private String cmsBaseUrl;
 
     @Test
     public void givenCaseIsInDNPronounced_WhenMakeCaseEligibleForDAIsCalled_CaseStateIsAwaitingDecreeAbsolute() {
@@ -57,6 +73,8 @@ public class MakeCaseEligibleForDATest extends RetrieveCaseSupport {
         updateCaseForCitizen(caseId, null, TEST_DN_PRONOUNCED, citizenUser);
         log.debug("Case {} moved to DNPronounced.", caseId);
 
+        ensureCaseIsSearchable(caseId, citizenUser.getAuthToken());
+
         assertCaseStateIsAsExpected(DN_PRONOUNCED, citizenUser.getAuthToken());
 
         final UserDetails caseWorkerUser = createCaseWorkerUser();
@@ -65,11 +83,46 @@ public class MakeCaseEligibleForDATest extends RetrieveCaseSupport {
         assertCaseStateIsAsExpected(AWAITING_DA, citizenUser.getAuthToken());
     }
 
+    private void ensureCaseIsSearchable(final String caseId, final String authToken) {
+        await().pollInterval(fibonacci(SECONDS)).atMost(40, SECONDS).untilAsserted(() -> {
+            List<CaseDetails> foundCases = searchCasesWithElasticSearch(caseId, authToken);
+            assertThat("The number of cases found by ElasticSearch was not expected",
+                        foundCases.size(), is(1));
+        });
+    }
+
+    private List<CaseDetails> searchCasesWithElasticSearch(final String caseId, final String authToken) {
+
+        QueryBuilder caseIdFilter = QueryBuilders.matchQuery(CASE_ID_JSON_KEY, caseId);
+        QueryBuilder stateFilter = QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, DN_PRONOUNCED);
+
+        SearchSourceBuilder searchSourceBuilder =
+                            buildCMSBooleanSearchSource(0, 10, caseIdFilter, stateFilter);
+
+
+        Response resp = postToCMS(searchSourceBuilder.toString(), authToken);
+        SearchResult searchResult = resp.body().as(SearchResult.class);
+        return searchResult.getCases();
+    }
+
+    private Response postToCMS(String searchQuery, String authToken) {
+
+        final String searchUrl = cmsBaseUrl + CMS_URL_SEARCH;
+        log.debug("About to call {}, auth token [{}]", searchUrl, authToken);
+
+        return RestUtil.postToRestService(searchUrl,
+                buildCommonHeaders(HttpHeaders.AUTHORIZATION, authToken,
+                                    HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString()),
+                searchQuery,
+                emptyMap());
+
+    }
 
     private void assertCaseStateIsAsExpected(final String expectedState, final String authToken) {
         await().pollInterval(3, SECONDS).atMost(20, SECONDS).untilAsserted(() -> {
             final Response retrievedCase = retrieveCase(authToken);
-            log.debug("Retrieved case " + retrievedCase.path("caseId") + "with state " + retrievedCase.path("state"));
+            log.debug("Retrived case {} with state {}",
+                        retrievedCase.path("caseId"), retrievedCase.path("state"));
             assertThat(retrievedCase.path(STATE_KEY), equalTo(expectedState));
         });
     }
@@ -86,9 +139,15 @@ public class MakeCaseEligibleForDATest extends RetrieveCaseSupport {
             serverUrl + jobSchedulerContextPath,
             headers,
             null,
-            new HashMap<>()
+            emptyMap()
         );
 
         assertThat(response.getStatusCode(), is(HttpStatus.OK.value()));
+    }
+
+    private Map<String, Object> buildCommonHeaders(String firstHeaderName, Object firstHeaderValue,
+                                                   Object ... headValuePairs) {
+        return MapCreator.createMapFromParams(MapCreator.CollisionStrategy.MERGE,
+                                                firstHeaderName, firstHeaderValue, headValuePairs);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cms/CmsClientSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cms/CmsClientSupport.java
@@ -1,18 +1,37 @@
 package uk.gov.hmcts.reform.divorce.support.cms;
 
+import io.restassured.internal.MapCreator;
+import io.restassured.response.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.entity.ContentType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
+import uk.gov.hmcts.reform.divorce.util.RestUtil;
 
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
+
 @Component
+@Slf4j
 public class CmsClientSupport {
 
+    private static final String CMS_URL_SEARCH = "/casemaintenance/version/1/search";
+
     @Autowired
-    CaseMaintenanceClient cmsClient;
+    private CaseMaintenanceClient cmsClient;
+
+    @Value("${case_maintenance.api.url}")
+    private String cmsBaseUrl;
+
 
     public Map<String, Object> getDrafts(UserDetails userDetails) {
         return cmsClient.getDrafts(userDetails.getAuthToken());
@@ -22,5 +41,37 @@ public class CmsClientSupport {
     public void saveDrafts(String fileName, UserDetails userDetails) {
         Map<String, Object> draftResource = ResourceLoader.loadJsonToObject(fileName, Map.class);
         cmsClient.saveDraft(draftResource, userDetails.getAuthToken(), true);
+    }
+
+    /**
+     * Search cases via CMS' search endpoint.
+     * @param queryString a JSON-formatted query string
+     * @param authToken An authentication token passed to the CMS
+     * @return a collection of found cases or empty if none is found
+     */
+    public List<CaseDetails> searchCases(final String queryString, final String authToken) {
+
+        log.debug("Search case with query [{}], auth [{}]",queryString, authToken);
+
+        final String searchUrl = cmsBaseUrl + CMS_URL_SEARCH;
+        log.debug("About to call [{}], auth token [{}]", searchUrl, authToken);
+
+        // todo: cmsClient.searchCases is not used here the main reason is different domain objects CaseDetails and
+        // SearchResult are defined in the COS and CMS (references ccd-store-client)
+        Response response = RestUtil.postToRestService(searchUrl,
+                buildCommonHeaders(HttpHeaders.AUTHORIZATION, authToken,
+                        HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString()),
+                queryString,
+                emptyMap());
+
+        SearchResult searchResult = response.getBody().as(SearchResult.class);
+
+        return searchResult.getCases();
+    }
+
+    private Map<String, Object> buildCommonHeaders(String firstHeaderName, Object firstHeaderValue,
+                                                   Object ... headValuePairs) {
+        return MapCreator.createMapFromParams(MapCreator.CollisionStrategy.MERGE,
+                firstHeaderName, firstHeaderValue, headValuePairs);
     }
 }

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -1,8 +1,9 @@
 ###############################################
 #  Logging                                    #
 ###############################################
-logging.level.uk.gov.hmcts.ccd=DEBUG
-logging.level.org.springframework.web=DEBUG
+logging.level.uk.gov.hmcts.ccd: DEBUG
+logging.level.org.springframework.web: DEBUG
+logging.level.uk.gov.hmcts.reform.divorce: DEBUG
 
 ###############################################
 #  Setup                                      #

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -327,4 +327,7 @@ public class OrchestrationConstants {
         = "uk.gov.hmcts.reform.divorce.orchestration.tasks.BulkPrinter_Error";
     public static final String EMAIL_ERROR_KEY
         = "uk.gov.hmcts.reform.divorce.orchestration.tasks.EmailNotification_Error";
+
+    // Elastic Search
+    public static final String ES_CASE_ID_KEY = "reference";
 }


### PR DESCRIPTION
Added a search (timeout set to 40 seconds) to the test case in ElasticSearch via CMS to ensure that indexing is somehow complete and the ES is ready for queries

- [x] Test Improvement (non-breaking change which does not change any business logic / rules)

# How Has This Been Tested?
- Integration Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
