### PR TITLE
Fixed AOS test event to be triggered by citizen's token

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorLinkCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorLinkCaseCallbackTest.java
@@ -61,7 +61,7 @@ public class SolicitorLinkCaseCallbackTest extends RetrieveAosCaseSupport {
 
         String caseId = String.valueOf(caseDetails.getId());
         updateCaseForCitizen(caseId, null, TEST_AOS_STARTED_EVENT_ID, petitionerUserDetails);
-        updateCase(caseId, null, AOS_NOMINATE_SOL_EVENT_ID,
+        updateCaseForCitizen(caseId, null, AOS_NOMINATE_SOL_EVENT_ID, petitionerUserDetails,
                 ImmutablePair.of(D8_RESPONDENT_SOLICITOR_NAME, TEST_SOLICITOR_NAME),
                 ImmutablePair.of(D8_RESPONDENT_SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL)
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdSubmissionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdSubmissionSupport.java
@@ -95,10 +95,14 @@ public abstract class CcdSubmissionSupport extends IntegrationTest {
     }
 
     protected CaseDetails updateCaseForCitizen(String caseId, String fileName, String eventId,
-                                               UserDetails userDetails) {
-        return ccdClientSupport.updateForCitizen(caseId,
-                fileName == null ? null : loadJsonToObject(PAYLOAD_CONTEXT_PATH + fileName, Map.class),
-                eventId, userDetails);
+                                               UserDetails userDetails, Pair<String, String>... additionalCaseData) {
+        final Map caseData = fileName == null
+                ? new HashMap() : loadJsonToObject(PAYLOAD_CONTEXT_PATH + fileName, Map.class);
+
+        Arrays.stream(additionalCaseData).forEach(
+            caseField -> caseData.put(caseField.getKey(), caseField.getValue())
+        );
+        return ccdClientSupport.updateForCitizen(caseId, caseData, eventId, userDetails);
     }
 
     public Response submitRespondentAosCase(String userToken, Long caseId, String requestBody) {


### PR DESCRIPTION
# Description

https://github.com/hmcts/div-ccd-definitions/pull/145 changed the permission of the `aosNominateSol` to be R for caseworker, so the test needed updating to trigger the event using the citizen token (which has CRU) as it is the citizen who usually triggers this event (through RFE)

Fixes pipeline


- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
