### PR TITLE
Only run wiremockFunctional if unit test report was generated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -402,6 +402,7 @@ test {
 }
 
 task wiremockFunctional(type: Test, description: 'Executes wiremock functional tests', group: 'Verification') {
+    onlyIf { project.file("./build/reports/tests/test/index.html").exists() }
     test.outputs.upToDateWhen {false}
     testLogging.showStandardStreams = true
     include '**/functionaltest/**/*'


### PR DESCRIPTION
The test/index.html is only generated when Unit Tests successfully finish (whether it passes or fails)
This will make the functional tests run only in that case.
Where the unit tests were aborted due to a failure in a parallel pipeline such as DepedencyCheck, this change will stop the wiremockFunctionals from running and wasting time.

This is to avoid wiremock functionals being run by the finally block in Jenkins even when standard unit tests fail. https://github.com/hmcts/cnp-jenkins-library/blob/master/src/uk/gov/hmcts/contino/PipelineCallbacksRunner.groovy#L26