### PR TITLE
modify AOS overdue due date

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflow.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FetchPrintDocsFromDmStore;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.ModifyDueDate;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGenerationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrinter;
 
@@ -82,6 +83,9 @@ public class IssueAosPackOfflineWorkflow extends DefaultWorkflow<Map<String, Obj
     @Autowired
     private BulkPrinter bulkPrinter;
 
+    @Autowired
+    private ModifyDueDate modifyDueDate;
+
     public Map<String, Object> run(String authToken, CaseDetails caseDetails, DivorceParty divorceParty) throws WorkflowException {
         final Map<String, Object> caseData = caseDetails.getCaseData();
         final String reasonForDivorce = (String) caseData.get(D_8_REASON_FOR_DIVORCE);
@@ -92,13 +96,17 @@ public class IssueAosPackOfflineWorkflow extends DefaultWorkflow<Map<String, Obj
             .map(DocumentGenerationRequest::getDocumentType)
             .collect(Collectors.toList());
 
-        return execute(
-            new Task[] {
-                documentsGenerationTask,
-                caseFormatterAddDocuments,
-                fetchPrintDocsFromDmStore,
-                bulkPrinter
-            },
+        final List<Task> tasks = new ArrayList<>();
+
+        tasks.add(documentsGenerationTask);
+        tasks.add(caseFormatterAddDocuments);
+        tasks.add(fetchPrintDocsFromDmStore);
+        tasks.add(bulkPrinter);
+        if (divorceParty.equals(RESPONDENT)) {
+            tasks.add(modifyDueDate);
+        }
+
+        return execute(tasks.toArray(new Task[0]),
             caseData,
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aospack/offline/AosPackRespondentOfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aospack/offline/AosPackRespondentOfflineTest.java
@@ -21,6 +21,9 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ff4j.FeatureToggle;
 import uk.gov.hmcts.reform.divorce.orchestration.functionaltest.MockedFunctionalTest;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -34,6 +37,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -123,28 +127,12 @@ public class AosPackRespondentOfflineTest extends MockedFunctionalTest {
         CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();
         caseDetails.getCaseData().put("D8ReasonForDivorce", SEPARATION_TWO_YEARS);
 
-        //Stubbing DGS mock for invitation letter
-        GenerateDocumentRequest invitationLetterDocumentRequest = GenerateDocumentRequest.builder()
-            .template(RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID)
-            .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
-            .build();
-        GeneratedDocumentInfo invitationLetterDocumentInfo = GeneratedDocumentInfo.builder()
-            .documentType(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE)
-            .fileName(RESPONDENT_AOS_INVITATION_LETTER_FILENAME)
-            .build();
-        stubDocumentGeneratorServerEndpoint(invitationLetterDocumentRequest, invitationLetterDocumentInfo);
+        final GenerateDocumentRequest invitationLetterDocumentRequest = stubDgsInvitationLetterUsing(
+                RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID, RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, caseDetails);
         String invitationLetterFilename = RESPONDENT_AOS_INVITATION_LETTER_FILENAME + caseDetails.getCaseId();
 
-        //Stubbing DGS mock for form
-        GenerateDocumentRequest formDocumentRequest = GenerateDocumentRequest.builder()
-            .template(AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID)
-            .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
-            .build();
-        GeneratedDocumentInfo formDocumentInfo = GeneratedDocumentInfo.builder()
-            .documentType(AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE)
-            .fileName(AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME)
-            .build();
-        stubDocumentGeneratorServerEndpoint(formDocumentRequest, formDocumentInfo);
+        final GenerateDocumentRequest formDocumentRequest = stubDgsFormUsing(AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID,
+                AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE, AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME, caseDetails);
         String formFilename = AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME + caseDetails.getCaseId();
 
         //Stubbing CFS
@@ -192,28 +180,12 @@ public class AosPackRespondentOfflineTest extends MockedFunctionalTest {
         CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();
         caseDetails.getCaseData().put("D8ReasonForDivorce", ADULTERY);
 
-        //Stubbing DGS mock for invitation letter
-        GenerateDocumentRequest invitationLetterDocumentRequest = GenerateDocumentRequest.builder()
-            .template(CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID)
-            .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
-            .build();
-        GeneratedDocumentInfo invitationLetterDocumentInfo = GeneratedDocumentInfo.builder()
-            .documentType(CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE)
-            .fileName(CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME)
-            .build();
-        stubDocumentGeneratorServerEndpoint(invitationLetterDocumentRequest, invitationLetterDocumentInfo);
+        final GenerateDocumentRequest invitationLetterDocumentRequest = stubDgsInvitationLetterUsing(
+                CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID, CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, caseDetails);
         String invitationLetterFilename = CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME + caseDetails.getCaseId();
 
-        //Stubbing DGS mock for form
-        GenerateDocumentRequest formDocumentRequest = GenerateDocumentRequest.builder()
-            .template(AOS_OFFLINE_ADULTERY_CO_RESPONDENT_TEMPLATE_ID)
-            .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
-            .build();
-        GeneratedDocumentInfo formDocumentInfo = GeneratedDocumentInfo.builder()
-            .documentType(AOS_OFFLINE_ADULTERY_CO_RESPONDENT_DOCUMENT_TYPE)
-            .fileName(AOS_OFFLINE_ADULTERY_CO_RESPONDENT_FILENAME)
-            .build();
-        stubDocumentGeneratorServerEndpoint(formDocumentRequest, formDocumentInfo);
+        final GenerateDocumentRequest formDocumentRequest = stubDgsFormUsing(AOS_OFFLINE_ADULTERY_CO_RESPONDENT_TEMPLATE_ID,
+                AOS_OFFLINE_ADULTERY_CO_RESPONDENT_DOCUMENT_TYPE, AOS_OFFLINE_ADULTERY_CO_RESPONDENT_FILENAME, caseDetails);
         String formFilename = AOS_OFFLINE_ADULTERY_CO_RESPONDENT_FILENAME + caseDetails.getCaseId();
 
         //Stubbing CFS
@@ -267,6 +239,98 @@ public class AosPackRespondentOfflineTest extends MockedFunctionalTest {
 
         documentGeneratorServiceServer.verify(0, postRequestedFor(urlEqualTo(GENERATE_DOCUMENT_CONTEXT_PATH)));
         formatterServiceServer.verify(0, postRequestedFor(urlEqualTo(ADD_DOCUMENTS_CONTEXT_PATH)));
+    }
+
+    @Test
+    public void testEndpointReturnsExpectedDueDateInResponse_ForRespondent() throws Exception {
+
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/genericPetitionerData.json", CcdCallbackRequest.class);
+        CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();
+        caseDetails.getCaseData().put("D8ReasonForDivorce", SEPARATION_TWO_YEARS);
+
+        GenerateDocumentRequest invitationLetterDocumentRequest = stubDgsInvitationLetterUsing(
+                RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID, RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, caseDetails);
+        String invitationLetterFilename = RESPONDENT_AOS_INVITATION_LETTER_FILENAME + caseDetails.getCaseId();
+
+        GenerateDocumentRequest formDocumentRequest = stubDgsFormUsing(AOS_OFFLINE_TWO_YEAR_SEPARATION_TEMPLATE_ID,
+                AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE, AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME, caseDetails);
+        String formFilename = AOS_OFFLINE_TWO_YEAR_SEPARATION_FILENAME + caseDetails.getCaseId();
+
+        //Stubbing CFS
+        stubFormatterServerEndpoint(asList(
+                ImmutablePair.of(invitationLetterFilename, RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE),
+                ImmutablePair.of(formFilename, AOS_OFFLINE_TWO_YEAR_SEPARATION_DOCUMENT_TYPE)
+        ));
+
+        String expectedDueDate = LocalDate.now().plus(9, ChronoUnit.DAYS).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        webClient.perform(post(format(API_URL, RESPONDENT.getDescription()))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
+                .header(AUTHORIZATION, USER_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(allOf(
+                        isJson(),
+                        hasJsonPath("$.data.dueDate", is(expectedDueDate)))));
+    }
+
+    @Test
+    public void testEndpointReturnsNoDueDateInResponse_ForCoRespondent() throws Exception {
+
+        CcdCallbackRequest ccdCallbackRequest = getJsonFromResourceFile(
+                "/jsonExamples/payloads/genericPetitionerData.json", CcdCallbackRequest.class);
+        CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();
+        caseDetails.getCaseData().put("D8ReasonForDivorce", ADULTERY);
+
+        GenerateDocumentRequest invitationLetterDocumentRequest = stubDgsInvitationLetterUsing(
+                CO_RESPONDENT_AOS_INVITATION_LETTER_TEMPLATE_ID, CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, caseDetails);
+        String invitationLetterFilename = CO_RESPONDENT_AOS_INVITATION_LETTER_FILENAME + caseDetails.getCaseId();
+
+        GenerateDocumentRequest formDocumentRequest = stubDgsFormUsing(AOS_OFFLINE_ADULTERY_CO_RESPONDENT_TEMPLATE_ID,
+                AOS_OFFLINE_ADULTERY_CO_RESPONDENT_DOCUMENT_TYPE, AOS_OFFLINE_ADULTERY_CO_RESPONDENT_FILENAME, caseDetails);
+        String formFilename = AOS_OFFLINE_ADULTERY_CO_RESPONDENT_FILENAME + caseDetails.getCaseId();
+
+        //Stubbing CFS
+        stubFormatterServerEndpoint(asList(
+                ImmutablePair.of(invitationLetterFilename, CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE),
+                ImmutablePair.of(formFilename, AOS_OFFLINE_ADULTERY_CO_RESPONDENT_DOCUMENT_TYPE)
+        ));
+
+        webClient.perform(post(format(API_URL, CO_RESPONDENT.getDescription()))
+                .content(convertObjectToJsonString(ccdCallbackRequest))
+                .header(AUTHORIZATION, USER_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(allOf(isJson())))
+                .andExpect(content().string(hasNoJsonPath("$.data.dueDate")));
+    }
+
+    private GenerateDocumentRequest stubDgsInvitationLetterUsing(String templateId, String documentType, CaseDetails caseDetails) {
+        GenerateDocumentRequest invitationLetterDocumentRequest = GenerateDocumentRequest.builder()
+                .template(templateId)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
+                .build();
+        GeneratedDocumentInfo invitationLetterDocumentInfo = GeneratedDocumentInfo.builder()
+                .documentType(documentType)
+                .fileName(RESPONDENT_AOS_INVITATION_LETTER_FILENAME)
+                .build();
+        stubDocumentGeneratorServerEndpoint(invitationLetterDocumentRequest, invitationLetterDocumentInfo);
+        return invitationLetterDocumentRequest;
+    }
+
+    private GenerateDocumentRequest stubDgsFormUsing(String templateId, String documentType, String filename, CaseDetails caseDetails) {
+        GenerateDocumentRequest formDocumentRequest = GenerateDocumentRequest.builder()
+                .template(templateId)
+                .values(singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails))
+                .build();
+        GeneratedDocumentInfo formDocumentInfo = GeneratedDocumentInfo.builder()
+                .documentType(documentType)
+                .fileName(filename)
+                .build();
+        stubDocumentGeneratorServerEndpoint(formDocumentRequest, formDocumentInfo);
+        return formDocumentRequest;
     }
 
     private void stubDocumentGeneratorServerEndpoint(GenerateDocumentRequest documentRequest, GeneratedDocumentInfo documentInfo) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aospack/offline/IssueAosPackOfflineWorkflowTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FetchPrintDocsFromDmStore;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.ModifyDueDate;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGenerationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrinter;
 
@@ -33,6 +34,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
@@ -105,6 +107,9 @@ public class IssueAosPackOfflineWorkflowTest {
     @Mock
     private BulkPrinter bulkPrinterTask;
 
+    @Mock
+    private ModifyDueDate modifyDueDate;
+
     @InjectMocks
     private IssueAosPackOfflineWorkflow classUnderTest;
 
@@ -122,6 +127,7 @@ public class IssueAosPackOfflineWorkflowTest {
         when(caseFormatterAddDocuments.execute(any(), any())).thenReturn(singletonMap("returnedKey2", "returnedValue2"));
         when(fetchPrintDocsFromDmStore.execute(any(), any())).thenReturn(singletonMap("returnedKey3", "returnedValue3"));
         when(bulkPrinterTask.execute(any(), any())).thenReturn(singletonMap("returnedKey4", "returnedValue4"));
+        when(modifyDueDate.execute(any(), any())).thenReturn(singletonMap("returnedKey5", "returnedValue5"));
         caseDetails = CaseDetails.builder().caseData(payload).build();
     }
 
@@ -130,7 +136,7 @@ public class IssueAosPackOfflineWorkflowTest {
         caseDetails.getCaseData().put(D_8_REASON_FOR_DIVORCE, SEPARATION_TWO_YEARS);
 
         Map<String, Object> returnedPayload = classUnderTest.run(testAuthToken, caseDetails, RESPONDENT);
-        assertThat(returnedPayload, hasEntry("returnedKey4", "returnedValue4"));
+        assertThat(returnedPayload, hasEntry("returnedKey5", "returnedValue5"));
 
         List<DocumentGenerationRequest> expectedDocumentGenerationRequests = asList(
             EXPECTED_RESPONDENT_AOS_OFFLINE_INVITATION_LETTER,
@@ -142,6 +148,7 @@ public class IssueAosPackOfflineWorkflowTest {
         );
         verifyDocumentGeneratorReceivesExpectedParameters(expectedDocumentGenerationRequests);
         verifyTasksAreCalledInOrder();
+        verifyModifyDueDateIsCalled();
         verifyBulkPrintIsCalledAsExpected(AOS_PACK_OFFLINE_RESPONDENT_LETTER_TYPE,
             asList(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, RESPONDENT_TWO_YEAR_SEPARATION_AOS_OFFLINE_FORM_DOCUMENT_TYPE));
     }
@@ -151,7 +158,7 @@ public class IssueAosPackOfflineWorkflowTest {
         caseDetails.getCaseData().put(D_8_REASON_FOR_DIVORCE, SEPARATION_FIVE_YEARS);
 
         Map<String, Object> returnedPayload = classUnderTest.run(testAuthToken, caseDetails, RESPONDENT);
-        assertThat(returnedPayload, hasEntry("returnedKey4", "returnedValue4"));
+        assertThat(returnedPayload, hasEntry("returnedKey5", "returnedValue5"));
 
         List<DocumentGenerationRequest> expectedDocumentGenerationRequests = asList(
             EXPECTED_RESPONDENT_AOS_OFFLINE_INVITATION_LETTER,
@@ -163,6 +170,7 @@ public class IssueAosPackOfflineWorkflowTest {
         );
         verifyDocumentGeneratorReceivesExpectedParameters(expectedDocumentGenerationRequests);
         verifyTasksAreCalledInOrder();
+        verifyModifyDueDateIsCalled();
         verifyBulkPrintIsCalledAsExpected(AOS_PACK_OFFLINE_RESPONDENT_LETTER_TYPE,
             asList(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, RESPONDENT_FIVE_YEAR_SEPARATION_FORM_DOCUMENT_TYPE));
     }
@@ -172,7 +180,7 @@ public class IssueAosPackOfflineWorkflowTest {
         caseDetails.getCaseData().put(D_8_REASON_FOR_DIVORCE, DESERTION);
 
         Map<String, Object> returnedPayload = classUnderTest.run(testAuthToken, caseDetails, RESPONDENT);
-        assertThat(returnedPayload, hasEntry("returnedKey4", "returnedValue4"));
+        assertThat(returnedPayload, hasEntry("returnedKey5", "returnedValue5"));
 
         List<DocumentGenerationRequest> expectedDocumentGenerationRequests = asList(
             EXPECTED_RESPONDENT_AOS_OFFLINE_INVITATION_LETTER,
@@ -184,6 +192,7 @@ public class IssueAosPackOfflineWorkflowTest {
         );
         verifyDocumentGeneratorReceivesExpectedParameters(expectedDocumentGenerationRequests);
         verifyTasksAreCalledInOrder();
+        verifyModifyDueDateIsCalled();
         verifyBulkPrintIsCalledAsExpected(AOS_PACK_OFFLINE_RESPONDENT_LETTER_TYPE,
             asList(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, RESPONDENT_BEHAVIOUR_DESERTION_FORM_DOCUMENT_TYPE));
     }
@@ -193,7 +202,7 @@ public class IssueAosPackOfflineWorkflowTest {
         caseDetails.getCaseData().put(D_8_REASON_FOR_DIVORCE, UNREASONABLE_BEHAVIOUR);
 
         Map<String, Object> returnedPayload = classUnderTest.run(testAuthToken, caseDetails, RESPONDENT);
-        assertThat(returnedPayload, hasEntry("returnedKey4", "returnedValue4"));
+        assertThat(returnedPayload, hasEntry("returnedKey5", "returnedValue5"));
 
         List<DocumentGenerationRequest> expectedDocumentGenerationRequests = asList(
             EXPECTED_RESPONDENT_AOS_OFFLINE_INVITATION_LETTER,
@@ -205,6 +214,7 @@ public class IssueAosPackOfflineWorkflowTest {
         );
         verifyDocumentGeneratorReceivesExpectedParameters(expectedDocumentGenerationRequests);
         verifyTasksAreCalledInOrder();
+        verifyModifyDueDateIsCalled();
         verifyBulkPrintIsCalledAsExpected(AOS_PACK_OFFLINE_RESPONDENT_LETTER_TYPE,
             asList(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, RESPONDENT_BEHAVIOUR_DESERTION_FORM_DOCUMENT_TYPE));
     }
@@ -214,7 +224,7 @@ public class IssueAosPackOfflineWorkflowTest {
         caseDetails.getCaseData().put(D_8_REASON_FOR_DIVORCE, ADULTERY);
 
         Map<String, Object> returnedPayload = classUnderTest.run(testAuthToken, caseDetails, RESPONDENT);
-        assertThat(returnedPayload, hasEntry("returnedKey4", "returnedValue4"));
+        assertThat(returnedPayload, hasEntry("returnedKey5", "returnedValue5"));
 
         List<DocumentGenerationRequest> expectedDocumentGenerationRequests = asList(
             EXPECTED_RESPONDENT_AOS_OFFLINE_INVITATION_LETTER,
@@ -226,6 +236,7 @@ public class IssueAosPackOfflineWorkflowTest {
         );
         verifyDocumentGeneratorReceivesExpectedParameters(expectedDocumentGenerationRequests);
         verifyTasksAreCalledInOrder();
+        verifyModifyDueDateIsCalled();
         verifyBulkPrintIsCalledAsExpected(AOS_PACK_OFFLINE_RESPONDENT_LETTER_TYPE,
             asList(RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, RESPONDENT_ADULTERY_FORM_DOCUMENT_TYPE));
     }
@@ -251,6 +262,7 @@ public class IssueAosPackOfflineWorkflowTest {
         );
         verifyDocumentGeneratorReceivesExpectedParameters(expectedDocumentGenerationRequests);
         verifyTasksAreCalledInOrder();
+        verifyModifyDueDateIsNotCalled();
 
         verifyBulkPrintIsCalledAsExpected(AOS_PACK_OFFLINE_CO_RESPONDENT_LETTER_TYPE,
             asList(CO_RESPONDENT_AOS_INVITATION_LETTER_DOCUMENT_TYPE, CO_RESPONDENT_ADULTERY_FORM_DOCUMENT_TYPE));
@@ -280,6 +292,16 @@ public class IssueAosPackOfflineWorkflowTest {
         verify(bulkPrinterTask).execute(taskContextArgumentCaptor.capture(), argThat(allOf(
             Matchers.<String, Object>hasEntry("returnedKey3", "returnedValue3")
         )));
+    }
+
+    private void verifyModifyDueDateIsCalled() {
+        verify(modifyDueDate).execute(any(), argThat(allOf(
+                Matchers.<String, Object>hasEntry("returnedKey4", "returnedValue4")
+        )));
+    }
+
+    private void verifyModifyDueDateIsNotCalled() {
+        verifyZeroInteractions(modifyDueDate);
     }
 
     private void verifyBulkPrintIsCalledAsExpected(String expectedLetterType, List<String> expectedDocumentTypesToPrint) {


### PR DESCRIPTION
# Description

When issuing AOS Pack offline, for a respondent, the AOS due date is reset to 30 days after the current date.

Fixes [DIV-5555](https://tools.hmcts.net/jira/browse/DIV-5555)
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests and functional tests added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
