### PR TITLE
Amend gradle to allow for lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,11 @@ def versions = [
 dependencies {
     compile project(':job-scheduler')
 
+    compileOnly("org.projectlombok:lombok:${versions.lombok}")
+    testCompileOnly("org.projectlombok:lombok:${versions.lombok}")
+    annotationProcessor("org.projectlombok:lombok:${versions.lombok}")
+    testAnnotationProcessor("org.projectlombok:lombok:${versions.lombok}")
+
     compile group: 'uk.gov.hmcts.reform', name: 'send-letter-client', version: versions.sendLetterClient
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-quartz'
     compile group: 'org.springframework.retry', name: 'spring-retry'
@@ -295,19 +300,16 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: versions.reformsJavaLogging
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: versions.reformsJavaLogging
     compile (group: 'uk.gov.hmcts.reform', name:'service-auth-provider-client', version: versions.serviceTokenGenerator)
-        {
-            exclude group: 'io.reactivex', module: 'io.reactivex'
-            exclude group: 'io.reactivex', module: 'rxnetty'
-            exclude group: 'io.reactivex', module: 'rxnetty-contexts'
-            exclude group: 'io.reactivex', module: 'rxnetty-servo'
-        }
+            {
+                exclude group: 'io.reactivex', module: 'io.reactivex'
+                exclude group: 'io.reactivex', module: 'rxnetty'
+                exclude group: 'io.reactivex', module: 'rxnetty-contexts'
+                exclude group: 'io.reactivex', module: 'rxnetty-servo'
+            }
     compile group: 'com.jayway.jsonpath', name:'json-path-assert', version: versions.jsonPathAssert
     compile group: 'org.pitest', name: 'pitest', version: versions.pitest
     compile group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: versions.gradlePitest
     compile group: 'org.codehaus.sonar-plugins', name:'sonar-pitest-plugin', version: versions.sonarPitest
-
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
     compile (group: 'com.fasterxml.jackson.core', name:'jackson-databind', version: versions.jacksonDatabind) {
         force = true
@@ -353,7 +355,6 @@ dependencies {
     }
     testCompile group: 'com.github.tomakehurst', name:'wiremock', version: versions.wiremockVersion
 
-    testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     testCompile 'org.awaitility:awaitility:3.1.6'
 
     //integration test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/ScheduleBulkCaseForListingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/ScheduleBulkCaseForListingTest.java
@@ -27,7 +27,7 @@ public class ScheduleBulkCaseForListingTest extends CcdSubmissionSupport {
     private static final String COURT_NAME_FIELD_KEY = "CourtName";
     private static final String BULK_LISTED_STATE = "Listed";
 
-    private static final int  MAX_WAITING_TIME_IN_SECONDS = 60;
+    private static final int  MAX_WAITING_TIME_IN_SECONDS = 90;
     private static final int  POOL_INTERVAL_IN_MILLIS = 1000;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/MakeCaseEligibleForDATest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/MakeCaseEligibleForDATest.java
@@ -106,7 +106,7 @@ public class MakeCaseEligibleForDATest extends RetrieveCaseSupport {
     }
 
     private void assertCaseStateIsAsExpected(final String expectedState, final String authToken) {
-        await().pollInterval(fibonacci(SECONDS)).atMost(150, SECONDS).untilAsserted(() -> {
+        await().pollInterval(fibonacci(SECONDS)).atMost(360, SECONDS).untilAsserted(() -> {
             final Response retrievedCase = retrieveCase(authToken);
             log.debug("Retrieved case {} with state {}",
                         retrievedCase.path("caseId"), retrievedCase.path("state"));


### PR DESCRIPTION
Allow Intelli-J test runner to pick up Lombok annotations after Gradle 5 upgrade.