### PR TITLE
Keep previous DN Clarification documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -280,6 +280,7 @@ public class OrchestrationConstants {
     public static final String DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00088.docx";
     public static final String DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE = "d79";
     public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME = "decreeNisiRefusalOrder";
+    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD = "previousDecreeNisiRefusalOrder";
     public static final String DECREE_ABSOLUTE_DOCUMENT_TYPE = "daGranted";
     public static final String DECREE_ABSOLUTE_FILENAME = "decreeAbsolute";
     public static final String DECREE_ABSOLUTE_TEMPLATE_ID = "FL-DIV-GOR-ENG-00062.docx";
@@ -288,6 +289,7 @@ public class OrchestrationConstants {
     public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE = "personalService";
 
     public static final String DOCUMENT_TYPE_COE = "coe";
+    public static final String DOCUMENT_TYPE_OTHER = "other";
 
     public static final String SOL_DOCUMENT_LINK_FIELD = "solDocumentLinkFieldName";
     public static final String MINI_PETITION_LINK = "minipetitionlink";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -51,23 +51,23 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
         final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.computeTransientObjectIfAbsent(DOCUMENT_COLLECTION,
             new LinkedHashSet<>());
 
+        // Rename and set previous refusal order documents to other type so it won't get overwritten
+        List<Map<String, Object>> d8DocumentsGenerated =
+            Optional.ofNullable((List<Map<String, Object>>) caseData.get(D8DOCUMENTS_GENERATED))
+                .orElse(new ArrayList<>());
+
+        d8DocumentsGenerated.stream().filter(collectionMember -> {
+            Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
+            return DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE.equals(document.get(DOCUMENT_TYPE));
+        }).forEach(collectionMember -> {
+            Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
+            document.put(DOCUMENT_TYPE, DOCUMENT_TYPE_OTHER);
+            document.put(DOCUMENT_FILENAME,
+                format(DOCUMENT_FILENAME_FMT, DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD,
+                    caseDetails.getCaseId() + "-" + Instant.now(clock).toEpochMilli()));
+        });
+
         if (REFUSAL_DECISION_MORE_INFO_VALUE.equalsIgnoreCase((String) caseData.get(REFUSAL_DECISION_CCD_FIELD))) {
-            // Rename and set previous refusal order documents to other type so it won't get overwritten
-            List<Map<String, Object>> d8DocumentsGenerated =
-                Optional.ofNullable((List<Map<String, Object>>) caseData.get(D8DOCUMENTS_GENERATED))
-                    .orElse(new ArrayList<>());
-
-            d8DocumentsGenerated.stream().filter(collectionMember -> {
-                Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
-                return DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE.equals(document.get(DOCUMENT_TYPE));
-            }).forEach(collectionMember -> {
-                Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
-                document.put(DOCUMENT_TYPE, DOCUMENT_TYPE_OTHER);
-                document.put(DOCUMENT_FILENAME,
-                    format(DOCUMENT_FILENAME_FMT, DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD,
-                        caseDetails.getCaseId() + "-" + Instant.now(clock).toEpochMilli()));
-            });
-
             GeneratedDocumentInfo generatedDocumentInfo = generatePdfDocument(
                 DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
                 DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -9,19 +9,31 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_MORE_INFO_VALUE;
 
@@ -29,7 +41,10 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @AllArgsConstructor
 public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, Object>> {
 
+    private static final String VALUE_KEY = "value";
+
     private final DocumentGeneratorClient documentGeneratorClient;
+    private final Clock clock;
 
     @Override
     public Map<String, Object> execute(final TaskContext context, final Map<String, Object> caseData) {
@@ -39,6 +54,22 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
             new LinkedHashSet<>());
 
         if (REFUSAL_DECISION_MORE_INFO_VALUE.equalsIgnoreCase((String) caseData.get(REFUSAL_DECISION_CCD_FIELD))) {
+            // Rename and set previous refusal order documents to other type so it won't get overwritten
+            List<Map<String, Object>> d8DocumentsGenerated =
+                Optional.ofNullable((List<Map<String, Object>>) caseData.get(D8DOCUMENTS_GENERATED))
+                    .orElse(new ArrayList<>());
+
+            d8DocumentsGenerated.stream().filter(collectionMember -> {
+                Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
+                return DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE.equals(document.get(DOCUMENT_TYPE));
+            }).forEach(collectionMember -> {
+                Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
+                document.put(DOCUMENT_TYPE, DOCUMENT_TYPE_OTHER);
+                document.put(DOCUMENT_FILENAME,
+                    format(DOCUMENT_FILENAME_FMT, DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD,
+                        caseDetails.getCaseId() + "-" + Instant.now(clock).toEpochMilli()));
+            });
+
             GeneratedDocumentInfo generatedDocumentInfo = generatePdfDocument(
                 DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
                 DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -11,8 +11,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -85,7 +85,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
     private static final String ADD_DOCUMENTS_CONTEXT_PATH = "/caseformatter/version/1/add-documents";
     private static final String GENERATE_DOCUMENT_CONTEXT_PATH = "/version/1/generatePDF";
 
-    private static final long FIXED_TIME_EPOCH = 1000000l;
+    private static final long FIXED_TIME_EPOCH = 1000000L;
 
     @Autowired
     private MockMvc webClient;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.Features;
@@ -17,7 +18,11 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration
 import uk.gov.hmcts.reform.divorce.orchestration.service.impl.FeatureToggleServiceImpl;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -25,12 +30,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
@@ -39,12 +46,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.VALUE_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_PRONOUNCEMENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_GRANTED_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_CCD_FIELD;
@@ -53,6 +63,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_OUTCOME_FLAG_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
@@ -72,6 +85,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
     private static final String ADD_DOCUMENTS_CONTEXT_PATH = "/caseformatter/version/1/add-documents";
     private static final String GENERATE_DOCUMENT_CONTEXT_PATH = "/version/1/generatePDF";
 
+    private static final long FIXED_TIME_EPOCH = 1000000l;
+
     @Autowired
     private MockMvc webClient;
 
@@ -81,9 +96,14 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
     @Autowired
     private FeatureToggleServiceImpl featureToggleService;
 
+    @MockBean
+    private Clock clock;
+
     @Before
     public void setup() {
         setDnFeature(true);
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(FIXED_TIME_EPOCH));
+        when(clock.getZone()).thenReturn(UTC);
     }
 
     @Test
@@ -177,6 +197,74 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
 
         Map<String, Object> expectedDocumentUpdateRequestData = new HashMap<>();
         expectedDocumentUpdateRequestData.putAll(caseData);
+        // Additional fields
+        expectedDocumentUpdateRequestData.putAll(ImmutableMap.of(
+            STATE_CCD_FIELD, AWAITING_CLARIFICATION,
+            DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat()
+        ));
+
+        final DocumentUpdateRequest documentUpdateRequest =
+            DocumentUpdateRequest.builder()
+                .documents(asList(documentGenerationResponse))
+                .caseData(expectedDocumentUpdateRequestData)
+                .build();
+
+        stubDocumentGeneratorServerEndpoint(documentGenerationRequest, documentGenerationResponse);
+        stubFormatterServerEndpoint(documentUpdateRequest, expectedDocumentUpdateRequestData);
+
+        String inputJson = JSONObject.valueToString(singletonMap(CASE_DETAILS_JSON_KEY,
+            ImmutableMap.of(
+                ID, TEST_CASE_ID,
+                CCD_CASE_DATA_FIELD, caseData
+            )
+        ));
+
+        webClient.perform(post(API_URL).header(AUTHORIZATION, AUTH_TOKEN).content(inputJson).contentType(APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(allOf(
+                isJson(),
+                hasJsonPath(CCD_RESPONSE_DATA_FIELD, allOf(
+                    hasJsonPath(DECREE_NISI_GRANTED_CCD_FIELD, equalTo(NO_VALUE)),
+                    hasJsonPath(STATE_CCD_FIELD, equalTo(AWAITING_CLARIFICATION)),
+                    hasJsonPath(DN_DECISION_DATE_FIELD, equalTo(ccdUtil.getCurrentDateCcdFormat())),
+                    hasNoJsonPath(WHO_PAYS_COSTS_CCD_FIELD),
+                    hasNoJsonPath(DN_OUTCOME_FLAG_CCD_FIELD)
+                ))
+            )));
+    }
+
+    @Test
+    public void shouldReturnCaseDataPlusClarificationDocument_AndState_WhenDN_NotGranted_AndDnRefusedForMoreInfoWithExistingDocs() throws Exception {
+        List<Map<String, Object>> existingDocuments =
+            buildDocumentCollection(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
+
+        Map<String, Object> caseData = ImmutableMap.of(
+            DECREE_NISI_GRANTED_CCD_FIELD, NO_VALUE,
+            REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE,
+            D8DOCUMENTS_GENERATED, existingDocuments
+        );
+
+        Map<String, Object> documentGenerationRequestCaseData = new HashMap<>();
+        documentGenerationRequestCaseData.putAll(caseData);
+        documentGenerationRequestCaseData.put(D8DOCUMENTS_GENERATED, buildDocumentCollection(DOCUMENT_TYPE_OTHER,
+            DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + TEST_CASE_ID + "-" + FIXED_TIME_EPOCH));
+
+        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(documentGenerationRequestCaseData).build();
+
+        final GenerateDocumentRequest documentGenerationRequest =
+            GenerateDocumentRequest.builder()
+                .template(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
+                .build();
+
+        final GeneratedDocumentInfo documentGenerationResponse =
+            GeneratedDocumentInfo.builder()
+                .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
+                .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+                .build();
+
+        Map<String, Object> expectedDocumentUpdateRequestData = new HashMap<>();
+        expectedDocumentUpdateRequestData.putAll(documentGenerationRequestCaseData);
         // Additional fields
         expectedDocumentUpdateRequestData.putAll(ImmutableMap.of(
             STATE_CCD_FIELD, AWAITING_CLARIFICATION,
@@ -313,5 +401,19 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
 
     private void setDnFeature(Boolean enableFeature) {
         featureToggleService.getToggle().put(Features.DN_REFUSAL.getName(), enableFeature.toString());
+    }
+
+    private List<Map<String, Object>> buildDocumentCollection(String documentType, String documentName) {
+        Map<String, Object> document = new HashMap<>();
+        document.put(DOCUMENT_TYPE, documentType);
+        document.put(DOCUMENT_FILENAME, documentName);
+
+        Map<String, Object> documentMember = new HashMap<>();
+        documentMember.put(VALUE_KEY, document);
+
+        List<Map<String, Object>> existingDocuments = new ArrayList<>();
+        existingDocuments.add(documentMember);
+
+        return existingDocuments;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -7,15 +8,24 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.client.DocumentGeneratorClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -25,13 +35,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.VALUE_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_MORE_INFO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGenerationTaskTest.matchesDocumentInputParameters;
@@ -39,8 +55,13 @@ import static uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGe
 @RunWith(MockitoJUnitRunner.class)
 public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
+    private static final long FIXED_TIME_EPOCH = 1000000l;
+
     @Mock
     private DocumentGeneratorClient documentGeneratorClient;
+
+    @Mock
+    private Clock clock;
 
     @InjectMocks
     private DecreeNisiRefusalDocumentGeneratorTask decreeNisiRefusalDocumentGeneratorTask;
@@ -78,6 +99,62 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         verify(documentGeneratorClient)
                 .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
+    }
+
+    @Test
+    public void callsDocumentGeneratorAndStoresAdditionalGeneratedDocumentForDnRefusalClarificationWithExistingDocs() {
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(FIXED_TIME_EPOCH));
+
+        Map<String, Object> document = new HashMap<>();
+        document.put(DOCUMENT_TYPE, DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE);
+        document.put(DOCUMENT_FILENAME, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
+
+        Map<String, Object> documentMember = new HashMap<>();
+        documentMember.put(VALUE_KEY, document);
+
+        List<Map<String, Object>> existingDocuments = new ArrayList<>();
+        existingDocuments.add(documentMember);
+
+        final Map<String, Object> payload = new HashMap<>();
+        payload.put(REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE);
+        payload.put(D8DOCUMENTS_GENERATED, existingDocuments);
+        final CaseDetails caseDetails = CaseDetails.builder()
+            .caseId(TEST_CASE_ID)
+            .caseData(payload)
+            .build();
+
+        final TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
+        context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
+
+        final GeneratedDocumentInfo expectedDocument = GeneratedDocumentInfo.builder()
+            .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
+            .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+            .build();
+
+        //given
+        when(documentGeneratorClient
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN))
+        ).thenReturn(expectedDocument);
+
+        //when
+        decreeNisiRefusalDocumentGeneratorTask.execute(context, payload);
+
+        final LinkedHashSet<GeneratedDocumentInfo> documentCollection = context.getTransientObject(DOCUMENT_COLLECTION);
+
+        assertThat(documentCollection, is(newLinkedHashSet(expectedDocument)));
+
+        List<Map<String, Object>> currentGeneratedDocs =
+            (List<Map<String, Object>>) caseDetails.getCaseData().get(D8DOCUMENTS_GENERATED);
+        Map<String, Object> initialDocument = (Map<String, Object>) currentGeneratedDocs.get(0).get(VALUE_KEY);
+
+        assertThat(initialDocument.get(DOCUMENT_TYPE), is(DOCUMENT_TYPE_OTHER));
+        assertThat(initialDocument.get(DOCUMENT_FILENAME),
+            is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + TEST_CASE_ID + "-" + FIXED_TIME_EPOCH));
+
+        verify(documentGeneratorClient)
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -8,24 +7,19 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.client.DocumentGeneratorClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
-import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -55,7 +49,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGe
 @RunWith(MockitoJUnitRunner.class)
 public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
-    private static final long FIXED_TIME_EPOCH = 1000000l;
+    private static final long FIXED_TIME_EPOCH = 1000000L;
 
     @Mock
     private DocumentGeneratorClient documentGeneratorClient;


### PR DESCRIPTION
# Description

[DIV-5098](https://tools.hmcts.net/jira/browse/DIV-5098) 
This PR does the following:

When generating a DN Refusal Order Clarification Document, it checks for existing documents and will change the Document type to 'other' and rename the document with a timestamp.
The new DN Refusal Order document will have the original Document Type and File Name and therefore frontend won't be affected. Caseworkers should be able to tell which document is old vs which is new based on the file name.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
