### PR TITLE
Added Formatting for Fee Amount Double

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponse.java
@@ -6,6 +6,8 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Data;
 
+import java.text.DecimalFormat;
+
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiModel(description = "The response from retrieving a fee from fees and payments service")
@@ -19,4 +21,9 @@ public class FeeResponse {
     private Integer version;
     @ApiModelProperty(value = "The fee description")
     private String description;
+
+    public String getFormattedFeeAmount() {
+        DecimalFormat df = new DecimalFormat("0.00");
+        return df.format(amount);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponse.java
@@ -24,6 +24,7 @@ public class FeeResponse {
 
     public String getFormattedFeeAmount() {
         DecimalFormat df = new DecimalFormat("0.00");
-        return df.format(amount);
+        // Remove trailing pence if 0
+        return df.format(amount).replace(".00", "");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/notification/NotifyForRefusalOrderTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/notification/NotifyForRefusalOrderTask.java
@@ -63,7 +63,7 @@ public class NotifyForRefusalOrderTask implements Task<Map<String, Object>> {
                     D_8_INFERRED_PETITIONER_GENDER);
                 String petitionerRelationshipToRespondent = getRelationshipTermByGender(petitionerInferredGender);
                 personalisation.put(NOTIFICATION_HUSBAND_OR_WIFE, petitionerRelationshipToRespondent);
-                personalisation.put(NOTIFICATION_FEES_KEY, String.valueOf(amendFee.getAmount()));
+                personalisation.put(NOTIFICATION_FEES_KEY, amendFee.getFormattedFeeAmount());
                 emailService.sendEmail(
                     petitionerEmail,
                     EmailTemplateNames.DECREE_NISI_REFUSAL_ORDER_REJECTION.name(),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponseTest.java
@@ -14,12 +14,22 @@ public class FeeResponseTest {
 
     @Test
     public void givenWholeNumberWithTwoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
-        assertEquals("11.00", FeeResponse.builder().amount(11.00d).build().getFormattedFeeAmount());
+        assertEquals("11", FeeResponse.builder().amount(11.00d).build().getFormattedFeeAmount());
     }
 
     @Test
     public void givenWholeNumberWithOneDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
-        assertEquals("11.00", FeeResponse.builder().amount(11.0d).build().getFormattedFeeAmount());
+        assertEquals("11", FeeResponse.builder().amount(11.0d).build().getFormattedFeeAmount());
+    }
+
+    @Test
+    public void givenNoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11", FeeResponse.builder().amount(11d).build().getFormattedFeeAmount());
+    }
+
+    @Test
+    public void givenOneDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11.10", FeeResponse.builder().amount(11.1d).build().getFormattedFeeAmount());
     }
 
     @Test
@@ -28,17 +38,7 @@ public class FeeResponseTest {
     }
 
     @Test
-    public void givenNoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
-        assertEquals("11.00", FeeResponse.builder().amount(11d).build().getFormattedFeeAmount());
-    }
-
-    @Test
     public void givenMoreThanTwoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
         assertEquals("11.11", FeeResponse.builder().amount(11.11111111d).build().getFormattedFeeAmount());
-    }
-
-    @Test
-    public void givenOneDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
-        assertEquals("11.10", FeeResponse.builder().amount(11.1d).build().getFormattedFeeAmount());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/fees/FeeResponseTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.rules.ExpectedException.none;
+
+public class FeeResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = none();
+
+    @Test
+    public void givenWholeNumberWithTwoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11.00", FeeResponse.builder().amount(11.00d).build().getFormattedFeeAmount());
+    }
+
+    @Test
+    public void givenWholeNumberWithOneDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11.00", FeeResponse.builder().amount(11.0d).build().getFormattedFeeAmount());
+    }
+
+    @Test
+    public void givenTwoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11.11", FeeResponse.builder().amount(11.11d).build().getFormattedFeeAmount());
+    }
+
+    @Test
+    public void givenNoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11.00", FeeResponse.builder().amount(11d).build().getFormattedFeeAmount());
+    }
+
+    @Test
+    public void givenMoreThanTwoDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11.11", FeeResponse.builder().amount(11.11111111d).build().getFormattedFeeAmount());
+    }
+
+    @Test
+    public void givenOneDecimalDouble_whenGetFormattedFeeAmount_thenReturnFeeInExpectedFormat() {
+        assertEquals("11.10", FeeResponse.builder().amount(11.1d).build().getFormattedFeeAmount());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DnDecisionMadeCallbackITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DnDecisionMadeCallbackITest.java
@@ -82,7 +82,7 @@ public class DnDecisionMadeCallbackITest extends MockedFunctionalTest {
             .build();
 
         stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, caseId), HttpStatus.OK, Strings.EMPTY, POST);
-        stubGetFeeFromFeesAndPayments(HttpStatus.OK, FeeResponse.builder().build());
+        stubGetFeeFromFeesAndPayments(HttpStatus.OK, FeeResponse.builder().amount(50.00).build());
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)
@@ -130,7 +130,7 @@ public class DnDecisionMadeCallbackITest extends MockedFunctionalTest {
             .build();
 
         stubCmsServerEndpoint(String.format(CMS_UPDATE_CASE, caseId), HttpStatus.OK, Strings.EMPTY, POST);
-        stubGetFeeFromFeesAndPayments(HttpStatus.OK, FeeResponse.builder().build());
+        stubGetFeeFromFeesAndPayments(HttpStatus.OK, FeeResponse.builder().amount(50.00).build());
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/notification/NotifyForRefusalOrderTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/notification/NotifyForRefusalOrderTaskTest.java
@@ -55,6 +55,7 @@ public class NotifyForRefusalOrderTaskTest {
     private static final String PETITIONER_LAST_NAME = "Johnson";
     private static final String RELATION = "husband";
     private static final FeeResponse TEST_FEES = FeeResponse.builder().amount(50.00).build();
+    private static final String FEE_AMOUNT_AS_STRING = "50.00";
 
     private Map<String, Object> incomingPayload;
     private TaskContext taskContext;
@@ -113,7 +114,7 @@ public class NotifyForRefusalOrderTaskTest {
                     hasEntry(NOTIFICATION_ADDRESSEE_FIRST_NAME_KEY, PETITIONER_FIRST_NAME),
                     hasEntry(NOTIFICATION_ADDRESSEE_LAST_NAME_KEY, PETITIONER_LAST_NAME),
                     hasEntry(NOTIFICATION_HUSBAND_OR_WIFE, RELATION),
-                    hasEntry(NOTIFICATION_FEES_KEY, TEST_FEES.getAmount().toString())
+                    hasEntry(NOTIFICATION_FEES_KEY, FEE_AMOUNT_AS_STRING)
                 )
             )),
             anyString()

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/notification/NotifyForRefusalOrderTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/notification/NotifyForRefusalOrderTaskTest.java
@@ -55,7 +55,7 @@ public class NotifyForRefusalOrderTaskTest {
     private static final String PETITIONER_LAST_NAME = "Johnson";
     private static final String RELATION = "husband";
     private static final FeeResponse TEST_FEES = FeeResponse.builder().amount(50.00).build();
-    private static final String FEE_AMOUNT_AS_STRING = "50.00";
+    private static final String FEE_AMOUNT_AS_STRING = "50";
 
     private Map<String, Object> incomingPayload;
     private TaskContext taskContext;


### PR DESCRIPTION
# Description

Adds public method to FeeResponse to get Fee Amount (double) as a formatted String.

Fails the task if FeeResponse amount is null, as this should not be a valid scenario.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
