### PR TITLE
Removing default terraform e-mails and fixing TF variable

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -11,4 +11,6 @@ scheduler_enabled = "true"
 feature_resp_solicitor_details = "true"
 feature_dn_refusal = "true"
 
+scheduler_send_updated_cases_to_robotics_enabled = "true"
+
 dataextraction_status_da_email_to = "da_data_extraction@sharklasers.com"

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -10,3 +10,5 @@ health_check_ttl = 30000
 scheduler_enabled = "true"
 feature_resp_solicitor_details = "true"
 feature_dn_refusal = "true"
+
+dataextraction_status_da_email_to = "da_data_extraction@sharklasers.com"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -100,7 +100,7 @@ module "div-cos" {
     SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_TRUST        = "${var.spring_mail_properties_mail_smtp_ssl_trust}"
 
     DATAEXTRACTION_STATUS_DA_EMAILTO       = "${var.dataextraction_status_da_email_to}"
-    SCHEDULER_SEND_UPDATED_CASES_TO_ROBOTICS_CRON  = "${var.scheduler_send_updated_cases_to_robotics_cron}"
+    SCHEDULER_SEND_UPDATED_CASES_TO_ROBOTICS_ENABLED  = "${var.scheduler_send_updated_cases_to_robotics_enabled}"
   }
 }
 

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -6,3 +6,5 @@ health_check_ttl = 30000
 scheduler_enabled = "true"
 feature_resp_solicitor_details = "true"
 feature_dn_refusal = "true"
+
+dataextraction_status_da_email_to = "da_data_extraction@sharklasers.com"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -6,6 +6,6 @@ documentation_swagger_enabled = "false"
 
 # Scheduler Jobs
 scheduler_make_cases_eligible_da_enabled = "true"
-scheduler_send_updated_cases_to_robotics_cron = "true"
+scheduler_send_updated_cases_to_robotics_enabled = "true"
 
 dataextraction_status_da_email_to = "StokeCTSC4.Auto@justice.gov.uk"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -122,12 +122,6 @@ variable "documentation_swagger_enabled" {
   default = "true"
 }
 
-variable "scheduler_send_updated_cases_to_robotics_cron" {
-  type    = "string"
-  default = "0 0 2 ? * * *"
-  description = "The scheduler job should run every day at 2 am"
-}
-
 variable "spring_mail_host" {
   type = "string"
   default = "mta.reform.hmcts.net"
@@ -152,5 +146,7 @@ variable "spring_mail_properties_mail_smtp_ssl_trust" {
 
 variable "dataextraction_status_da_email_to" {
   type = "string"
-  default = "da_data_extraction@sharklasers.com"
+}
+
+variable "scheduler_send_updated_cases_to_robotics_enabled" {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -344,7 +344,7 @@ dataExtraction:
   emailFrom: noreply@reform.hmcts.net
   status:
     DA:
-      emailTo: da-extraction@divorce.gov.uk
+      emailTo:
 
 bulk-action:
   page-size: 50

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks.dataextraction;
 
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +16,9 @@ import java.nio.file.Files;
 
 import javax.mail.MessagingException;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.rules.ExpectedException.none;
+
 /**
  * This test can be run to test (locally) that our e-mail is sent according to our expectations.
  * This assertion has to be done manually for now, using MailHog.
@@ -24,6 +29,9 @@ import javax.mail.MessagingException;
 public class DataExtractionEmailClientTest {
 
     private File file;
+
+    @Rule
+    public ExpectedException expectedException = none();
 
     @Autowired
     private DataExtractionEmailClient dataExtractionEmailClient;
@@ -41,6 +49,13 @@ public class DataExtractionEmailClientTest {
     public void sendEmailWithAttachment() throws MessagingException {
         dataExtractionEmailClient.sendEmailWithAttachment("test@divorce.gov.uk", "myFileName.csv", file);
         //Now go to MailHog and check that your e-mail has been sent as expected
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenEmailIsEmpty() throws MessagingException {
+        expectedException.expect(instanceOf(Exception.class));
+
+        dataExtractionEmailClient.sendEmailWithAttachment("", "myFileName.csv", file);
     }
 
 }


### PR DESCRIPTION
# Description

This is about not having test e-mail addresses as default, so that if something goes wrong in the AKS migration, we don't end up sending the prod data to test e-mails.
I'm also addressing a TF variable issue identified by @hosainnet.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Integration tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
