### PR TITLE
DIV-5766 Add AwaitingClarification Path in DN-Submit Endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
@@ -28,4 +28,23 @@ public class SubmitDnCaseTest extends CcdSubmissionSupport {
         assertEquals(caseDetails.getId(), cosResponse.path("id"));
         assertEquals("AwaitingLegalAdvisorReferral", cosResponse.path("state"));
     }
+
+    @Test
+    public void whenSubmitDnWithAwaitingClarification_thenProceedAsExpected() throws Exception {
+        final UserDetails userDetails = createCitizenUser();
+
+        final CaseDetails caseDetails = submitCase("submit-complete-case.json", userDetails);
+
+        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, TEST_AOS_STARTED_EVENT_ID, userDetails);
+        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, "aosSubmittedUndefended", userDetails);
+        updateCase(String.valueOf(caseDetails.getId()), null, "refertoLegalAdvisor");
+        updateCase(String.valueOf(caseDetails.getId()), null, "dnClarificationRequested");
+
+        Response cosResponse = submitDnCase(userDetails.getAuthToken(), caseDetails.getId(),
+            "dn-submit.json");
+
+        assertEquals(OK.value(), cosResponse.getStatusCode());
+        assertEquals(caseDetails.getId(), cosResponse.path("id"));
+        assertEquals("ClarificationSubmitted", cosResponse.path("state"));
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.divorce.maintenance;
 
 import io.restassured.response.Response;
+import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
@@ -11,40 +12,60 @@ import static org.springframework.http.HttpStatus.OK;
 
 public class SubmitDnCaseTest extends CcdSubmissionSupport {
     private static final String TEST_AOS_STARTED_EVENT_ID = "testAosStarted";
+    private static final String AOS_SUBMITTED_UNDEFENDED_EVENT_ID = "aosSubmittedUndefended";
+
+    private UserDetails userDetails;
+    private CaseDetails caseDetails;
+
+    @Before
+    public void setup() {
+        userDetails = createCitizenUser();
+        caseDetails = submitCase("submit-complete-case.json", userDetails);
+    }
 
     @Test
     public void whenSubmitDn_thenProceedAsExpected() throws Exception {
-        final UserDetails userDetails = createCitizenUser();
+        updateCaseForCitizen(TEST_AOS_STARTED_EVENT_ID);
+        updateCaseForCitizen(AOS_SUBMITTED_UNDEFENDED_EVENT_ID);
 
-        final CaseDetails caseDetails = submitCase("submit-complete-case.json", userDetails);
-
-        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, TEST_AOS_STARTED_EVENT_ID, userDetails);
-        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, "aosSubmittedUndefended", userDetails);
-
-        Response cosResponse = submitDnCase(userDetails.getAuthToken(), caseDetails.getId(),
-            "dn-submit.json");
+        Response cosResponse = submitDnCase();
 
         assertEquals(OK.value(), cosResponse.getStatusCode());
         assertEquals(caseDetails.getId(), cosResponse.path("id"));
         assertEquals("AwaitingLegalAdvisorReferral", cosResponse.path("state"));
     }
 
+
     @Test
     public void whenSubmitDnWithAwaitingClarification_thenProceedAsExpected() throws Exception {
-        final UserDetails userDetails = createCitizenUser();
+        updateCaseForCitizen(TEST_AOS_STARTED_EVENT_ID);
+        updateCaseForCitizen(AOS_SUBMITTED_UNDEFENDED_EVENT_ID);
+        submitDnCase();
 
-        final CaseDetails caseDetails = submitCase("submit-complete-case.json", userDetails);
+        // Move to AwaitingClarification
+        updateCaseForCaseworker("refertoLegalAdvisor");
+        updateCaseForCaseworker("dnClarificationRequested");
 
-        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, TEST_AOS_STARTED_EVENT_ID, userDetails);
-        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, "aosSubmittedUndefended", userDetails);
-        updateCase(String.valueOf(caseDetails.getId()), null, "refertoLegalAdvisor");
-        updateCase(String.valueOf(caseDetails.getId()), null, "dnClarificationRequested");
-
-        Response cosResponse = submitDnCase(userDetails.getAuthToken(), caseDetails.getId(),
-            "dn-submit.json");
+        Response cosResponse = submitDnCase();
 
         assertEquals(OK.value(), cosResponse.getStatusCode());
         assertEquals(caseDetails.getId(), cosResponse.path("id"));
         assertEquals("ClarificationSubmitted", cosResponse.path("state"));
+    }
+
+    private void updateCaseForCitizen(final String eventId) {
+        updateCaseForCitizen(String.valueOf(caseDetails.getId()), null, eventId, userDetails);
+    }
+
+    private void updateCaseForCaseworker(final String eventId) {
+        updateCase(String.valueOf(caseDetails.getId()), null, eventId);
+    }
+
+    private Response submitDnCase() throws Exception {
+        return submitDnCase(
+            userDetails.getAuthToken(),
+            caseDetails.getId(),
+            "dn-submit.json"
+        );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.divorce.maintenance;
 
 import io.restassured.response.Response;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
@@ -35,7 +36,7 @@ public class SubmitDnCaseTest extends CcdSubmissionSupport {
         assertEquals("AwaitingLegalAdvisorReferral", cosResponse.path("state"));
     }
 
-
+    @Ignore // Needs config to pass
     @Test
     public void whenSubmitDnWithAwaitingClarification_thenProceedAsExpected() throws Exception {
         updateCaseForCitizen(TEST_AOS_STARTED_EVENT_ID);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
@@ -64,6 +64,15 @@ public interface CaseFormatterClient {
     );
 
     @RequestMapping(
+        method = RequestMethod.POST,
+        value = "/caseformatter/version/1/to-dn-clarification-format",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+    )
+    Map<String, Object> transformToDnClarificationCaseFormat(
+        @RequestBody Map<String, Object> divorceCaseWrapper
+    );
+
+    @RequestMapping(
             method = RequestMethod.POST,
             value = "/caseformatter/version/1/remove-all-petition-documents",
             headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -129,6 +129,7 @@ public class OrchestrationConstants {
     // CCD Events
     public static final String DN_RECEIVED = "dnReceived";
     public static final String DN_RECEIVED_AOS_COMPLETE = "dnReceivedAosCompleted";
+    public static final String DN_RECEIVED_CLARIFICATION = "submitDnClarification";
     public static final String AMEND_PETITION_EVENT = "amendPetition";
     public static final String AOS_START_FROM_OVERDUE = "startAosFromOverdue";
     public static final String AOS_START_FROM_REISSUE = "startAosFromReissue";
@@ -384,4 +385,8 @@ public class OrchestrationConstants {
     // Elastic Search
     public static final String ES_CASE_ID_KEY = "reference";
     public static final String QUERY_BUILDERS = "queryBuilders";
+
+    // Case Data Formatter Meta Fields
+    public static final String FORMATTER_CASE_DATA_KEY = "caseData";
+    public static final String FORMATTER_DIVORCE_SESSION_KEY = "divorceSession";
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDnCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDnCaseData.java
@@ -1,12 +1,19 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
+import com.google.common.collect.ImmutableMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseFormatterClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
 import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FORMATTER_CASE_DATA_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FORMATTER_DIVORCE_SESSION_KEY;
 
 @Component
 public class FormatDivorceSessionToDnCaseData implements Task<Map<String, Object>> {
@@ -20,8 +27,18 @@ public class FormatDivorceSessionToDnCaseData implements Task<Map<String, Object
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> sessionData) {
-        return caseFormatterClient.transformToDnCaseFormat(
-            sessionData
-        );
+        CaseDetails caseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
+
+        if (AWAITING_CLARIFICATION.equalsIgnoreCase(caseDetails.getState())) {
+            Map<String, Object> divorceCaseWrapper = ImmutableMap.of(
+                FORMATTER_CASE_DATA_KEY, caseDetails.getCaseData(),
+                FORMATTER_DIVORCE_SESSION_KEY, sessionData
+            );
+            return caseFormatterClient.transformToDnClarificationCaseFormat(divorceCaseWrapper);
+        } else {
+            return caseFormatterClient.transformToDnCaseFormat(
+                sessionData
+            );
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitDnCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitDnCase.java
@@ -11,10 +11,13 @@ import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_COMPLETED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED_AOS_COMPLETE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED_CLARIFICATION;
 
 @Component
 public class SubmitDnCase implements Task<Map<String, Object>> {
@@ -33,10 +36,7 @@ public class SubmitDnCase implements Task<Map<String, Object>> {
         String authToken = context.getTransientObject(AUTH_TOKEN_JSON_KEY);
         String caseId = context.getTransientObject(CASE_ID_JSON_KEY);
 
-        final CaseDetails currentCaseDetails = caseMaintenanceClient.retrievePetitionById(
-                authToken,
-                caseId
-        );
+        final CaseDetails currentCaseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
 
         String eventId = getDnEventId(currentCaseDetails);
 
@@ -58,11 +58,11 @@ public class SubmitDnCase implements Task<Map<String, Object>> {
 
         final String caseState = currentCaseDetails.getState();
 
-        if (AOS_COMPLETED.equalsIgnoreCase(caseState)) {
+        if (AWAITING_CLARIFICATION.equalsIgnoreCase(caseState)) {
+            return DN_RECEIVED_CLARIFICATION;
+        } else if (AOS_COMPLETED.equalsIgnoreCase(caseState)) {
             return DN_RECEIVED_AOS_COMPLETE;
-
         } else {
-
             return DN_RECEIVED;
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
@@ -57,12 +57,10 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
         tasksToRun.add(setDNDecisionStateTask);
         tasksToRun.add(validateDNDecisionTask);
         tasksToRun.add(addDecreeNisiDecisionDateTask);
-        Object decreeNisiGranted = caseData.get(DECREE_NISI_GRANTED_CCD_FIELD);
+        tasksToRun.add(addDnOutcomeFlagFieldTask);
 
-        if (YES_VALUE.equals(decreeNisiGranted)) {
-            tasksToRun.add(addDnOutcomeFlagFieldTask);
-            Object costsClaimGranted = caseData.get(DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD);
-            if (YES_VALUE.equals(costsClaimGranted)) {
+        if (YES_VALUE.equals(caseData.get(DECREE_NISI_GRANTED_CCD_FIELD))) {
+            if (YES_VALUE.equals(caseData.get(DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD))) {
                 tasksToRun.add(defineWhoPaysCostsOrderTask);
             }
         } else if (featureToggleService.isFeatureEnabled(DN_REFUSAL)) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
@@ -53,11 +53,12 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
     public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
         List<Task> tasksToRun = new ArrayList<>();
 
-        Map<String, Object> caseData = caseDetails.getCaseData();
         tasksToRun.add(setDNDecisionStateTask);
         tasksToRun.add(validateDNDecisionTask);
         tasksToRun.add(addDecreeNisiDecisionDateTask);
         tasksToRun.add(addDnOutcomeFlagFieldTask);
+
+        Map<String, Object> caseData = caseDetails.getCaseData();
 
         if (YES_VALUE.equals(caseData.get(DECREE_NISI_GRANTED_CCD_FIELD))) {
             if (YES_VALUE.equals(caseData.get(DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD))) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDnCaseWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDnCaseWorkflow.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkf
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToDnCaseData;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithIdTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SubmitDnCase;
 
 import java.util.Map;
@@ -16,6 +17,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @Component
 public class SubmitDnCaseWorkflow extends DefaultWorkflow<Map<String, Object>> {
+
+    @Autowired
+    private GetCaseWithIdTask getCaseWithIdTask;
 
     @Autowired
     private FormatDivorceSessionToDnCaseData formatDivorceSessionToDnCaseData;
@@ -28,6 +32,7 @@ public class SubmitDnCaseWorkflow extends DefaultWorkflow<Map<String, Object>> {
                                    String caseId) throws WorkflowException {
         return this.execute(
             new Task[] {
+                getCaseWithIdTask,
                 formatDivorceSessionToDnCaseData,
                 submitDnCase
             },

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -178,8 +178,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     hasJsonPath(DECREE_NISI_GRANTED_CCD_FIELD, equalTo(NO_VALUE)),
                     hasJsonPath(STATE_CCD_FIELD, equalTo(AWAITING_CLARIFICATION)),
                     hasJsonPath(DN_DECISION_DATE_FIELD, equalTo(ccdUtil.getCurrentDateCcdFormat())),
-                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD),
-                    hasNoJsonPath(DN_OUTCOME_FLAG_CCD_FIELD)
+                    hasJsonPath(DN_OUTCOME_FLAG_CCD_FIELD, equalTo(YES_VALUE)),
+                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD)
                 ))
             )));
     }
@@ -195,7 +195,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
         expectedRequestData.putAll(caseData);
         expectedRequestData.putAll(ImmutableMap.of(
             STATE_CCD_FIELD, AWAITING_CLARIFICATION,
-            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat()
+            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat(),
+            DN_OUTCOME_FLAG_CCD_FIELD, YES_VALUE
         ));
 
         CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(expectedRequestData).build();
@@ -237,8 +238,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     hasJsonPath(DECREE_NISI_GRANTED_CCD_FIELD, equalTo(NO_VALUE)),
                     hasJsonPath(STATE_CCD_FIELD, equalTo(AWAITING_CLARIFICATION)),
                     hasJsonPath(DN_DECISION_DATE_FIELD, equalTo(ccdUtil.getCurrentDateCcdFormat())),
-                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD),
-                    hasNoJsonPath(DN_OUTCOME_FLAG_CCD_FIELD)
+                    hasJsonPath(DN_OUTCOME_FLAG_CCD_FIELD, equalTo(YES_VALUE)),
+                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD)
                 ))
             )));
     }
@@ -260,7 +261,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
             D8DOCUMENTS_GENERATED, buildDocumentCollection(DOCUMENT_TYPE_OTHER,
             DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE),
             STATE_CCD_FIELD, AWAITING_CLARIFICATION,
-            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat()
+            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat(),
+            DN_OUTCOME_FLAG_CCD_FIELD, YES_VALUE
         ));
 
         CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(expectedRequestData).build();
@@ -302,8 +304,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     hasJsonPath(DECREE_NISI_GRANTED_CCD_FIELD, equalTo(NO_VALUE)),
                     hasJsonPath(STATE_CCD_FIELD, equalTo(AWAITING_CLARIFICATION)),
                     hasJsonPath(DN_DECISION_DATE_FIELD, equalTo(ccdUtil.getCurrentDateCcdFormat())),
-                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD),
-                    hasNoJsonPath(DN_OUTCOME_FLAG_CCD_FIELD)
+                    hasJsonPath(DN_OUTCOME_FLAG_CCD_FIELD, equalTo(YES_VALUE)),
+                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD)
                 ))
             )));
     }
@@ -355,7 +357,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
         Map<String, Object> expectedRequestData = new HashMap<>(caseData);
         expectedRequestData.putAll(ImmutableMap.of(
             STATE_CCD_FIELD, DN_REFUSED,
-            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat()
+            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat(),
+            DN_OUTCOME_FLAG_CCD_FIELD, YES_VALUE
         ));
 
         Map<String, Object> expectedDocumentRequestData = new HashMap<>(expectedRequestData);
@@ -403,8 +406,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
                     hasJsonPath(DECREE_NISI_GRANTED_CCD_FIELD, equalTo(NO_VALUE)),
                     hasJsonPath(STATE_CCD_FIELD, equalTo(DN_REFUSED)),
                     hasJsonPath(DN_DECISION_DATE_FIELD, equalTo(ccdUtil.getCurrentDateCcdFormat())),
-                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD),
-                    hasNoJsonPath(DN_OUTCOME_FLAG_CCD_FIELD)
+                    hasJsonPath(DN_OUTCOME_FLAG_CCD_FIELD, equalTo(YES_VALUE)),
+                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD)
                 ))
             )));
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitDnCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitDnCaseITest.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,19 +26,25 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.BEARER_AUTH_TOKEN_1;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_ERROR;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_AWAITING;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_COMPLETED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED_AOS_COMPLETE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED_CLARIFICATION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FORMATTER_CASE_DATA_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FORMATTER_DIVORCE_SESSION_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
-public class SubmitDnCaseITest extends MockedFunctionalTest {
+public class SubmitDnCaseITest extends IdamTestSupport {
     private static final String API_URL = String.format("/submit-dn/%s", TEST_CASE_ID);
     private static final String FORMAT_TO_DN_CASE_CONTEXT_PATH = "/caseformatter/version/1/to-dn-submit-format";
+    private static final String FORMAT_TO_DN_CLARIFICATION_CONTEXT_PATH = "/caseformatter/version/1/to-dn-clarification-format";
     private static final String UPDATE_CONTEXT_PATH = "/casemaintenance/version/1/updateCase/" + TEST_CASE_ID + "/";
     private static final String RETRIEVE_CASE_CONTEXT_PATH = String.format(
             "/casemaintenance/version/1/case/%s",
@@ -69,6 +76,7 @@ public class SubmitDnCaseITest extends MockedFunctionalTest {
     public void givenCaseFormatterFails_whenSubmitDn_thenPropagateTheException() throws Exception {
         final Map<String, Object> caseData = getCaseData();
 
+        stubSignInForCaseworker();
         stubFormatterServerEndpoint(BAD_REQUEST, caseData, TEST_ERROR);
 
         webClient.perform(MockMvcRequestBuilders.post(API_URL)
@@ -89,6 +97,7 @@ public class SubmitDnCaseITest extends MockedFunctionalTest {
         caseDetails.put(CASE_STATE_JSON_KEY, AOS_AWAITING);
         caseDetails.put(CCD_CASE_DATA_FIELD, caseData);
 
+        stubSignInForCaseworker();
         stubMaintenanceServerEndpointForRetrieveCaseById(OK, caseDetails);
         stubMaintenanceServerEndpointForUpdate(OK, DN_RECEIVED, caseData, caseDataString);
         stubFormatterServerEndpoint(OK, caseData, convertObjectToJsonString(caseData));
@@ -112,6 +121,7 @@ public class SubmitDnCaseITest extends MockedFunctionalTest {
         caseDetails.put(CASE_STATE_JSON_KEY, AOS_AWAITING);
         caseDetails.put(CCD_CASE_DATA_FIELD, caseData);
 
+        stubSignInForCaseworker();
         stubMaintenanceServerEndpointForRetrieveCaseById(OK, caseDetails);
         stubFormatterServerEndpoint(OK, caseData, caseDataString);
         stubMaintenanceServerEndpointForUpdate(OK, DN_RECEIVED, caseData, caseDataString);
@@ -134,6 +144,7 @@ public class SubmitDnCaseITest extends MockedFunctionalTest {
         caseDetails.put(CASE_STATE_JSON_KEY, AOS_COMPLETED);
         caseDetails.put(CCD_CASE_DATA_FIELD, caseData);
 
+        stubSignInForCaseworker();
         stubMaintenanceServerEndpointForRetrieveCaseById(OK, caseDetails);
         stubFormatterServerEndpoint(OK, caseData, caseDataString);
         stubMaintenanceServerEndpointForUpdate(OK, DN_RECEIVED_AOS_COMPLETE, caseData, caseDataString);
@@ -147,8 +158,44 @@ public class SubmitDnCaseITest extends MockedFunctionalTest {
             .andExpect(content().json(caseDataString));
     }
 
+    @Test
+    public void givenDnReceivedAndAwaitingClarification_whenSubmitDn_thenProceedAsExpected() throws Exception {
+        final Map<String, Object> caseData = getCaseData();
+        final String caseDataString = convertObjectToJsonString(caseData);
+        final Map<String, Object> caseDetails = new HashMap<>();
+
+        caseDetails.put(CASE_STATE_JSON_KEY, AWAITING_CLARIFICATION);
+        caseDetails.put(CCD_CASE_DATA_FIELD, caseData);
+
+        stubSignInForCaseworker();
+        stubMaintenanceServerEndpointForRetrieveCaseById(OK, caseDetails);
+        stubFormatterClarificationEndpoint(OK,
+            ImmutableMap.of(
+                FORMATTER_CASE_DATA_KEY, Collections.emptyMap(),
+                FORMATTER_DIVORCE_SESSION_KEY, Collections.emptyMap()
+            ), caseDataString);
+        stubMaintenanceServerEndpointForUpdate(OK, DN_RECEIVED_CLARIFICATION, caseData, caseDataString);
+
+        webClient.perform(MockMvcRequestBuilders.post(API_URL)
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(caseData))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(caseDataString));
+    }
+
     private void stubFormatterServerEndpoint(HttpStatus status, Map<String, Object> caseData, String response) {
         formatterServiceServer.stubFor(post(FORMAT_TO_DN_CASE_CONTEXT_PATH)
+            .withRequestBody(equalToJson(convertObjectToJsonString(caseData)))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .withBody(response)));
+    }
+
+    private void stubFormatterClarificationEndpoint(HttpStatus status, Map<String, Object> caseData, String response) {
+        formatterServiceServer.stubFor(post(FORMAT_TO_DN_CLARIFICATION_CONTEXT_PATH)
             .withRequestBody(equalToJson(convertObjectToJsonString(caseData)))
             .willReturn(aResponse()
                 .withStatus(status.value())
@@ -169,7 +216,7 @@ public class SubmitDnCaseITest extends MockedFunctionalTest {
 
     private void stubMaintenanceServerEndpointForRetrieveCaseById(HttpStatus status, Map<String, Object> cmsData) {
         maintenanceServiceServer.stubFor(WireMock.get(RETRIEVE_CASE_CONTEXT_PATH)
-            .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
+            .withHeader(AUTHORIZATION, new EqualToPattern(BEARER_AUTH_TOKEN_1))
             .willReturn(aResponse()
                 .withStatus(status.value())
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDnCaseDataUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDnCaseDataUTest.java
@@ -1,18 +1,30 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseFormatterClient;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DECREE_NISI;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FORMATTER_CASE_DATA_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FORMATTER_DIVORCE_SESSION_KEY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FormatDivorceSessionToDnCaseDataUTest {
@@ -25,14 +37,39 @@ public class FormatDivorceSessionToDnCaseDataUTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void whenExecute_thenProceedAsExpected() {
+    public void whenExecuteWithNotClarificationState_thenProceedAsExpected() {
         final Map<String, Object> sessionData = mock(Map.class);
         final Map<String, Object> expectedOutput = mock(Map.class);
 
         when(caseFormatterClient.transformToDnCaseFormat(sessionData)).thenReturn(expectedOutput);
 
-        assertEquals(expectedOutput, classUnderTest.execute(null, sessionData));
+        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_DETAILS_JSON_KEY,
+            CaseDetails.builder().state(AWAITING_DECREE_NISI).caseData(Collections.emptyMap()).build());
+        assertEquals(expectedOutput, classUnderTest.execute(context, sessionData));
 
         verify(caseFormatterClient).transformToDnCaseFormat(sessionData);
+        verify(caseFormatterClient, never()).transformToDnClarificationCaseFormat(any());
+    }
+
+    @Test
+    public void whenExecuteWithAwaitingClarificationState_thenProceedAsExpected() {
+        final Map<String, Object> sessionData = mock(Map.class);
+        final Map<String, Object> expectedOutput = mock(Map.class);
+
+        Map<String, Object> divorceCaseWrapper = ImmutableMap.of(
+            FORMATTER_CASE_DATA_KEY, Collections.emptyMap(),
+            FORMATTER_DIVORCE_SESSION_KEY, sessionData
+        );
+
+        when(caseFormatterClient.transformToDnClarificationCaseFormat(divorceCaseWrapper)).thenReturn(expectedOutput);
+
+        TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_DETAILS_JSON_KEY,
+            CaseDetails.builder().state(AWAITING_CLARIFICATION).caseData(Collections.emptyMap()).build());
+        assertEquals(expectedOutput, classUnderTest.execute(context, sessionData));
+
+        verify(caseFormatterClient, never()).transformToDnCaseFormat(any());
+        verify(caseFormatterClient).transformToDnClarificationCaseFormat(divorceCaseWrapper);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitDnCaseUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitDnCaseUTest.java
@@ -18,16 +18,18 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_COMPLETED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DECREE_NISI;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED_AOS_COMPLETE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_RECEIVED_CLARIFICATION;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SubmitDnCaseUTest {
@@ -52,8 +54,8 @@ public class SubmitDnCaseUTest {
     public void givenDnSubmitAndAosNotComplete_whenExecute_thenProceedAsExpected() {
         final Map<String, Object> divorceSession = ImmutableMap.of();
 
-        when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).state(AWAITING_DECREE_NISI).build());
+        TASK_CONTEXT.setTransientObject(CASE_DETAILS_JSON_KEY,
+            CaseDetails.builder().caseId(TEST_CASE_ID).state(AWAITING_DECREE_NISI).build());
 
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
@@ -65,12 +67,25 @@ public class SubmitDnCaseUTest {
     public void givenDnSubmitAndAosComplete_whenExecute_thenProceedAsExpected() {
         final Map<String, Object> divorceSession = ImmutableMap.of();
 
-        when(caseMaintenanceClient.retrievePetitionById(AUTH_TOKEN, TEST_CASE_ID)).thenReturn(
-                CaseDetails.builder().caseId(TEST_CASE_ID).state(AOS_COMPLETED).build());
+        TASK_CONTEXT.setTransientObject(CASE_DETAILS_JSON_KEY,
+            CaseDetails.builder().caseId(TEST_CASE_ID).state(AOS_COMPLETED).build());
 
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
 
         verify(caseMaintenanceClient)
                 .updateCase(AUTH_TOKEN, TEST_CASE_ID, DN_RECEIVED_AOS_COMPLETE, divorceSession);
+    }
+
+    @Test
+    public void givenDnSubmitAndAwaitingClarification_whenExecute_thenProceedAsExpected() {
+        final Map<String, Object> divorceSession = ImmutableMap.of();
+
+        TASK_CONTEXT.setTransientObject(CASE_DETAILS_JSON_KEY,
+            CaseDetails.builder().caseId(TEST_CASE_ID).state(AWAITING_CLARIFICATION).build());
+
+        assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
+
+        verify(caseMaintenanceClient)
+            .updateCase(AUTH_TOKEN, TEST_CASE_ID, DN_RECEIVED_CLARIFICATION, divorceSession);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflowTest.java
@@ -164,6 +164,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(setDNDecisionStateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(validateDNDecisionTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(addDecreeNisiDecisionDateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(payloadReturnedByTask);
+        when(addDnOutcomeFlagFieldTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
 
         Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
 
@@ -175,15 +176,16 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
             featureToggleService,
             setDNDecisionStateTask,
             validateDNDecisionTask,
-            addDecreeNisiDecisionDateTask
+            addDecreeNisiDecisionDateTask,
+            addDnOutcomeFlagFieldTask
         );
 
         inOrder.verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
         inOrder.verify(setDNDecisionStateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(validateDNDecisionTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDecreeNisiDecisionDateTask).execute(any(TaskContext.class), eq(inputPayload));
+        inOrder.verify(addDnOutcomeFlagFieldTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
 
-        verify(addDnOutcomeFlagFieldTask, never()).execute(any(), any());
         verify(defineWhoPaysCostsOrderTask, never()).execute(any(), any());
     }
 
@@ -196,6 +198,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(setDNDecisionStateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(validateDNDecisionTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(addDecreeNisiDecisionDateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(payloadReturnedByTask);
+        when(addDnOutcomeFlagFieldTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
 
         Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
 
@@ -207,15 +210,16 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
             featureToggleService,
             setDNDecisionStateTask,
             validateDNDecisionTask,
-            addDecreeNisiDecisionDateTask
+            addDecreeNisiDecisionDateTask,
+            addDnOutcomeFlagFieldTask
         );
 
         inOrder.verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
         inOrder.verify(setDNDecisionStateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(validateDNDecisionTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDecreeNisiDecisionDateTask).execute(any(TaskContext.class), eq(inputPayload));
+        inOrder.verify(addDnOutcomeFlagFieldTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
 
-        verify(addDnOutcomeFlagFieldTask, never()).execute(any(), any());
         verify(defineWhoPaysCostsOrderTask, never()).execute(any(), any());
         verify(decreeNisiRefusalDocumentGeneratorTask, never()).execute(any(), any());
         verify(caseFormatterAddDocuments, never()).execute(any(), any());
@@ -230,6 +234,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(setDNDecisionStateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(validateDNDecisionTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(addDecreeNisiDecisionDateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(payloadReturnedByTask);
+        when(addDnOutcomeFlagFieldTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
         when(getAmendPetitionFeeTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
         when(decreeNisiRefusalDocumentGeneratorTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
         when(caseFormatterAddDocuments.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
@@ -245,6 +250,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
             setDNDecisionStateTask,
             validateDNDecisionTask,
             addDecreeNisiDecisionDateTask,
+            addDnOutcomeFlagFieldTask,
             getAmendPetitionFeeTask,
             decreeNisiRefusalDocumentGeneratorTask,
             caseFormatterAddDocuments
@@ -254,11 +260,11 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         inOrder.verify(setDNDecisionStateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(validateDNDecisionTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDecreeNisiDecisionDateTask).execute(any(TaskContext.class), eq(inputPayload));
+        inOrder.verify(addDnOutcomeFlagFieldTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
         inOrder.verify(getAmendPetitionFeeTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
         inOrder.verify(decreeNisiRefusalDocumentGeneratorTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
         inOrder.verify(caseFormatterAddDocuments).execute(any(TaskContext.class), eq(payloadReturnedByTask));
 
-        verify(addDnOutcomeFlagFieldTask, never()).execute(any(), any());
         verify(defineWhoPaysCostsOrderTask, never()).execute(any(), any());
     }
 
@@ -271,6 +277,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(setDNDecisionStateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(validateDNDecisionTask.execute(isNotNull(), eq(inputPayload))).thenReturn(inputPayload);
         when(addDecreeNisiDecisionDateTask.execute(isNotNull(), eq(inputPayload))).thenReturn(payloadReturnedByTask);
+        when(addDnOutcomeFlagFieldTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
 
         Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
 
@@ -282,15 +289,16 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
             featureToggleService,
             setDNDecisionStateTask,
             validateDNDecisionTask,
-            addDecreeNisiDecisionDateTask
+            addDecreeNisiDecisionDateTask,
+            addDnOutcomeFlagFieldTask
         );
 
         inOrder.verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
         inOrder.verify(setDNDecisionStateTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(validateDNDecisionTask).execute(any(TaskContext.class), eq(inputPayload));
         inOrder.verify(addDecreeNisiDecisionDateTask).execute(any(TaskContext.class), eq(inputPayload));
+        inOrder.verify(addDnOutcomeFlagFieldTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
 
-        verify(addDnOutcomeFlagFieldTask, never()).execute(any(), any());
         verify(defineWhoPaysCostsOrderTask, never()).execute(any(), any());
         verify(decreeNisiRefusalDocumentGeneratorTask, never()).execute(any(), any());
         verify(caseFormatterAddDocuments, never()).execute(any(), any());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDnCaseWorkflowUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SubmitDnCaseWorkflowUTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToDnCaseData;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetCaseWithIdTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SubmitDnCase;
 
 import java.util.Map;
@@ -23,6 +24,10 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @RunWith(MockitoJUnitRunner.class)
 public class SubmitDnCaseWorkflowUTest {
+
+    @Mock
+    private GetCaseWithIdTask getCaseWithIdTask;
+
     @Mock
     private FormatDivorceSessionToDnCaseData formatDivorceSessionToDnCaseData;
 


### PR DESCRIPTION
# Description

## PENDING Config change required before build will pass.

[DIV-5766 - Awaiting Clarification For DN Submit](https://tools.hmcts.net/jira/browse/DIV-5766)

When the current case state is in AwaitingClarification, then when the user adds more information and submits on the Decree Nisi frontend, we can reuse the original DN Submit endpoint but trigger a different event based on the case state (AwaitingClarification instead of AwaitingDecreeNisi).

Data will be posted as is: may require mapper change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Still requires config change from https://tools.hmcts.net/jira/browse/DIV-5464