### PR TITLE
fix wrong reference showing in emails

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaGrantedNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaGrantedNotificationEmail.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
@@ -27,7 +28,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_FIRST_NAME_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_LAST_NAME_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getMandatoryPropertyValueAsString;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.DateUtils.formatDateWithCustomerFacingFormat;
 
@@ -56,7 +56,7 @@ public class SendDaGrantedNotificationEmail implements Task<Map<String, Object>>
             (String) caseData.get(D_8_PETITIONER_EMAIL),
             PETITIONER,
             caseData,
-            getCaseId(context)
+            getMandatoryPropertyValueAsString(caseData, D_8_CASE_REFERENCE)
         );
         // Send Respondent notification email
         sendEmail(
@@ -65,7 +65,7 @@ public class SendDaGrantedNotificationEmail implements Task<Map<String, Object>>
             (String) caseData.get(RESPONDENT_EMAIL_ADDRESS),
             RESPONDENT,
             caseData,
-            getCaseId(context)
+            getMandatoryPropertyValueAsString(caseData, D_8_CASE_REFERENCE)
         );
 
         return caseData;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaRequestedNotifyRespondentEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaRequestedNotifyRespondentEmail.java
@@ -16,6 +16,7 @@ import uk.gov.service.notify.NotificationClientException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_INFERRED_PETITIONER_GENDER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_LAST_NAME_KEY;
@@ -25,7 +26,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_FIRST_NAME_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_LAST_NAME_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getMandatoryPropertyValueAsString;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils.getRelationshipTermByGender;
 
@@ -48,7 +48,7 @@ public class SendDaRequestedNotifyRespondentEmail implements Task<Map<String, Ob
         String emailAddress = (String) caseData.get(RESPONDENT_EMAIL_ADDRESS);
         String firstName = (String) caseData.get(RESP_FIRST_NAME_CCD_FIELD);
         String lastName = (String) caseData.get(RESP_LAST_NAME_CCD_FIELD);
-        String ccdReference = getCaseId(context);
+        String d8Reference = (String) caseData.get(D_8_CASE_REFERENCE);
         String petitionerInferredGender = getMandatoryPropertyValueAsString(caseData,
             D_8_INFERRED_PETITIONER_GENDER);
         String petitionerRelationshipToRespondent = getRelationshipTermByGender(petitionerInferredGender);
@@ -59,7 +59,7 @@ public class SendDaRequestedNotifyRespondentEmail implements Task<Map<String, Ob
             templateVars.put(NOTIFICATION_EMAIL_ADDRESS_KEY, emailAddress);
             templateVars.put(NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY, firstName);
             templateVars.put(NOTIFICATION_ADDRESSEE_LAST_NAME_KEY, lastName);
-            templateVars.put(NOTIFICATION_CASE_NUMBER_KEY, ccdReference);
+            templateVars.put(NOTIFICATION_CASE_NUMBER_KEY, d8Reference);
             templateVars.put(NOTIFICATION_HUSBAND_OR_WIFE, petitionerRelationshipToRespondent);
 
             try {
@@ -73,7 +73,7 @@ public class SendDaRequestedNotifyRespondentEmail implements Task<Map<String, Ob
             }
 
         } else {
-            log.warn("no respondent email present for case reference, divorce may be using paper journey: {}", ccdReference);
+            log.warn("no respondent email present for case reference, divorce may be using paper journey: {}", d8Reference);
         }
 
         return caseData;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeAbsoluteAboutToBeGrantedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeAbsoluteAboutToBeGrantedWorkflow.java
@@ -17,7 +17,6 @@ import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_TEMPLATE_ID;
@@ -53,7 +52,6 @@ public class DecreeAbsoluteAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<
             caseDetails.getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails),
-            ImmutablePair.of(CASE_ID_JSON_KEY, caseDetails.getCaseId()),
             ImmutablePair.of(DOCUMENT_TYPE, DECREE_ABSOLUTE_DOCUMENT_TYPE),
             ImmutablePair.of(DOCUMENT_TEMPLATE_ID, DECREE_ABSOLUTE_TEMPLATE_ID),
             ImmutablePair.of(DOCUMENT_FILENAME, DECREE_ABSOLUTE_FILENAME)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/NotifyRespondentOfDARequestedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/NotifyRespondentOfDARequestedWorkflow.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendDaRequestedNotifyResp
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
 @Component
 public class NotifyRespondentOfDARequestedWorkflow extends DefaultWorkflow<Map<String, Object>> {
@@ -29,8 +28,7 @@ public class NotifyRespondentOfDARequestedWorkflow extends DefaultWorkflow<Map<S
         return this.execute(
             new Task[] {sendDaRequestedNotifyRespondentEmail},
             ccdCallbackRequest.getCaseDetails().getCaseData(),
-            ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails),
-            ImmutablePair.of(CASE_ID_JSON_KEY, caseDetails.getCaseId())
+            ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails)
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeAbsoluteRequestedRespondentNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeAbsoluteRequestedRespondentNotificationTest.java
@@ -38,7 +38,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPO
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_INFERRED_PETITIONER_GENDER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_EMAIL_ADDRESS;
@@ -67,7 +66,6 @@ public class DecreeAbsoluteRequestedRespondentNotificationTest {
     private static final Map CASE_DETAILS = singletonMap(CASE_DETAILS_JSON_KEY,
         ImmutableMap.<String, Object>builder()
             .put(CCD_CASE_DATA_FIELD, CASE_DATA)
-            .put(CCD_CASE_ID, TEST_CASE_ID)
             .build()
     );
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/DecreeAbsoluteServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/DecreeAbsoluteServiceImplTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.service.impl;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -7,13 +8,32 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.NotifyRespondentOfDARequestedWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.UpdateDNPronouncedCasesWorkflow;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_DECREE_ABSOLUTE_GRANTED_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PRONOUNCEMENT_JUDGE;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PRONOUNCEMENT_JUDGE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_FIRST_NAME_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_LAST_NAME_CCD_FIELD;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DecreeAbsoluteServiceImplTest {
@@ -26,6 +46,9 @@ public class DecreeAbsoluteServiceImplTest {
 
     @Mock
     private UpdateDNPronouncedCasesWorkflow updateDNPronouncedCasesWorkflow;
+
+    @Mock
+    private NotifyRespondentOfDARequestedWorkflow notifyRespondentOfDARequestedWorkflow;
 
     @Test
     public void run_10CasesEligibleForDA_10CasesProcessed() throws WorkflowException {
@@ -44,6 +67,45 @@ public class DecreeAbsoluteServiceImplTest {
         when(updateDNPronouncedCasesWorkflow.run(AUTH_TOKEN)).thenThrow(new WorkflowException(" a WorkflowException message"));
 
         classUnderTest.enableCaseEligibleForDecreeAbsolute(AUTH_TOKEN);
+    }
+
+
+    @Test
+    public void shouldCallTheRightWorkflow_forNotifyRespondentOfDARequested() throws WorkflowException {
+        CcdCallbackRequest ccdCallbackRequest = notifyRespondentOfDaCallbackRequest();
+
+        classUnderTest.notifyRespondentOfDARequested(ccdCallbackRequest, AUTH_TOKEN);
+
+        verify(notifyRespondentOfDARequestedWorkflow).run(ccdCallbackRequest);
+
+    }
+
+    @Test
+    public void shouldThrowWorkflowException_forNotifyRespondentOfDARequested() throws WorkflowException {
+        expectedException.expect(WorkflowException.class);
+        expectedException.expectMessage("a WorkflowException message");
+
+        CcdCallbackRequest ccdCallbackRequest = notifyRespondentOfDaCallbackRequest();
+
+        when(notifyRespondentOfDARequestedWorkflow.run(ccdCallbackRequest)).thenThrow(new WorkflowException(" a WorkflowException message"));
+
+        classUnderTest.notifyRespondentOfDARequested(ccdCallbackRequest, AUTH_TOKEN);
+    }
+
+    private CcdCallbackRequest notifyRespondentOfDaCallbackRequest() {
+        Map<String, Object> caseData = ImmutableMap.<String, Object>builder()
+            .put(PRONOUNCEMENT_JUDGE_CCD_FIELD, TEST_PRONOUNCEMENT_JUDGE)
+            .put(D_8_PETITIONER_FIRST_NAME, TEST_PETITIONER_FIRST_NAME)
+            .put(D_8_PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME)
+            .put(RESP_FIRST_NAME_CCD_FIELD, TEST_RESPONDENT_FIRST_NAME)
+            .put(RESP_LAST_NAME_CCD_FIELD, TEST_RESPONDENT_LAST_NAME)
+            .put(D_8_CASE_REFERENCE, TEST_CASE_ID)
+            .put(DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD, TEST_DECREE_ABSOLUTE_GRANTED_DATE)
+            .build();
+
+        return CcdCallbackRequest.builder().caseDetails(
+            CaseDetails.builder().caseData(caseData).build())
+            .build();
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaGrantedNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaGrantedNotificationEmailTest.java
@@ -33,6 +33,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPO
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
@@ -62,10 +63,9 @@ public class SendDaGrantedNotificationEmailTest {
     @Before
     public void setup() {
         context = new DefaultTaskContext();
-        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
 
         testData = new HashMap<>();
-        testData.put(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        testData.put(D_8_CASE_REFERENCE, TEST_CASE_ID);
         testData.put(DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD, TEST_DECREE_ABSOLUTE_GRANTED_DATE);
 
         expectedPetitionerTemplateVars = new HashMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaRequestedNotifyRespondentEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaRequestedNotifyRespondentEmailTest.java
@@ -34,6 +34,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPO
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_INFERRED_PETITIONER_GENDER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_ADDRESSEE_LAST_NAME_KEY;
@@ -62,10 +63,9 @@ public class SendDaRequestedNotifyRespondentEmailTest {
     @Before
     public void setup() {
         context = new DefaultTaskContext();
-        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
 
         testData = new HashMap<>();
-        testData.put(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        testData.put(D_8_CASE_REFERENCE, TEST_CASE_ID);
         testData.put(DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD, TEST_DECREE_ABSOLUTE_GRANTED_DATE);
 
         expectedTemplateVars = new HashMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeAbsoluteAboutToBeGrantedWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeAbsoluteAboutToBeGrantedWorkflowTest.java
@@ -27,7 +27,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_TEMPLATE_ID;
@@ -68,7 +67,6 @@ public class DecreeAbsoluteAboutToBeGrantedWorkflowTest {
         final Map<String, Object> result = decreeAbsoluteAboutToBeGrantedWorkflow.run(ccdCallbackRequest, "auth");
 
         context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
-        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, "auth");
         context.setTransientObject(DOCUMENT_TEMPLATE_ID, DECREE_ABSOLUTE_TEMPLATE_ID);
         context.setTransientObject(DOCUMENT_TYPE, DECREE_ABSOLUTE_DOCUMENT_TYPE);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/NotifyRespondentOfDARequestedWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/NotifyRespondentOfDARequestedWorkflowTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NotifyRespondentOfDARequestedWorkflowTest {
@@ -49,7 +48,6 @@ public class NotifyRespondentOfDARequestedWorkflowTest {
         final Map<String, Object> result = notifyRespondentOfDARequestedWorkflow.run(ccdCallbackRequest);
 
         context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
-        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
 
         assertThat(result, is(payload));
 


### PR DESCRIPTION
# Description

Previously the CCD case Id was being shown where the D8Familyman reference should of been shown on these emails. This PR is to fix this to show the D8Familyman reference.

Fixes # (issue)
https://tools.hmcts.net/jira/browse/DIV-5365

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
