### PR TITLE
Bumped elasticsearch version to remove vuln failing builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,7 @@ def versions = [
         postgresql                      : '42.2.5',
         hibernateTypes                  : '2.4.0',
         flyway                          : '5.2.4',
-        elasticsearch                   : '7.1.1'
+        elasticsearch                   : '7.2.1'
 ]
 
 dependencies {


### PR DESCRIPTION
Removes vulnerability failing our builds:
https://nvd.nist.gov/vuln/detail/CVE-2019-7614