### PR TITLE
DIV-5098 DN Refusal Order Clarification Document

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnAboutToBeGrantedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnAboutToBeGrantedTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.divorce.callback;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
+import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
+import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.junit.Assert.assertThat;
+import static uk.gov.hmcts.reform.divorce.util.ResourceLoader.objectToJson;
+
+public class DnAboutToBeGrantedTest extends IntegrationTest {
+
+    private static final String CCD_CALLBACK_REQUEST = "fixtures/callback/dn-refusal-clarification.json";
+
+    @Autowired
+    private CosApiClient cosApiClient;
+
+    @Test
+    public void givenCcdCallbackRequest_whenDnAboutToBeGrantedWithRefusalClarification_thenGenerateRefusalOrderDocument() {
+        CcdCallbackRequest ccdCallbackRequest = ResourceLoader.loadJsonToObject(CCD_CALLBACK_REQUEST, CcdCallbackRequest.class);
+
+        CcdCallbackResponse response = cosApiClient.processDnAboutToBeGranted(createCaseWorkerUser().getAuthToken(), ccdCallbackRequest);
+
+        String jsonResponse = objectToJson(response);
+
+        assertThat(jsonResponse,
+            hasJsonPath("$.data.state"),
+            hasJsonPath("$.data.D8DocumentsGenerated"));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -188,4 +188,13 @@ public interface CosApiClient {
             @RequestHeader(AUTHORIZATION) String authorisation,
             @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
+
+    @RequestMapping(
+            method = RequestMethod.POST,
+            value = "/dn-about-to-be-granted"
+    )
+    CcdCallbackResponse processDnAboutToBeGranted(
+            @RequestHeader(AUTHORIZATION) String authorisation,
+            @RequestBody CcdCallbackRequest ccdCallbackRequest
+    );
 }

--- a/src/integrationTest/resources/fixtures/callback/dn-refusal-clarification.json
+++ b/src/integrationTest/resources/fixtures/callback/dn-refusal-clarification.json
@@ -1,0 +1,12 @@
+{
+  "token": "token",
+  "event_id": "eventId",
+  "case_details": {
+    "id": "0123456789012345",
+    "state": "state",
+    "case_data": {
+      "DecreeNisiGranted": "No",
+      "RefusalDecision": "moreInfo"
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -616,6 +616,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> dnAboutToBeGranted(
+        @RequestHeader(value = "Authorization") String authToken,
         @RequestBody @ApiParam("CaseData")
             CcdCallbackRequest ccdCallbackRequest) {
 
@@ -623,7 +624,7 @@ public class CallbackController {
 
         CcdCallbackResponse.CcdCallbackResponseBuilder callbackResponseBuilder = CcdCallbackResponse.builder();
         try {
-            callbackResponseBuilder.data(caseOrchestrationService.processCaseBeforeDecreeNisiIsGranted(ccdCallbackRequest));
+            callbackResponseBuilder.data(caseOrchestrationService.processCaseBeforeDecreeNisiIsGranted(ccdCallbackRequest, authToken));
             log.info("Processed case successfully. Case id: {}", caseId);
         } catch (CaseOrchestrationServiceException exception) {
             log.error(format("Failed to execute service. Case id:  %s", caseId), exception);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -108,6 +108,7 @@ public class OrchestrationConstants {
     //CCD DN fields
     public static final String DN_OUTCOME_FLAG_CCD_FIELD = "DnOutcomeCase";
     public static final String REFUSAL_DECISION_CCD_FIELD = "RefusalDecision";
+    public static final String REFUSAL_DECISION_MORE_INFO_VALUE = "moreInfo";
 
     // CCD Events
     public static final String DN_RECEIVED = "dnReceived";
@@ -261,6 +262,9 @@ public class OrchestrationConstants {
     public static final String DECREE_NISI_TEMPLATE_ID = "FL-DIV-GNO-ENG-00021.docx";
     public static final String DOCUMENT_TYPE_DN_ANSWERS = "dnAnswers";
     public static final String DN_ANSWERS_TEMPLATE_ID = "FL-DIV-GNO-ENG-00022.docx";
+    public static final String DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00088.docx";
+    public static final String DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE = "d79";
+    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME = "decreeNisiRefusalOrder";
     public static final String DECREE_ABSOLUTE_DOCUMENT_TYPE = "daGranted";
     public static final String DECREE_ABSOLUTE_FILENAME = "decreeAbsolute";
     public static final String DECREE_ABSOLUTE_TEMPLATE_ID = "FL-DIV-GOR-ENG-00062.docx";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -111,7 +111,7 @@ public interface CaseOrchestrationService {
 
     Map<String, Object> processAosSolicitorLinkCase(CcdCallbackRequest request, String authToken) throws CaseOrchestrationServiceException;
 
-    Map<String, Object> processCaseBeforeDecreeNisiIsGranted(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException;
+    Map<String, Object> processCaseBeforeDecreeNisiIsGranted(CcdCallbackRequest ccdCallbackRequest, String authToken) throws CaseOrchestrationServiceException;
 
     Map<String, Object> updateBulkCaseDnPronounce(CaseDetails caseDetails, String authToken) throws WorkflowException;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -627,9 +627,11 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     }
 
     @Override
-    public Map<String, Object> processCaseBeforeDecreeNisiIsGranted(CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
+    public Map<String, Object> processCaseBeforeDecreeNisiIsGranted(CcdCallbackRequest ccdCallbackRequest, String authToken)
+        throws CaseOrchestrationServiceException {
+
         try {
-            return decreeNisiAboutToBeGrantedWorkflow.run(ccdCallbackRequest.getCaseDetails());
+            return decreeNisiAboutToBeGrantedWorkflow.run(ccdCallbackRequest.getCaseDetails(), authToken);
         } catch (WorkflowException e) {
             throw new CaseOrchestrationServiceException(e);
         }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.client.DocumentGeneratorClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GenerateDocumentRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.service.FeatureToggleService;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonMap;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Features.DN_REFUSAL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_MORE_INFO_VALUE;
+
+@Component
+@AllArgsConstructor
+public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, Object>> {
+
+    private final DocumentGeneratorClient documentGeneratorClient;
+    private final FeatureToggleService featureToggleService;
+
+    @Override
+    public Map<String, Object> execute(final TaskContext context, final Map<String, Object> caseData) {
+        CaseDetails caseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
+
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.computeTransientObjectIfAbsent(DOCUMENT_COLLECTION,
+            new LinkedHashSet<>());
+
+        if (String.valueOf(caseData.get(REFUSAL_DECISION_CCD_FIELD)).equalsIgnoreCase(REFUSAL_DECISION_MORE_INFO_VALUE)
+            && featureToggleService.isFeatureEnabled(DN_REFUSAL)) {
+
+            GeneratedDocumentInfo generatedDocumentInfo = generatePdfDocument(
+                DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
+                DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE,
+                DECREE_NISI_REFUSAL_DOCUMENT_NAME,
+                context.getTransientObject(AUTH_TOKEN_JSON_KEY),
+                caseDetails
+            );
+
+            documentCollection.add(generatedDocumentInfo);
+        }
+
+        return caseData;
+    }
+
+    private GeneratedDocumentInfo generatePdfDocument(String templateId, String documentType, String documentName,
+                                                      String authToken, CaseDetails caseDetails) {
+        final GeneratedDocumentInfo generatedDocumentInfo =
+            documentGeneratorClient.generatePDF(
+                GenerateDocumentRequest.builder()
+                    .template(templateId)
+                    .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
+                    .build(),
+                authToken
+            );
+
+        generatedDocumentInfo.setDocumentType(documentType);
+        generatedDocumentInfo.setFileName(format(DOCUMENT_FILENAME_FMT, documentName, caseDetails.getCaseId()));
+
+        return generatedDocumentInfo;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
@@ -8,6 +9,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddDecreeNisiDecisionDateTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddDnOutcomeFlagFieldTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.DecreeNisiRefusalDocumentGeneratorTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DefineWhoPaysCostsOrderTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetDNDecisionStateTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateDNDecisionTask;
@@ -16,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_GRANTED_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
@@ -34,7 +39,11 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
 
     private final SetDNDecisionStateTask setDNDecisionStateTask;
 
-    public Map<String, Object> run(CaseDetails caseDetails) throws WorkflowException {
+    private final DecreeNisiRefusalDocumentGeneratorTask decreeNisiRefusalDocumentGeneratorTask;
+
+    private final CaseFormatterAddDocuments caseFormatterAddDocuments;
+
+    public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
         List<Task> tasksToRun = new ArrayList<>();
 
         Map<String, Object> caseData = caseDetails.getCaseData();
@@ -51,7 +60,15 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
             }
         }
 
-        Map<String, Object> payloadToReturn = this.execute(tasksToRun.stream().toArray(Task[]::new), caseData);
+        tasksToRun.add(decreeNisiRefusalDocumentGeneratorTask);
+        tasksToRun.add(caseFormatterAddDocuments);
+
+        Map<String, Object> payloadToReturn = this.execute(
+            tasksToRun.stream().toArray(Task[]::new),
+            caseData,
+            ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
+            ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails)
+        );
 
         return payloadToReturn;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
@@ -759,7 +759,7 @@ public class CallbackControllerTest {
     }
 
     public void testDnAboutToBeGrantedCallsRightServiceMethod() throws CaseOrchestrationServiceException {
-        when(caseOrchestrationService.processCaseBeforeDecreeNisiIsGranted(any()))
+        when(caseOrchestrationService.processCaseBeforeDecreeNisiIsGranted(any(), eq(AUTH_TOKEN)))
             .thenReturn(singletonMap("newKey", "newValue"));
 
         CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder()
@@ -767,17 +767,17 @@ public class CallbackControllerTest {
                 .caseData(singletonMap("testKey", "testValue"))
                 .build())
             .build();
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.dnAboutToBeGranted(ccdCallbackRequest);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.dnAboutToBeGranted(AUTH_TOKEN, ccdCallbackRequest);
 
         assertThat(response.getStatusCode(), equalTo(OK));
         assertThat(response.getBody().getData(), hasEntry("newKey", "newValue"));
         assertThat(response.getBody().getErrors(), is(nullValue()));
-        verify(caseOrchestrationService).processCaseBeforeDecreeNisiIsGranted(eq(ccdCallbackRequest));
+        verify(caseOrchestrationService).processCaseBeforeDecreeNisiIsGranted(eq(ccdCallbackRequest), eq(AUTH_TOKEN));
     }
 
     @Test
     public void testDnAboutToBeGrantedHandlesServiceException() throws CaseOrchestrationServiceException {
-        when(caseOrchestrationService.processCaseBeforeDecreeNisiIsGranted(any()))
+        when(caseOrchestrationService.processCaseBeforeDecreeNisiIsGranted(any(), eq(AUTH_TOKEN)))
             .thenThrow(new CaseOrchestrationServiceException(new Exception("This is a test error message.")));
 
         CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder()
@@ -785,12 +785,12 @@ public class CallbackControllerTest {
                 .caseData(singletonMap("testKey", "testValue"))
                 .build())
             .build();
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.dnAboutToBeGranted(ccdCallbackRequest);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.dnAboutToBeGranted(AUTH_TOKEN, ccdCallbackRequest);
 
         assertThat(response.getStatusCode(), equalTo(OK));
         assertThat(response.getBody().getData(), is(nullValue()));
         assertThat(response.getBody().getErrors(), hasItem(equalTo("This is a test error message.")));
-        verify(caseOrchestrationService).processCaseBeforeDecreeNisiIsGranted(eq(ccdCallbackRequest));
+        verify(caseOrchestrationService).processCaseBeforeDecreeNisiIsGranted(eq(ccdCallbackRequest), eq(AUTH_TOKEN));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -1,53 +1,79 @@
 package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.google.common.collect.ImmutableMap;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.Features;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.DocumentUpdateRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GenerateDocumentRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.orchestration.service.impl.FeatureToggleServiceImpl;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.util.HashMap;
+import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_PRONOUNCEMENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_GRANTED_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_DECISION_DATE_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_OUTCOME_FLAG_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_MORE_INFO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.STATE_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.WHO_PAYS_CCD_CODE_FOR_RESPONDENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.WHO_PAYS_COSTS_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.SetDNDecisionStateTask.DN_REFUSED_REJECT_OPTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
 @RunWith(SpringRunner.class)
 public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
 
     private static final String API_URL = "/dn-about-to-be-granted";
     private static final String CCD_RESPONSE_DATA_FIELD = "data";
+
+    private static final String ADD_DOCUMENTS_CONTEXT_PATH = "/caseformatter/version/1/add-documents";
+    private static final String GENERATE_DOCUMENT_CONTEXT_PATH = "/version/1/generatePDF";
 
     @Autowired
     private MockMvc webClient;
@@ -73,7 +99,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
             singletonMap(CCD_CASE_DATA_FIELD, caseData)
         ));
 
-        webClient.perform(post(API_URL).content(inputJson).contentType(APPLICATION_JSON))
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(allOf(
                 isJson(),
@@ -95,7 +121,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
             )
         ));
 
-        webClient.perform(post(API_URL).content(inputJson).contentType(APPLICATION_JSON))
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(allOf(
                 isJson(),
@@ -117,7 +143,66 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
             )
         ));
 
-        webClient.perform(post(API_URL).content(inputJson).contentType(APPLICATION_JSON))
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(allOf(
+                isJson(),
+                hasJsonPath(CCD_RESPONSE_DATA_FIELD, allOf(
+                    hasJsonPath(DECREE_NISI_GRANTED_CCD_FIELD, equalTo(NO_VALUE)),
+                    hasJsonPath(STATE_CCD_FIELD, equalTo(AWAITING_CLARIFICATION)),
+                    hasJsonPath(DN_DECISION_DATE_FIELD, equalTo(ccdUtil.getCurrentDateCcdFormat())),
+                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD),
+                    hasNoJsonPath(DN_OUTCOME_FLAG_CCD_FIELD)
+                ))
+            )));
+    }
+
+    @Test
+    public void shouldReturnCaseDataPlusClarificationDocument_AndState_WhenDN_NotGranted_AndDnReusedForMoreInfo() throws Exception {
+        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(ImmutableMap.of(
+            DECREE_NISI_GRANTED_CCD_FIELD, NO_VALUE,
+            REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE
+        )).build();
+
+        final GenerateDocumentRequest documentGenerationRequest =
+            GenerateDocumentRequest.builder()
+                .template(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
+                .build();
+
+        final GeneratedDocumentInfo documentGenerationResponse =
+            GeneratedDocumentInfo.builder()
+                .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
+                .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+                .build();
+
+        Map<String, Object> expectedDocumentUpdateRequestData = ImmutableMap.of(
+            DECREE_NISI_GRANTED_CCD_FIELD, NO_VALUE,
+            REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE,
+            STATE_CCD_FIELD, AWAITING_CLARIFICATION,
+            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat()
+        );
+
+        final DocumentUpdateRequest documentUpdateRequest =
+            DocumentUpdateRequest.builder()
+                .documents(asList(documentGenerationResponse))
+                .caseData(expectedDocumentUpdateRequestData)
+                .build();
+
+        stubDocumentGeneratorServerEndpoint(documentGenerationRequest, documentGenerationResponse);
+        stubFormatterServerEndpoint(documentUpdateRequest, expectedDocumentUpdateRequestData);
+
+        String inputJson = JSONObject.valueToString(singletonMap(CASE_DETAILS_JSON_KEY,
+            ImmutableMap.of(
+                ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, ImmutableMap.of(
+                    DECREE_NISI_GRANTED_CCD_FIELD, NO_VALUE,
+                    REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE
+                )
+            )
+        ));
+
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(allOf(
                 isJson(),
@@ -140,7 +225,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                 DECREE_NISI_GRANTED_CCD_FIELD, YES_VALUE)
             ))
         );
-        webClient.perform(post(API_URL).content(inputJson).contentType(APPLICATION_JSON))
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(allOf(
                 isJson(),
@@ -157,7 +242,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     DECREE_NISI_GRANTED_CCD_FIELD, YES_VALUE)
             ))
         );
-        webClient.perform(post(API_URL).content(inputJson).contentType(APPLICATION_JSON))
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(allOf(
                 isJson(),
@@ -174,7 +259,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     DECREE_NISI_GRANTED_CCD_FIELD, NO_VALUE)
             ))
         );
-        webClient.perform(post(API_URL).content(inputJson).contentType(APPLICATION_JSON))
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(allOf(
                 isJson(),
@@ -196,7 +281,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     DECREE_NISI_GRANTED_CCD_FIELD, NO_VALUE)
             ))
         );
-        webClient.perform(post(API_URL).content(inputJson).contentType(APPLICATION_JSON))
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(allOf(
                 isJson(),
@@ -206,6 +291,27 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     hasJsonPath(DN_DECISION_DATE_FIELD, equalTo(ccdUtil.getCurrentDateCcdFormat()))
                 ))
             )));
+    }
+
+    private void stubDocumentGeneratorServerEndpoint(GenerateDocumentRequest generateDocumentRequest,
+                                                     GeneratedDocumentInfo response) {
+        documentGeneratorServiceServer.stubFor(WireMock.post(GENERATE_DOCUMENT_CONTEXT_PATH)
+                .withRequestBody(equalToJson(convertObjectToJsonString(generateDocumentRequest)))
+                .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+                .willReturn(aResponse()
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withStatus(HttpStatus.OK.value())
+                        .withBody(convertObjectToJsonString(response))));
+    }
+
+    private void stubFormatterServerEndpoint(DocumentUpdateRequest documentUpdateRequest,
+                                             Map<String, Object> response) {
+        formatterServiceServer.stubFor(WireMock.post(ADD_DOCUMENTS_CONTEXT_PATH)
+                .withRequestBody(equalToJson(convertObjectToJsonString(documentUpdateRequest)))
+                .willReturn(aResponse()
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                        .withStatus(HttpStatus.OK.value())
+                        .withBody(convertObjectToJsonString(response))));
     }
 
     private void setDnFeature(Boolean enableFeature) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -1190,9 +1190,10 @@ public class CaseOrchestrationServiceImplTest {
 
     @Test
     public void shouldCallWorkflow_ForDecreeNisiIsAboutToBeGranted() throws WorkflowException, CaseOrchestrationServiceException {
-        when(decreeNisiAboutToBeGrantedWorkflow.run(ccdCallbackRequest.getCaseDetails())).thenReturn(singletonMap("returnedKey", "returnedValue"));
+        when(decreeNisiAboutToBeGrantedWorkflow.run(ccdCallbackRequest.getCaseDetails(), AUTH_TOKEN))
+                .thenReturn(singletonMap("returnedKey", "returnedValue"));
 
-        Map<String, Object> returnedPayload = classUnderTest.processCaseBeforeDecreeNisiIsGranted(ccdCallbackRequest);
+        Map<String, Object> returnedPayload = classUnderTest.processCaseBeforeDecreeNisiIsGranted(ccdCallbackRequest, AUTH_TOKEN);
 
         assertThat(returnedPayload, hasEntry("returnedKey", "returnedValue"));
     }
@@ -1200,14 +1201,14 @@ public class CaseOrchestrationServiceImplTest {
     @Test
     public void shouldThrowServiceException_ForDecreeNisiIsAboutToBeGranted_WhenWorkflowExceptionIsCaught()
         throws WorkflowException, CaseOrchestrationServiceException {
-        when(decreeNisiAboutToBeGrantedWorkflow.run(ccdCallbackRequest.getCaseDetails()))
+        when(decreeNisiAboutToBeGrantedWorkflow.run(ccdCallbackRequest.getCaseDetails(), AUTH_TOKEN))
             .thenThrow(new WorkflowException("This operation threw an exception."));
 
         expectedException.expect(CaseOrchestrationServiceException.class);
         expectedException.expectMessage(is("This operation threw an exception."));
         expectedException.expectCause(is(instanceOf(WorkflowException.class)));
 
-        classUnderTest.processCaseBeforeDecreeNisiIsGranted(ccdCallbackRequest);
+        classUnderTest.processCaseBeforeDecreeNisiIsGranted(ccdCallbackRequest, AUTH_TOKEN);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -19,9 +19,9 @@ import java.util.Map;
 
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -100,17 +100,13 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
         context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
 
-        //given
-        when(featureToggleService.isFeatureEnabled(eq(Features.DN_REFUSAL))).thenReturn(true);
-
         //when
         decreeNisiRefusalDocumentGeneratorTask.execute(context, payload);
 
         final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.getTransientObject(DOCUMENT_COLLECTION);
 
-        assertThat(documentCollection, isNull());
-
-        verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
+        assertThat(documentCollection.size(), is(0));
+;
         verify(documentGeneratorClient, never())
                 .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
     }
@@ -137,7 +133,7 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.getTransientObject(DOCUMENT_COLLECTION);
 
-        assertThat(documentCollection, isNull());
+        assertThat(documentCollection.size(), is(0));
 
         verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
         verify(documentGeneratorClient, never())

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -1,0 +1,146 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.client.DocumentGeneratorClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.Features;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.service.FeatureToggleService;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_MORE_INFO_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGenerationTaskTest.matchesDocumentInputParameters;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DecreeNisiRefusalDocumentGeneratorTaskTest {
+
+    @Mock
+    private DocumentGeneratorClient documentGeneratorClient;
+
+    @Mock
+    private FeatureToggleService featureToggleService;
+
+    @InjectMocks
+    private DecreeNisiRefusalDocumentGeneratorTask decreeNisiRefusalDocumentGeneratorTask;
+
+    @Test
+    public void callsDocumentGeneratorAndStoresGeneratedDocumentForDnRefusalClarification() {
+        final Map<String, Object> payload = new HashMap<>();
+        payload.put(REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE);
+        final CaseDetails caseDetails = CaseDetails.builder()
+                .caseId(TEST_CASE_ID)
+                .caseData(payload)
+                .build();
+
+        final TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
+
+        final GeneratedDocumentInfo expectedDocument = GeneratedDocumentInfo.builder()
+                .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
+                .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+                .build();
+
+        //given
+        when(featureToggleService.isFeatureEnabled(eq(Features.DN_REFUSAL))).thenReturn(true);
+        when(documentGeneratorClient
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN))
+        ).thenReturn(expectedDocument);
+
+        //when
+        decreeNisiRefusalDocumentGeneratorTask.execute(context, payload);
+
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.getTransientObject(DOCUMENT_COLLECTION);
+
+        assertThat(documentCollection, is(newLinkedHashSet(expectedDocument)));
+
+        verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
+        verify(documentGeneratorClient)
+                .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
+    }
+
+    @Test
+    public void doesNotCallDocumentGeneratorWhenRefusalReasonIsNotMoreInfo() {
+        final Map<String, Object> payload = new HashMap<>();
+        final CaseDetails caseDetails = CaseDetails.builder()
+                .caseId(TEST_CASE_ID)
+                .caseData(payload)
+                .build();
+
+        final TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
+
+        //given
+        when(featureToggleService.isFeatureEnabled(eq(Features.DN_REFUSAL))).thenReturn(true);
+
+        //when
+        decreeNisiRefusalDocumentGeneratorTask.execute(context, payload);
+
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.getTransientObject(DOCUMENT_COLLECTION);
+
+        assertThat(documentCollection, isNull());
+
+        verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
+        verify(documentGeneratorClient, never())
+                .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
+    }
+
+    @Test
+    public void doesNotCallDocumentGeneratorWhenFeatureToggleIsOff() {
+        final Map<String, Object> payload = new HashMap<>();
+        payload.put(REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE);
+        final CaseDetails caseDetails = CaseDetails.builder()
+                .caseId(TEST_CASE_ID)
+                .caseData(payload)
+                .build();
+
+        final TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
+
+        //given
+        when(featureToggleService.isFeatureEnabled(eq(Features.DN_REFUSAL))).thenReturn(false);
+
+        //when
+        decreeNisiRefusalDocumentGeneratorTask.execute(context, payload);
+
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.getTransientObject(DOCUMENT_COLLECTION);
+
+        assertThat(documentCollection, isNull());
+
+        verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
+        verify(documentGeneratorClient, never())
+                .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflowTest.java
@@ -13,6 +13,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddDecreeNisiDecisionDateTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddDnOutcomeFlagFieldTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.DecreeNisiRefusalDocumentGeneratorTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DefineWhoPaysCostsOrderTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetDNDecisionStateTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateDNDecisionTask;
@@ -33,6 +35,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
@@ -57,6 +60,12 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
     @Mock
     private SetDNDecisionStateTask setDNDecisionStateTask;
 
+    @Mock
+    private DecreeNisiRefusalDocumentGeneratorTask decreeNisiRefusalDocumentGeneratorTask;
+
+    @Mock
+    private CaseFormatterAddDocuments caseFormatterAddDocuments;
+
     @InjectMocks
     private DecreeNisiAboutToBeGrantedWorkflow workflow;
 
@@ -79,8 +88,11 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(addDecreeNisiDecisionDateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(payloadReturnedByTask);
         when(defineWhoPaysCostsOrderTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
         when(addDnOutcomeFlagFieldTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
+        when(decreeNisiRefusalDocumentGeneratorTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
+        when(caseFormatterAddDocuments.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
 
-        Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build());
+
+        Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
 
         assertThat(returnedPayload, allOf(
             hasEntry(equalTo("addedKey"), equalTo("addedValue")),
@@ -92,7 +104,9 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
             validateDNDecisionTask,
             addDecreeNisiDecisionDateTask,
             defineWhoPaysCostsOrderTask,
-            addDnOutcomeFlagFieldTask
+            addDnOutcomeFlagFieldTask,
+            decreeNisiRefusalDocumentGeneratorTask,
+            caseFormatterAddDocuments
         );
 
         inOrder.verify(setDNDecisionStateTask).execute(any(TaskContext.class), eq(inputPayload));
@@ -100,6 +114,8 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         inOrder.verify(addDecreeNisiDecisionDateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDnOutcomeFlagFieldTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
         inOrder.verify(defineWhoPaysCostsOrderTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
+        inOrder.verify(decreeNisiRefusalDocumentGeneratorTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
+        inOrder.verify(caseFormatterAddDocuments).execute(any(TaskContext.class), eq(payloadReturnedByTask));
     }
 
     @Test
@@ -113,8 +129,10 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(validateDNDecisionTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(addDecreeNisiDecisionDateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(payloadReturnedByTask);
         when(addDnOutcomeFlagFieldTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
+        when(decreeNisiRefusalDocumentGeneratorTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
+        when(caseFormatterAddDocuments.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
 
-        Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build());
+        Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
 
         assertThat(returnedPayload, allOf(
             hasEntry(equalTo("addedKey"), equalTo("addedValue")),
@@ -125,13 +143,18 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
             setDNDecisionStateTask,
             validateDNDecisionTask,
             addDecreeNisiDecisionDateTask,
-            addDnOutcomeFlagFieldTask
+            addDnOutcomeFlagFieldTask,
+            decreeNisiRefusalDocumentGeneratorTask,
+            caseFormatterAddDocuments
         );
 
         inOrder.verify(setDNDecisionStateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(validateDNDecisionTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDecreeNisiDecisionDateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDnOutcomeFlagFieldTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
+        inOrder.verify(decreeNisiRefusalDocumentGeneratorTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
+        inOrder.verify(caseFormatterAddDocuments).execute(any(TaskContext.class), eq(payloadReturnedByTask));
+
         verify(defineWhoPaysCostsOrderTask, never()).execute(any(), any());
     }
 
@@ -142,8 +165,10 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(setDNDecisionStateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(validateDNDecisionTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(addDecreeNisiDecisionDateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(payloadReturnedByTask);
+        when(decreeNisiRefusalDocumentGeneratorTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
+        when(caseFormatterAddDocuments.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
 
-        Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build());
+        Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
 
         assertThat(returnedPayload, allOf(
             hasEntry(equalTo(DECREE_NISI_GRANTED_CCD_FIELD), equalTo(NO_VALUE))
@@ -152,12 +177,16 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         final InOrder inOrder = inOrder(
             setDNDecisionStateTask,
             validateDNDecisionTask,
-            addDecreeNisiDecisionDateTask
+            addDecreeNisiDecisionDateTask,
+            decreeNisiRefusalDocumentGeneratorTask,
+            caseFormatterAddDocuments
         );
 
         inOrder.verify(setDNDecisionStateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(validateDNDecisionTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDecreeNisiDecisionDateTask).execute(any(TaskContext.class), eq(inputPayload));
+        inOrder.verify(decreeNisiRefusalDocumentGeneratorTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
+        inOrder.verify(caseFormatterAddDocuments).execute(any(TaskContext.class), eq(payloadReturnedByTask));
 
         verify(addDnOutcomeFlagFieldTask, never()).execute(any(), any());
         verify(defineWhoPaysCostsOrderTask, never()).execute(any(), any());
@@ -171,7 +200,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(validateDNDecisionTask.execute(isNotNull(), eq(inputPayload))).thenThrow(new TaskException(errorMessage));
 
         try {
-            workflow.run(CaseDetails.builder().caseData(inputPayload).build());
+            workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
             fail("Workflow exception expected");
         } catch (WorkflowException e) {
             assertThat(e.getMessage(), is(errorMessage));


### PR DESCRIPTION
# Description

[DIV-5098](https://tools.hmcts.net/jira/browse/DIV-5098)

This PR modifies the existing Legal Advisor Make a Decision event callback to generate a DN Refusal Order document (for Clarification) when the LA has requested moreInfo. It attaches this generated PDF's binary url to the case.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
