### PR TITLE
DIV-5516 - bump chart version to 1.2.0

### DIFF
--- a/charts/div-cos/Chart.yaml
+++ b/charts/div-cos/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Divorce - Case Orchestration Service
 name: div-cos
-version: 1.1.0
+version: 1.2.0


### PR DESCRIPTION

# Description

Because of chart configuration changes in https://github.com/hmcts/div-case-orchestration-service/pull/448
We need to bump the version number to make sure new changes take effect

Fixes #DIV-5516

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
