### PR TITLE
Enable DN Refusal Clarification on AAT by default

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -9,3 +9,4 @@ health_check_ttl = 30000
 
 scheduler_enabled = "true"
 feature_resp_solicitor_details = "true"
+feature_dn_refusal = "true"


### PR DESCRIPTION
Has been tested on PRs and ready to by demoed on AAT.

This will enable the feature on AAT by default.