### PR TITLE
DIV-5586: Adapting COS to generate two document for respondent AOS pa…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/IssueAosPackOfflineTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/IssueAosPackOfflineTest.java
@@ -16,10 +16,10 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.facts.DivorceFacts.SEPARATION_TWO_YEARS;
 import static uk.gov.hmcts.reform.divorce.util.ResourceLoader.objectToJson;
 
@@ -65,7 +65,7 @@ public class IssueAosPackOfflineTest extends IntegrationTest {
             hasJsonPath("$.data.D8DocumentsGenerated", allOf(
                 hasSize(2),
                 hasJsonPath("[0].value.DocumentFileName", is(RESPONDENT_AOS_INVITATION_LETTER_FILENAME + testCaseId)),
-                hasJsonPath("[1].value.DocumentFileName", is(TWO_YEAR_SEPARATION_FILENAME + testCaseId))
+                hasJsonPath("[1].value.DocumentFileName", is(AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME + testCaseId))
             )));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -15,7 +15,7 @@ public class OrchestrationConstants {
     // Task context properties
     public static final String CCD_CASE_DATA = "ccdCaseData";
     public static final String DN_COURT_DETAILS = "dnCourtDetails";
-    public static final String BULK_LINK_CASE_ID =  "bulkLinkCaseId";
+    public static final String BULK_LINK_CASE_ID = "bulkLinkCaseId";
 
     // Authentication
     public static final String ACCESS_CODE = "access_code";
@@ -269,15 +269,19 @@ public class OrchestrationConstants {
     public static final String DECREE_ABSOLUTE_DOCUMENT_TYPE = "daGranted";
     public static final String DECREE_ABSOLUTE_FILENAME = "decreeAbsolute";
     public static final String DECREE_ABSOLUTE_TEMPLATE_ID = "FL-DIV-GOR-ENG-00062.docx";
+    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_TEMPLATE_ID = "FL-DIV-GNO-ENG-00073.docx";
+    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_FILENAME = "solicitor-personal-service-";
+    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE = "personalService";
+
     public static final String RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE = "aosinvitationletter-offline-resp";
     public static final String RESPONDENT_AOS_INVITATION_LETTER_FILENAME = "aos-invitation-letter-offline-respondent";
     public static final String RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID = "FL-DIV-LET-ENG-00075.doc";
     public static final String CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE = "aosinvitationletter-offline-co-resp";
     public static final String CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME = "aos-invitation-letter-offline-co-respondent";
     public static final String CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID = "FL-DIV-LET-ENG-00076.doc";
-    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_TEMPLATE_ID = "FL-DIV-GNO-ENG-00073.docx";
-    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_FILENAME = "solicitor-personal-service-";
-    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE = "personalService";
+    public static final String TWO_YEAR_SEPARATION_DOCUMENT_TYPE = "two-year-separation-aos-form";
+    public static final String TWO_YEAR_SEPARATION_FILENAME = "two-year-separation-aos-form-resp";
+    public static final String TWO_YEAR_SEPARATION_TEMPLATE_ID = "FL-DIV-APP-ENG-00080.doc";
 
     public static final String DOCUMENT_TYPE_COE = "coe";
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -281,7 +281,7 @@ public class OrchestrationConstants {
     public static final String CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID = "FL-DIV-LET-ENG-00076.doc";
     public static final String AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE = "two-year-separation-aos-form";
     public static final String AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME = "two-year-separation-aos-form-resp";
-    public static final String AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID = "FL-DIV-APP-ENG-00080.doc";
+    public static final String AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID = "FL-DIV-APP-ENG-00080.docx";
 
     public static final String DOCUMENT_TYPE_COE = "coe";
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -279,9 +279,9 @@ public class OrchestrationConstants {
     public static final String CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE = "aosinvitationletter-offline-co-resp";
     public static final String CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME = "aos-invitation-letter-offline-co-respondent";
     public static final String CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID = "FL-DIV-LET-ENG-00076.doc";
-    public static final String TWO_YEAR_SEPARATION_DOCUMENT_TYPE = "two-year-separation-aos-form";
-    public static final String TWO_YEAR_SEPARATION_FILENAME = "two-year-separation-aos-form-resp";
-    public static final String TWO_YEAR_SEPARATION_TEMPLATE_ID = "FL-DIV-APP-ENG-00080.doc";
+    public static final String AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE = "two-year-separation-aos-form";
+    public static final String AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME = "two-year-separation-aos-form-resp";
+    public static final String AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID = "FL-DIV-APP-ENG-00080.doc";
 
     public static final String DOCUMENT_TYPE_COE = "coe";
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
@@ -74,13 +74,11 @@ public class IssueAosPackOfflineWorkflow extends DefaultWorkflow<Map<String, Obj
 
         if (divorceParty.equals(RESPONDENT)) {
             documentGenerationRequestList.add(RESPONDENT_AOS_INVITATION_LETTER);
-            if (StringUtils.isNotEmpty(reasonForDivorce)) {
-                log.debug("reasonForDivorce is {}", reasonForDivorce);
-                if (SEPARATION_TWO_YEARS.equals(reasonForDivorce)) {
-                    documentGenerationRequestList.add(new DocumentGenerationRequest(TWO_YEAR_SEPARATION_TEMPLATE_ID,
-                        TWO_YEAR_SEPARATION_DOCUMENT_TYPE,
-                        TWO_YEAR_SEPARATION_FILENAME));
-                }
+            log.debug("reasonForDivorce is {}", reasonForDivorce);
+            if (SEPARATION_TWO_YEARS.equals(reasonForDivorce)) {
+                documentGenerationRequestList.add(new DocumentGenerationRequest(TWO_YEAR_SEPARATION_TEMPLATE_ID,
+                    TWO_YEAR_SEPARATION_DOCUMENT_TYPE,
+                    TWO_YEAR_SEPARATION_FILENAME));
             }
         } else if (divorceParty.equals(CO_RESPONDENT)) {
             documentGenerationRequestList.add(CO_RESPONDENT_AOS_INVITATION_LETTER);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows.aospack.offline;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
@@ -18,6 +18,9 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE;
@@ -28,9 +31,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_DOCUMENT_TYPE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.facts.DivorceFacts.SEPARATION_TWO_YEARS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.parties.DivorceParty.CO_RESPONDENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.parties.DivorceParty.RESPONDENT;
@@ -75,9 +75,9 @@ public class IssueAosPackOfflineWorkflow extends DefaultWorkflow<Map<String, Obj
             documentGenerationRequestList.add(RESPONDENT_AOS_INVITATION_LETTER);
             log.debug("reasonForDivorce is {}", reasonForDivorce);
             if (SEPARATION_TWO_YEARS.equals(reasonForDivorce)) {
-                documentGenerationRequestList.add(new DocumentGenerationRequest(TWO_YEAR_SEPARATION_TEMPLATE_ID,
-                    TWO_YEAR_SEPARATION_DOCUMENT_TYPE,
-                    TWO_YEAR_SEPARATION_FILENAME));
+                documentGenerationRequestList.add(new DocumentGenerationRequest(AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID,
+                    AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE,
+                    AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME));
             }
         } else if (divorceParty.equals(CO_RESPONDENT)) {
             documentGenerationRequestList.add(CO_RESPONDENT_AOS_INVITATION_LETTER);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows.aospack.offline;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -12,10 +14,10 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGenerationTask;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
@@ -23,23 +25,27 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_GENERATION_REQUESTS_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_FILENAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.facts.DivorceFacts.SEPARATION_TWO_YEARS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.parties.DivorceParty.CO_RESPONDENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.parties.DivorceParty.RESPONDENT;
 
 @Component
+@Slf4j
 public class IssueAosPackOfflineWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
-    private static final List<DocumentGenerationRequest> RESPONDENT_DOCUMENT_GENERATION_REQUEST_LIST = asList(
-        new DocumentGenerationRequest(RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID,
-            RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, RESPONDENT_AOS_INVITATION_LETTER_FILENAME)
-    );
-    private static final List<DocumentGenerationRequest> CO_RESPONDENT_DOCUMENT_GENERATION_REQUEST_LIST = asList(
-        new DocumentGenerationRequest(CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID,
-            CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME)
-    );
+    private static final DocumentGenerationRequest RESPONDENT_AOS_INVITATION_LETTER = new DocumentGenerationRequest(
+        RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID, RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, RESPONDENT_AOS_INVITATION_LETTER_FILENAME);
+
+    private static final DocumentGenerationRequest CO_RESPONDENT_AOS_INVITATION_LETTER = new DocumentGenerationRequest(
+        CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID, CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE,
+        CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME);
 
     @Autowired
     private MultipleDocumentGenerationTask documentsGenerationTask;
@@ -48,25 +54,36 @@ public class IssueAosPackOfflineWorkflow extends DefaultWorkflow<Map<String, Obj
     private CaseFormatterAddDocuments caseFormatterAddDocuments;
 
     public Map<String, Object> run(String authToken, CaseDetails caseDetails, DivorceParty divorceParty) throws WorkflowException {
+        Map<String, Object> caseData = caseDetails.getCaseData();
+        String reasonForDivorce = (String) caseData.get(D_8_REASON_FOR_DIVORCE);
+
         return execute(
             new Task[] {
                 documentsGenerationTask,
                 caseFormatterAddDocuments
             },
-            caseDetails.getCaseData(),
+            caseData,
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails),
-            ImmutablePair.of(DOCUMENT_GENERATION_REQUESTS_KEY, getDocumentGenerationRequestsList(divorceParty))
+            ImmutablePair.of(DOCUMENT_GENERATION_REQUESTS_KEY, getDocumentGenerationRequestsList(divorceParty, reasonForDivorce))
         );
     }
 
-    private List<DocumentGenerationRequest> getDocumentGenerationRequestsList(DivorceParty divorceParty) {
-        List<DocumentGenerationRequest> documentGenerationRequestList;
+    private List<DocumentGenerationRequest> getDocumentGenerationRequestsList(DivorceParty divorceParty, String reasonForDivorce) {
+        List<DocumentGenerationRequest> documentGenerationRequestList = new ArrayList<>();
 
         if (divorceParty.equals(RESPONDENT)) {
-            documentGenerationRequestList = RESPONDENT_DOCUMENT_GENERATION_REQUEST_LIST;
+            documentGenerationRequestList.add(RESPONDENT_AOS_INVITATION_LETTER);
+            if (StringUtils.isNotEmpty(reasonForDivorce)) {
+                log.debug("reasonForDivorce is {}", reasonForDivorce);
+                if (SEPARATION_TWO_YEARS.equals(reasonForDivorce)) {
+                    documentGenerationRequestList.add(new DocumentGenerationRequest(TWO_YEAR_SEPARATION_TEMPLATE_ID,
+                        TWO_YEAR_SEPARATION_DOCUMENT_TYPE,
+                        TWO_YEAR_SEPARATION_FILENAME));
+                }
+            }
         } else if (divorceParty.equals(CO_RESPONDENT)) {
-            documentGenerationRequestList = CO_RESPONDENT_DOCUMENT_GENERATION_REQUEST_LIST;
+            documentGenerationRequestList.add(CO_RESPONDENT_AOS_INVITATION_LETTER);
         } else {
             documentGenerationRequestList = emptyList();
         }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aospack/offline/AosPackRespondentOfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aospack/offline/AosPackRespondentOfflineTest.java
@@ -49,6 +49,9 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID;
@@ -56,9 +59,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_DOCUMENT_TYPE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.TWO_YEAR_SEPARATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.getJsonFromResourceFile;
 
@@ -148,20 +148,20 @@ public class AosPackRespondentOfflineTest {
 
         //Stubbing DGS mock for form
         GenerateDocumentRequest formDocumentRequest = GenerateDocumentRequest.builder()
-            .template(TWO_YEAR_SEPARATION_TEMPLATE_ID)
+            .template(AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID)
             .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
             .build();
         GeneratedDocumentInfo formDocumentInfo = GeneratedDocumentInfo.builder()
-            .documentType(TWO_YEAR_SEPARATION_DOCUMENT_TYPE)
-            .fileName(TWO_YEAR_SEPARATION_FILENAME)
+            .documentType(AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE)
+            .fileName(AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME)
             .build();
         stubDocumentGeneratorServerEndpoint(formDocumentRequest, formDocumentInfo);
-        String formFilename = TWO_YEAR_SEPARATION_FILENAME + caseDetails.getCaseId();
+        String formFilename = AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME + caseDetails.getCaseId();
 
         //Stubbing CFS
         stubFormatterServerEndpoint(asList(
             ImmutablePair.of(invitationLetterFilename, RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE),
-            ImmutablePair.of(formFilename, TWO_YEAR_SEPARATION_DOCUMENT_TYPE)
+            ImmutablePair.of(formFilename, AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE)
         ));
 
         webClient.perform(post(format(API_URL, "respondent"))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflowTest.java
@@ -51,7 +51,7 @@ public class IssueAosPackOfflineWorkflowTest {
     private static final String CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE = "aosinvitationletter-offline-co-resp";
     private static final String CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_FILENAME = "aos-invitation-letter-offline-co-respondent";
 
-    private static final String RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM = "FL-DIV-APP-ENG-00080.doc";
+    private static final String RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM = "FL-DIV-APP-ENG-00080.docx";
     private static final String RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM_DOCUMENT_TYPE = "two-year-separation-aos-form";
     private static final String RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM_FILENAME = "two-year-separation-aos-form-resp";
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflowTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskExc
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGenerationTask;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +36,9 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_GENERATION_REQUESTS_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.facts.DivorceFacts.SEPARATION_TWO_YEARS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.parties.DivorceParty.RESPONDENT;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IssueAosPackOfflineWorkflowTest {
@@ -46,6 +50,10 @@ public class IssueAosPackOfflineWorkflowTest {
     private static final String CO_RESPONDENT_AOS_INVITATION_LETTER = "FL-DIV-LET-ENG-00076.doc";
     private static final String CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE = "aosinvitationletter-offline-co-resp";
     private static final String CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_FILENAME = "aos-invitation-letter-offline-co-respondent";
+
+    private static final String RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM = "FL-DIV-APP-ENG-00080.doc";
+    private static final String RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM_DOCUMENT_TYPE = "two-year-separation-aos-form";
+    private static final String RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM_FILENAME = "two-year-separation-aos-form-resp";
 
     @Mock
     private MultipleDocumentGenerationTask documentsGenerationTask;
@@ -64,15 +72,43 @@ public class IssueAosPackOfflineWorkflowTest {
 
     @Before
     public void setUp() throws TaskException {
-        Map<String, Object> payload = singletonMap("testKey", "testValue");
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("testKey", "testValue");
         when(documentsGenerationTask.execute(any(), any())).thenReturn(singletonMap("returnedKey1", "returnedValue1"));
         when(caseFormatterAddDocuments.execute(any(), any())).thenReturn(singletonMap("returnedKey2", "returnedValue2"));
         caseDetails = CaseDetails.builder().caseData(payload).build();
     }
 
     @Test
-    public void testTasksAreCalledWithTheCorrectParams_ForRespondent() throws WorkflowException, TaskException {
-        Map<String, Object> returnedPayload = issueAosPackOfflineWorkflow.run(testAuthToken, caseDetails, DivorceParty.RESPONDENT);
+    public void testTasksAreCalledWithTheCorrectParams_ForRespondent_ForTwoYearSeparation() throws WorkflowException, TaskException {
+        caseDetails.getCaseData().put(D_8_REASON_FOR_DIVORCE, SEPARATION_TWO_YEARS);
+
+        Map<String, Object> returnedPayload = issueAosPackOfflineWorkflow.run(testAuthToken, caseDetails, RESPONDENT);
+        assertThat(returnedPayload, hasEntry("returnedKey2", "returnedValue2"));
+
+        verify(documentsGenerationTask).execute(taskContextArgumentCaptor.capture(), eq(caseDetails.getCaseData()));
+        TaskContext taskContext = taskContextArgumentCaptor.getValue();
+        assertThat(taskContext.getTransientObject(AUTH_TOKEN_JSON_KEY), is(testAuthToken));
+        assertThat(taskContext.getTransientObject(CASE_DETAILS_JSON_KEY), is(caseDetails));
+
+        List<DocumentGenerationRequest> documentGenerationRequestList = taskContext.getTransientObject(DOCUMENT_GENERATION_REQUESTS_KEY);
+        DocumentGenerationRequest firstDocumentGenerationRequest = documentGenerationRequestList.get(0);
+        assertThat(firstDocumentGenerationRequest.getDocumentTemplateId(), is(RESPONDENT_AOS_INVITATION_LETTER));
+        assertThat(firstDocumentGenerationRequest.getDocumentType(), is(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE));
+        assertThat(firstDocumentGenerationRequest.getDocumentFileName(), is(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_FILENAME));
+        DocumentGenerationRequest secondDocumentGenerationRequest = documentGenerationRequestList.get(1);
+        assertThat(secondDocumentGenerationRequest.getDocumentTemplateId(), is(RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM));
+        assertThat(secondDocumentGenerationRequest.getDocumentType(), is(RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM_DOCUMENT_TYPE));
+        assertThat(secondDocumentGenerationRequest.getDocumentFileName(), is(RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM_FILENAME));
+
+        verify(caseFormatterAddDocuments).execute(any(), argThat(new HamcrestArgumentMatcher<>(allOf(
+            Matchers.<String, Object>hasEntry("returnedKey1", "returnedValue1")
+        ))));
+    }
+
+    @Test
+    public void testTasksAreCalledWithTheCorrectParams_ForRespondent_ForOtherReason() throws WorkflowException, TaskException {
+        Map<String, Object> returnedPayload = issueAosPackOfflineWorkflow.run(testAuthToken, caseDetails, RESPONDENT);
         assertThat(returnedPayload, hasEntry("returnedKey2", "returnedValue2"));
 
         verify(documentsGenerationTask).execute(taskContextArgumentCaptor.capture(), eq(caseDetails.getCaseData()));


### PR DESCRIPTION
…ck offline for two-years separation

**Obs.: This should only be merged after https://github.com/hmcts/div-document-generator-client/pull/186. In fact, the integration tests won't pass until this is merged.**

# Description

One more document need to be produced as part of the AOS pack offline for respondent for two-years separation.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit, functional and integration tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
