### PR TITLE
DIV-5889: Modify the data extractor to be run on demand for a given d…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/dataextraction/FamilyManDataExtractionIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/dataextraction/FamilyManDataExtractionIT.java
@@ -1,21 +1,15 @@
 package uk.gov.hmcts.reform.divorce.dataextraction;
 
 import io.restassured.response.Response;
-import org.apache.http.entity.ContentType;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.RetrieveCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.http.HttpStatus.OK;
 
 /**
  * This is going to be used to assert that the listener side of the data extraction job is called and runs successfully.
@@ -44,24 +38,27 @@ public class FamilyManDataExtractionIT extends RetrieveCaseSupport {
      */
     @Test
     public void shouldEmailCsvFiles() {
-        final UserDetails caseWorkerUser = createCaseWorkerUser();
+        Response response = RestUtil.postToRestService(
+            serverUrl + testDataExtractionEndPoint,
+            emptyMap(),
+            null
+        );
 
-        Response response = callTestEndpoint(caseWorkerUser.getAuthToken());
-
-        assertThat(response.getStatusCode(), is(HttpStatus.OK.value()));
+        assertThat(response.getStatusCode(), is(OK.value()));
     }
 
-    private Response callTestEndpoint(String userToken) {
-        final Map<String, Object> headers = new HashMap<>();
-        headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
-        headers.put(HttpHeaders.AUTHORIZATION, userToken);
-
-        return RestUtil.postToRestService(
-            serverUrl + testDataExtractionEndPoint,
-            headers,
-            null,
-            emptyMap()
+    /**
+     * Please look into class-level comment if this test is not passing locally.
+     */
+    @Test
+    public void shouldEmailCsvFiles_ForGivenStatusAndDate() {
+        Response response = RestUtil.postToRestService(
+            serverUrl + testDataExtractionEndPoint + "/status/DA/lastModifiedDate/2019-10-01",
+            emptyMap(),
+            null
         );
+
+        assertThat(response.getStatusCode(), is(OK.value()));
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/DataExtractionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/DataExtractionController.java
@@ -1,10 +1,12 @@
-package uk.gov.hmcts.reform.divorce.orchestration.controller.internal;
+package uk.gov.hmcts.reform.divorce.orchestration.controller;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.divorce.orchestration.event.domain.DataExtractionRequest;
@@ -17,25 +19,39 @@ import static uk.gov.hmcts.reform.divorce.orchestration.event.domain.DataExtract
 import static uk.gov.hmcts.reform.divorce.orchestration.event.domain.DataExtractionRequest.Status.DN;
 
 /**
- * This class provides endpoint so trigger the data extraction process on demand (meant to be used for tests).
+ * This class provides endpoint so trigger the data extraction process on demand.
  */
 @RestController
 @RequiredArgsConstructor
-public class DataExtractionInternalController {
+public class DataExtractionController {
 
     @Autowired
     private final DataExtractionRequestListener listener;
 
     @PostMapping(path = "/cases/data-extraction/family-man")
-    @ApiOperation(value = "Starts data extraction for family man for the present day. This is meant to only be used as a testing tool.")
+    @ApiOperation(value = "Starts data extraction for family man for the day before today. This is meant to only be used as a testing tool.")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Data extraction process started"),
-            @ApiResponse(code = 400, message = "Bad Request")})
+        @ApiResponse(code = 200, message = "Data extraction process started"),
+        @ApiResponse(code = 400, message = "Bad Request")})
     public void startDataExtractionToFamilyMan() {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         listener.onApplicationEvent(new DataExtractionRequest(this, DA, yesterday));
         listener.onApplicationEvent(new DataExtractionRequest(this, AOS, yesterday));
         listener.onApplicationEvent(new DataExtractionRequest(this, DN, yesterday));
+    }
+
+    @PostMapping(path = "/cases/data-extraction/family-man/status/{status}/lastModifiedDate/{lastModifiedDate}")
+    @ApiOperation(value = "Starts data extraction for family man for given status and given date.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Data extraction process started"),
+        @ApiResponse(code = 400, message = "Bad Request")})
+    public void startDataExtractionToFamilyManForGivenStatusAndDate(
+        @PathVariable(value = "status")
+            DataExtractionRequest.Status status,
+        @PathVariable(value = "lastModifiedDate")
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate lastModifiedDate) {
+        listener.onApplicationEvent(new DataExtractionRequest(this, status, lastModifiedDate));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManOnDemandTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManOnDemandTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.divorce.orchestration.functionaltest.dataextraction;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * This test is very similar to its parent class, but it uses the REST endpoint (like we'd use if we wanted to run the data extraction on demand).
+ */
+public class DataExtractionToFamilyManOnDemandTest extends DataExtractionToFamilyManTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void checkEmailIsSentOnDemandForGivenDateAndStatus() throws Exception {
+        mockMvc.perform(post("/cases/data-extraction/family-man/status/{status}/lastModifiedDate/{lastModifiedDate}", "DA", "2019-08-12"))
+            .andExpect(status().isOk());
+
+        verify(mockEmailClient).sendEmailWithAttachment(eq("da-extraction@divorce.gov.uk"), eq("DA_12082019000000.csv"), notNull());
+    }
+
+    @Test
+    public void shouldReplyWithBadRequest_WhenPassingInvalidStatus() throws Exception {
+        mockMvc.perform(post("/cases/data-extraction/family-man/status/{status}/lastModifiedDate/{lastModifiedDate}", "INVALID_STATUS", "2019-08-12"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void shouldReplyWithBadRequest_WhenDateIsMalformed() throws Exception {
+        mockMvc.perform(post("/cases/data-extraction/family-man/status/{status}/lastModifiedDate/{lastModifiedDate}", "DA", "abc"))
+            .andExpect(status().isBadRequest());
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManTest.java
@@ -42,14 +42,17 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * This test uses the service (just like the scheduled job will).
+ */
 public class DataExtractionToFamilyManTest extends MockedFunctionalTest {
 
-    private static final String DA_DESIRED_STATES = "[\"divorcegranted\"]";
+    protected static final String DA_DESIRED_STATES = "[\"divorcegranted\"]";
     private static final String AOS_DESIRED_STATES = "[\"awaitinglegaladvisorreferral\"]";
     private static final String DN_DESIRED_STATES = "[\"dnisrefused\", \"dnpronounced\"]";
 
     private static final DateTimeFormatter FILE_NAME_DATE_FORMAT = ofPattern("ddMMyyyy000000");
-    private static final String TEST_AUTH_TOKEN = "testAuthToken";
+    protected static final String TEST_AUTH_TOKEN = "testAuthToken";
 
     private String yesterday;
 
@@ -57,22 +60,21 @@ public class DataExtractionToFamilyManTest extends MockedFunctionalTest {
     private DataExtractionService dataExtractionService;
 
     @MockBean
-    private DataExtractionEmailClient mockEmailClient;
+    protected DataExtractionEmailClient mockEmailClient;
 
     @MockBean
-    private AuthUtil authUtil;
+    protected AuthUtil authUtil;
 
     @Captor
     private ArgumentCaptor<File> attachmentCaptor;
 
     @Before
     public void setUp() {
+        maintenanceServiceServer.resetAll();
+
         when(authUtil.getCaseworkerToken()).thenReturn(TEST_AUTH_TOKEN);
         yesterday = LocalDate.now().minusDays(1).format(FILE_NAME_DATE_FORMAT);
-    }
 
-    @Test
-    public void shouldEmailCsvFileWithCase_ForDecreeAbsoluteIssued() throws Exception {
         //Mock CMS to return a case like Elastic search will
         stubJsonResponse(DA_DESIRED_STATES, "{"
             + "  \"cases\": [{"
@@ -120,7 +122,10 @@ public class DataExtractionToFamilyManTest extends MockedFunctionalTest {
             + "    }"
             + "  }]"
             + "}");
+    }
 
+    @Test
+    public void shouldEmailCsvFileWithCase_ForDecreeAbsoluteIssued() throws Exception {
         dataExtractionService.requestDataExtractionForPreviousDay();
 
         await().untilAsserted(() -> {


### PR DESCRIPTION
…ate for a given status

# Description

The idea here is that the data extraction tool can be run on demand for a specified date. The client is aware that this won't re-generate the file exactly as it would have been generated on the following day, but at least, this will give the ability to the client to extract cases in "Divorce Granted" for a given date (since this is a final state).

## Type of change

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit, functional and integration tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
