### PR TITLE
Fixed older clarification documents not being stored properly

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnAboutToBeGrantedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnAboutToBeGrantedTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_CLARIFICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.util.ResourceLoader.objectToJson;
 
 public class DnAboutToBeGrantedTest extends IntegrationTest {
@@ -33,7 +34,10 @@ public class DnAboutToBeGrantedTest extends IntegrationTest {
         assertThat(jsonResponse,
             hasJsonPath("$.data.state", is(AWAITING_CLARIFICATION)));
 
+        // Note, requires DN Refusal feature flag to be true
         assertThat(jsonResponse,
-            hasJsonPath("$.data.D8DocumentsGenerated[0].value.DocumentType", is(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)));
+            hasJsonPath("$.data.D8DocumentsGenerated[0].value.DocumentType", is(DOCUMENT_TYPE_OTHER)));
+        assertThat(jsonResponse,
+            hasJsonPath("$.data.D8DocumentsGenerated[1].value.DocumentType", is(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnAboutToBeGrantedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnAboutToBeGrantedTest.java
@@ -34,7 +34,6 @@ public class DnAboutToBeGrantedTest extends IntegrationTest {
         assertThat(jsonResponse,
             hasJsonPath("$.data.state", is(AWAITING_CLARIFICATION)));
 
-        // Note, requires DN Refusal feature flag to be true
         assertThat(jsonResponse,
             hasJsonPath("$.data.D8DocumentsGenerated[0].value.DocumentType", is(DOCUMENT_TYPE_OTHER)));
         assertThat(jsonResponse,

--- a/src/integrationTest/resources/fixtures/callback/dn-refusal-clarification.json
+++ b/src/integrationTest/resources/fixtures/callback/dn-refusal-clarification.json
@@ -10,7 +10,24 @@
       "D8caseReference": "LV88D85000",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",
-      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk"
+      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
+      "D8DocumentsGenerated": [
+        {
+          "id": "7b22bf15-d055-41f8-9d77-224fed546841",
+          "value": {
+            "DocumentLink": {
+              "document_url": "https://localhost:8080/documents/1234",
+              "document_filename": "refusalOrder1513951627081724.pdf",
+              "document_binary_url": "https://localhost:8080/documents/1234/binary"
+            },
+            "DocumentType": "d79",
+            "DocumentComment": null,
+            "DocumentFileName": "DecreeNisiRefusalOrder.pdf",
+            "DocumentDateAdded": null,
+            "DocumentEmailContent": null
+          }
+        }
+      ]
     }
   }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -252,6 +252,9 @@ public class OrchestrationConstants {
     // Document Generator
     public static final String DOCUMENT_TYPE_JSON_KEY = "DocumentType";
     public static final String DOCUMENT_FILENAME_JSON_KEY = "DocumentFileName";
+    public static final String DOCUMENT_LINK_JSON_KEY = "DocumentLink";
+    public static final String DOCUMENT_LINK_FILENAME_JSON_KEY = "document_filename";
+    public static final String DOCUMENT_EXTENSION = ".pdf";
     public static final String DOCUMENT_CASE_DETAILS_JSON_KEY = "caseDetails";
     public static final String DOCUMENT_TYPE_RESPONDENT_INVITATION = "aos";
     public static final String DOCUMENT_TYPE_RESPONDENT_ANSWERS = "respondentAnswers";
@@ -284,7 +287,7 @@ public class OrchestrationConstants {
     public static final String DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00088.docx";
     public static final String DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00098.docx";
     public static final String DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE = "d79";
-    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME = "DecreeNisiRefusalOrder";
+    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME = "decreeNisiRefusalOrder";
     public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD = "PreviousDNRefusalOrder";
     public static final String DECREE_ABSOLUTE_DOCUMENT_TYPE = "daGranted";
     public static final String DECREE_ABSOLUTE_FILENAME = "decreeAbsolute";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -284,8 +284,8 @@ public class OrchestrationConstants {
     public static final String DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00088.docx";
     public static final String DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00098.docx";
     public static final String DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE = "d79";
-    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME = "decreeNisiRefusalOrder";
-    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD = "previousDecreeNisiRefusalOrder";
+    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME = "DecreeNisiRefusalOrder";
+    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD = "PreviousDNRefusalOrder";
     public static final String DECREE_ABSOLUTE_DOCUMENT_TYPE = "daGranted";
     public static final String DECREE_ABSOLUTE_FILENAME = "decreeAbsolute";
     public static final String DECREE_ABSOLUTE_TEMPLATE_ID = "FL-DIV-GOR-ENG-00062.docx";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -250,6 +250,8 @@ public class OrchestrationConstants {
     public static final String PHONE_LABEL = "Phone:";
 
     // Document Generator
+    public static final String DOCUMENT_TYPE_JSON_KEY = "DocumentType";
+    public static final String DOCUMENT_FILENAME_JSON_KEY = "DocumentFileName";
     public static final String DOCUMENT_CASE_DETAILS_JSON_KEY = "caseDetails";
     public static final String DOCUMENT_TYPE_RESPONDENT_INVITATION = "aos";
     public static final String DOCUMENT_TYPE_RESPONDENT_ANSWERS = "respondentAnswers";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -287,8 +287,9 @@ public class OrchestrationConstants {
     public static final String DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00088.docx";
     public static final String DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID = "FL-DIV-DEC-ENG-00098.docx";
     public static final String DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE = "d79";
-    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME = "decreeNisiRefusalOrder";
-    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD = "PreviousDNRefusalOrder";
+    public static final String DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME = "decreeNisiRefusalOrderClarification";
+    public static final String DECREE_NISI_REFUSAL_REJECTION_DOCUMENT_NAME = "decreeNisiRefusalOrderRejection";
+    public static final String DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD = "PreviousDNClarificationRefusalOrder";
     public static final String DECREE_ABSOLUTE_DOCUMENT_TYPE = "daGranted";
     public static final String DECREE_ABSOLUTE_FILENAME = "decreeAbsolute";
     public static final String DECREE_ABSOLUTE_TEMPLATE_ID = "FL-DIV-GOR-ENG-00062.docx";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -24,7 +24,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
@@ -83,7 +83,7 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
             GeneratedDocumentInfo generatedDocumentInfo = generatePdfDocument(
                 DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
                 DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE,
-                DECREE_NISI_REFUSAL_DOCUMENT_NAME,
+                DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME,
                 context.getTransientObject(AUTH_TOKEN_JSON_KEY),
                 caseDetails.toBuilder().caseData(caseData).build()
             );

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -32,8 +32,11 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_EXTENSION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_LINK_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_LINK_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_TO_PAY_JSON_KEY;
@@ -65,11 +68,15 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
             Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
             return DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE.equals(document.get(DOCUMENT_TYPE_JSON_KEY));
         }).forEach(collectionMember -> {
+            String newFileName = format(DOCUMENT_FILENAME_FMT, DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD,
+                ccdUtil.getCurrentDateCcdFormat());
+
             Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
             document.put(DOCUMENT_TYPE_JSON_KEY, DOCUMENT_TYPE_OTHER);
-            document.put(DOCUMENT_FILENAME_JSON_KEY,
-                format(DOCUMENT_FILENAME_FMT, DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD,
-                    ccdUtil.getCurrentDateCcdFormat()));
+            document.put(DOCUMENT_FILENAME_JSON_KEY,newFileName);
+
+            Map<String, Object> documentLink = (Map<String, Object>) document.get(DOCUMENT_LINK_JSON_KEY);
+            documentLink.put(DOCUMENT_LINK_FILENAME_JSON_KEY, newFileName.concat(DOCUMENT_EXTENSION));
         });
 
         if (REFUSAL_DECISION_MORE_INFO_VALUE.equalsIgnoreCase((String) caseData.get(REFUSAL_DECISION_CCD_FIELD))) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -9,8 +9,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees.FeeResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,7 +48,7 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
     private static final String VALUE_KEY = "value";
 
     private final DocumentGeneratorClient documentGeneratorClient;
-    private final Clock clock;
+    private final CcdUtil ccdUtil;
 
     @Override
     public Map<String, Object> execute(final TaskContext context, final Map<String, Object> caseData) {
@@ -70,7 +70,7 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
             document.put(DOCUMENT_TYPE_JSON_KEY, DOCUMENT_TYPE_OTHER);
             document.put(DOCUMENT_FILENAME_JSON_KEY,
                 format(DOCUMENT_FILENAME_FMT, DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD,
-                    caseDetails.getCaseId() + "-" + Instant.now(clock).toEpochMilli()));
+                    ccdUtil.getCurrentDateCcdFormat()));
         });
 
         if (REFUSAL_DECISION_MORE_INFO_VALUE.equalsIgnoreCase((String) caseData.get(REFUSAL_DECISION_CCD_FIELD))) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -29,6 +29,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_REJECTION_DOCUMENT_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
@@ -99,7 +100,7 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
             GeneratedDocumentInfo generatedDocumentInfo = generatePdfDocument(
                 DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID,
                 DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE,
-                DECREE_NISI_REFUSAL_DOCUMENT_NAME,
+                DECREE_NISI_REFUSAL_REJECTION_DOCUMENT_NAME,
                 context.getTransientObject(AUTH_TOKEN_JSON_KEY),
                 caseDetails.toBuilder().caseData(caseDataToSend).build()
             );

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTask.java
@@ -33,9 +33,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
@@ -64,11 +64,11 @@ public class DecreeNisiRefusalDocumentGeneratorTask implements Task<Map<String, 
 
         d8DocumentsGenerated.stream().filter(collectionMember -> {
             Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
-            return DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE.equals(document.get(DOCUMENT_TYPE));
+            return DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE.equals(document.get(DOCUMENT_TYPE_JSON_KEY));
         }).forEach(collectionMember -> {
             Map<String, Object> document = (Map<String, Object>) collectionMember.get(VALUE_KEY);
-            document.put(DOCUMENT_TYPE, DOCUMENT_TYPE_OTHER);
-            document.put(DOCUMENT_FILENAME,
+            document.put(DOCUMENT_TYPE_JSON_KEY, DOCUMENT_TYPE_OTHER);
+            document.put(DOCUMENT_FILENAME_JSON_KEY,
                 format(DOCUMENT_FILENAME_FMT, DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD,
                     caseDetails.getCaseId() + "-" + Instant.now(clock).toEpochMilli()));
         });

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,7 +112,7 @@ feature-toggle:
   toggle:
     bulk-printer-toggle-name: "divorce_bulk_print"
     feature_resp_solicitor_details: ${FEATURE_RESP_SOLICITOR_DETAILS:false}
-    dn_refusal: ${FEATURE_DN_REFUSAL:false}
+    dn_refusal: ${FEATURE_DN_REFUSAL:true}
 
 send-letter:
   url: ${SEND_LETTER_SERIVCE_BASEURL:http://localhost:4021}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,7 +112,7 @@ feature-toggle:
   toggle:
     bulk-printer-toggle-name: "divorce_bulk_print"
     feature_resp_solicitor_details: ${FEATURE_RESP_SOLICITOR_DETAILS:false}
-    dn_refusal: ${FEATURE_DN_REFUSAL:true}
+    dn_refusal: ${FEATURE_DN_REFUSAL:false}
 
 send-letter:
   url: ${SEND_LETTER_SERIVCE_BASEURL:http://localhost:4021}

--- a/src/main/resources/example-application-aat.yml
+++ b/src/main/resources/example-application-aat.yml
@@ -26,6 +26,10 @@ feature-toggle:
   service:
     api:
       baseurl: ${FEATURE_TOGGLE_SERVICE_API_BASEURL:http://rpe-feature-toggle-api-aat.service.core-compute-aat.internal}
+  toggle:
+    bulk-printer-toggle-name: "divorce_bulk_print"
+    feature_resp_solicitor_details: true
+    dn_refusal: true
 
 send-letter:
   url: ${SEND_LETTER_SERIVCE_BASEURL:http://rpe-send-letter-service-aat.service.core-compute-aat.internal}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.impl.FeatureToggleServi
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.time.Clock;
-import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +90,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
     private static final String AMEND_PETITION_FEE_CONTEXT_PATH =  "/fees-and-payments/version/1/amend-fee";
     private static final String GENERATE_DOCUMENT_CONTEXT_PATH = "/version/1/generatePDF";
 
-    private static final long FIXED_TIME_EPOCH = 1000000L;
+    private static final String FIXED_DATE = "2010-10-10";
 
     @Autowired
     private MockMvc webClient;
@@ -107,7 +107,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
     @Before
     public void setup() {
         setDnFeature(true);
-        when(clock.instant()).thenReturn(Instant.ofEpochMilli(FIXED_TIME_EPOCH));
+        when(clock.instant()).thenReturn(LocalDate.of(2010, 10, 10).atStartOfDay(UTC).toInstant());
         when(clock.getZone()).thenReturn(UTC);
     }
 
@@ -257,6 +257,10 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
             STATE_CCD_FIELD, AWAITING_CLARIFICATION,
             DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat()
         ));
+        Map<String, Object> documentGenerationRequestCaseData = new HashMap<>();
+        documentGenerationRequestCaseData.putAll(caseData);
+        documentGenerationRequestCaseData.put(D8DOCUMENTS_GENERATED, buildDocumentCollection(DOCUMENT_TYPE_OTHER,
+            DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE));
 
         CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(expectedRequestData).build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,10 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_EXTENSION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_LINK_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_LINK_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_TO_PAY_JSON_KEY;
@@ -467,6 +471,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
         Map<String, Object> document = new HashMap<>();
         document.put(DOCUMENT_TYPE_JSON_KEY, documentType);
         document.put(DOCUMENT_FILENAME_JSON_KEY, documentName);
+        document.put(DOCUMENT_LINK_JSON_KEY,
+            Collections.singletonMap(DOCUMENT_LINK_FILENAME_JSON_KEY, documentName + DOCUMENT_EXTENSION));
 
         Map<String, Object> documentMember = new HashMap<>();
         documentMember.put(VALUE_KEY, document);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -61,6 +61,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_REJECTION_DOCUMENT_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_DECISION_DATE_FIELD;
@@ -257,14 +258,10 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
         expectedRequestData.putAll(caseData);
         expectedRequestData.putAll(ImmutableMap.of(
             D8DOCUMENTS_GENERATED, buildDocumentCollection(DOCUMENT_TYPE_OTHER,
-            DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + TEST_CASE_ID + "-" + FIXED_TIME_EPOCH),
+            DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE),
             STATE_CCD_FIELD, AWAITING_CLARIFICATION,
             DN_DECISION_DATE_FIELD, ccdUtil.getCurrentDateCcdFormat()
         ));
-        Map<String, Object> documentGenerationRequestCaseData = new HashMap<>();
-        documentGenerationRequestCaseData.putAll(caseData);
-        documentGenerationRequestCaseData.put(D8DOCUMENTS_GENERATED, buildDocumentCollection(DOCUMENT_TYPE_OTHER,
-            DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE));
 
         CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(expectedRequestData).build();
 
@@ -378,7 +375,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
         final GeneratedDocumentInfo documentGenerationResponse =
             GeneratedDocumentInfo.builder()
                 .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
-                .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+                .fileName(DECREE_NISI_REFUSAL_REJECTION_DOCUMENT_NAME + TEST_CASE_ID)
                 .build();
 
         final DocumentUpdateRequest documentUpdateRequest =

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -56,7 +56,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_GRANTED_CCD_FIELD;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
@@ -208,7 +208,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
         final GeneratedDocumentInfo documentGenerationResponse =
             GeneratedDocumentInfo.builder()
                 .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
-                .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+                .fileName(DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME + TEST_CASE_ID)
                 .build();
 
         final DocumentUpdateRequest documentUpdateRequest =
@@ -245,7 +245,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
     @Test
     public void shouldReturnCaseDataPlusClarificationDocument_AndState_WhenDN_NotGranted_AndDnRefusedForMoreInfoWithExistingDocs() throws Exception {
         List<Map<String, Object>> existingDocuments =
-            buildDocumentCollection(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
+            buildDocumentCollection(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE, DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME);
 
         Map<String, Object> caseData = ImmutableMap.of(
             DECREE_NISI_GRANTED_CCD_FIELD, NO_VALUE,
@@ -277,7 +277,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
         final GeneratedDocumentInfo documentGenerationResponse =
             GeneratedDocumentInfo.builder()
                 .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
-                .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+                .fileName(DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME + TEST_CASE_ID)
                 .build();
 
         final DocumentUpdateRequest documentUpdateRequest =

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -67,8 +67,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
@@ -461,8 +461,8 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
 
     private List<Map<String, Object>> buildDocumentCollection(String documentType, String documentName) {
         Map<String, Object> document = new HashMap<>();
-        document.put(DOCUMENT_TYPE, documentType);
-        document.put(DOCUMENT_FILENAME, documentName);
+        document.put(DOCUMENT_TYPE_JSON_KEY, documentType);
+        document.put(DOCUMENT_FILENAME_JSON_KEY, documentName);
 
         Map<String, Object> documentMember = new HashMap<>();
         documentMember.put(VALUE_KEY, document);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -44,8 +44,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.REFUSAL_DECISION_CCD_FIELD;
@@ -106,8 +106,8 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         when(clock.instant()).thenReturn(Instant.ofEpochMilli(FIXED_TIME_EPOCH));
 
         Map<String, Object> document = new HashMap<>();
-        document.put(DOCUMENT_TYPE, DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE);
-        document.put(DOCUMENT_FILENAME, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
+        document.put(DOCUMENT_TYPE_JSON_KEY, DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE);
+        document.put(DOCUMENT_FILENAME_JSON_KEY, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
 
         Map<String, Object> documentMember = new HashMap<>();
         documentMember.put(VALUE_KEY, document);
@@ -149,8 +149,8 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
             (List<Map<String, Object>>) caseDetails.getCaseData().get(D8DOCUMENTS_GENERATED);
         Map<String, Object> initialDocument = (Map<String, Object>) currentGeneratedDocs.get(0).get(VALUE_KEY);
 
-        assertThat(initialDocument.get(DOCUMENT_TYPE), is(DOCUMENT_TYPE_OTHER));
-        assertThat(initialDocument.get(DOCUMENT_FILENAME),
+        assertThat(initialDocument.get(DOCUMENT_TYPE_JSON_KEY), is(DOCUMENT_TYPE_OTHER));
+        assertThat(initialDocument.get(DOCUMENT_FILENAME_JSON_KEY),
             is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + TEST_CASE_ID + "-" + FIXED_TIME_EPOCH));
         
         verify(documentGeneratorClient)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -36,7 +36,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
@@ -84,7 +84,7 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         final GeneratedDocumentInfo expectedDocument = GeneratedDocumentInfo.builder()
             .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
-            .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+            .fileName(DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME + TEST_CASE_ID)
             .build();
 
         //given
@@ -111,10 +111,10 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         Map<String, Object> document = new HashMap<>();
         document.put(DOCUMENT_TYPE_JSON_KEY, DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE);
-        document.put(DOCUMENT_FILENAME_JSON_KEY, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
+        document.put(DOCUMENT_FILENAME_JSON_KEY, DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME);
         document.put(DOCUMENT_LINK_JSON_KEY, new HashMap<String, Object>() {
             {
-                put(DOCUMENT_LINK_FILENAME_JSON_KEY,DECREE_NISI_REFUSAL_DOCUMENT_NAME + DOCUMENT_EXTENSION);
+                put(DOCUMENT_LINK_FILENAME_JSON_KEY,DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME + DOCUMENT_EXTENSION);
             }
         });
 
@@ -139,7 +139,7 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         final GeneratedDocumentInfo expectedDocument = GeneratedDocumentInfo.builder()
             .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
-            .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+            .fileName(DECREE_NISI_REFUSAL_CLARIFICATION_DOCUMENT_NAME + TEST_CASE_ID)
             .build();
 
         //given

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -43,7 +44,10 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_EXTENSION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_LINK_FILENAME_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_LINK_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_OTHER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_TO_PAY_JSON_KEY;
@@ -107,6 +111,10 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         Map<String, Object> document = new HashMap<>();
         document.put(DOCUMENT_TYPE_JSON_KEY, DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE);
         document.put(DOCUMENT_FILENAME_JSON_KEY, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
+        document.put(DOCUMENT_LINK_JSON_KEY, new HashMap<String, Object>() {{
+            put(DOCUMENT_LINK_FILENAME_JSON_KEY,
+                DECREE_NISI_REFUSAL_DOCUMENT_NAME + DOCUMENT_EXTENSION);
+        }});
 
         Map<String, Object> documentMember = new HashMap<>();
         documentMember.put(VALUE_KEY, document);
@@ -153,6 +161,12 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
             is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + TEST_CASE_ID + "-" + FIXED_TIME_EPOCH));
 
             is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE));
+        assertThat(initialDocument.get(DOCUMENT_LINK_JSON_KEY),
+            is(new HashMap<String, Object>() {{
+                put(DOCUMENT_LINK_FILENAME_JSON_KEY,
+                    DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE + DOCUMENT_EXTENSION);
+            }})
+        );
 
         verify(documentGeneratorClient)
             .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -11,9 +11,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees.FeeResponse;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.Clock;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -55,13 +54,13 @@ import static uk.gov.hmcts.reform.divorce.orchestration.tasks.MultipleDocumentGe
 @RunWith(MockitoJUnitRunner.class)
 public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
-    private static final long FIXED_TIME_EPOCH = 1000000L;
+    private static final String FIXED_DATE = "2010-10-10";
 
     @Mock
     private DocumentGeneratorClient documentGeneratorClient;
 
     @Mock
-    private Clock clock;
+    private CcdUtil ccdUtil;
 
     @InjectMocks
     private DecreeNisiRefusalDocumentGeneratorTask decreeNisiRefusalDocumentGeneratorTask;
@@ -103,7 +102,7 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
     @Test
     public void callsDocumentGeneratorAndStoresAdditionalGeneratedDocumentForDnRefusalClarificationWithExistingDocs() {
-        when(clock.instant()).thenReturn(Instant.ofEpochMilli(FIXED_TIME_EPOCH));
+        when(ccdUtil.getCurrentDateCcdFormat()).thenReturn(FIXED_DATE);
 
         Map<String, Object> document = new HashMap<>();
         document.put(DOCUMENT_TYPE_JSON_KEY, DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE);
@@ -152,11 +151,13 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         assertThat(initialDocument.get(DOCUMENT_TYPE_JSON_KEY), is(DOCUMENT_TYPE_OTHER));
         assertThat(initialDocument.get(DOCUMENT_FILENAME_JSON_KEY),
             is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + TEST_CASE_ID + "-" + FIXED_TIME_EPOCH));
-        
+
+            is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE));
+
         verify(documentGeneratorClient)
             .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
     }
-  
+
     @Test
     public void callsDocumentGeneratorAndStoresGeneratedDocumentForDnRefusalRejectionWithRejectOption() {
         final FeeResponse amendFee = FeeResponse.builder().amount(TEST_FEE_AMOUNT).build();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -41,6 +41,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_ORDER_REJECTION_TEMPLATE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_REFUSAL_REJECTION_DOCUMENT_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DN_REFUSED_REJECT_OPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_EXTENSION;
@@ -161,8 +162,6 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         assertThat(initialDocument.get(DOCUMENT_TYPE_JSON_KEY), is(DOCUMENT_TYPE_OTHER));
         assertThat(initialDocument.get(DOCUMENT_FILENAME_JSON_KEY),
-            is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + TEST_CASE_ID + "-" + FIXED_TIME_EPOCH));
-
             is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE));
         assertThat(initialDocument.get(DOCUMENT_LINK_JSON_KEY),
             is(new HashMap<String, Object>() {
@@ -198,7 +197,7 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         final GeneratedDocumentInfo expectedDocument = GeneratedDocumentInfo.builder()
             .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
-            .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+            .fileName(DECREE_NISI_REFUSAL_REJECTION_DOCUMENT_NAME + TEST_CASE_ID)
             .build();
 
         final Map<String, Object> expectedPayload = new HashMap<>(payload);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DecreeNisiRefusalDocumentGeneratorTaskTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -74,9 +73,9 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         final Map<String, Object> payload = new HashMap<>();
         payload.put(REFUSAL_DECISION_CCD_FIELD, REFUSAL_DECISION_MORE_INFO_VALUE);
         final CaseDetails caseDetails = CaseDetails.builder()
-                .caseId(TEST_CASE_ID)
-                .caseData(payload)
-                .build();
+            .caseId(TEST_CASE_ID)
+            .caseData(payload)
+            .build();
 
         final TaskContext context = new DefaultTaskContext();
         context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
@@ -84,13 +83,14 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         context.setTransientObject(CASE_DETAILS_JSON_KEY, caseDetails);
 
         final GeneratedDocumentInfo expectedDocument = GeneratedDocumentInfo.builder()
-                .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
-                .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
-                .build();
+            .documentType(DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE)
+            .fileName(DECREE_NISI_REFUSAL_DOCUMENT_NAME + TEST_CASE_ID)
+            .build();
 
         //given
         when(documentGeneratorClient
-            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN))
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
+                caseDetails), eq(AUTH_TOKEN))
         ).thenReturn(expectedDocument);
 
         //when
@@ -101,7 +101,8 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         assertThat(documentCollection, is(newLinkedHashSet(expectedDocument)));
 
         verify(documentGeneratorClient)
-                .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
+                caseDetails), eq(AUTH_TOKEN));
     }
 
     @Test
@@ -111,10 +112,11 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         Map<String, Object> document = new HashMap<>();
         document.put(DOCUMENT_TYPE_JSON_KEY, DECREE_NISI_REFUSAL_ORDER_DOCUMENT_TYPE);
         document.put(DOCUMENT_FILENAME_JSON_KEY, DECREE_NISI_REFUSAL_DOCUMENT_NAME);
-        document.put(DOCUMENT_LINK_JSON_KEY, new HashMap<String, Object>() {{
-            put(DOCUMENT_LINK_FILENAME_JSON_KEY,
-                DECREE_NISI_REFUSAL_DOCUMENT_NAME + DOCUMENT_EXTENSION);
-        }});
+        document.put(DOCUMENT_LINK_JSON_KEY, new HashMap<String, Object>() {
+            {
+                put(DOCUMENT_LINK_FILENAME_JSON_KEY,DECREE_NISI_REFUSAL_DOCUMENT_NAME + DOCUMENT_EXTENSION);
+            }
+        });
 
         Map<String, Object> documentMember = new HashMap<>();
         documentMember.put(VALUE_KEY, document);
@@ -142,7 +144,8 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
         //given
         when(documentGeneratorClient
-            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN))
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
+                caseDetails), eq(AUTH_TOKEN))
         ).thenReturn(expectedDocument);
 
         //when
@@ -162,14 +165,17 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
 
             is(DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE));
         assertThat(initialDocument.get(DOCUMENT_LINK_JSON_KEY),
-            is(new HashMap<String, Object>() {{
-                put(DOCUMENT_LINK_FILENAME_JSON_KEY,
-                    DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE + DOCUMENT_EXTENSION);
-            }})
+            is(new HashMap<String, Object>() {
+                {
+                    put(DOCUMENT_LINK_FILENAME_JSON_KEY,
+                            DECREE_NISI_REFUSAL_DOCUMENT_NAME_OLD + FIXED_DATE + DOCUMENT_EXTENSION);
+                }
+            })
         );
 
         verify(documentGeneratorClient)
-            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
+                caseDetails), eq(AUTH_TOKEN));
     }
 
     @Test
@@ -240,6 +246,7 @@ public class DecreeNisiRefusalDocumentGeneratorTaskTest {
         assertEquals(documentCollection.size(), 0);
 
         verify(documentGeneratorClient, never())
-            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID, caseDetails), eq(AUTH_TOKEN));
+            .generatePDF(matchesDocumentInputParameters(DECREE_NISI_REFUSAL_ORDER_CLARIFICATION_TEMPLATE_ID,
+                caseDetails), eq(AUTH_TOKEN));
     }
 }


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-5098

Previously, the wrong Json Key name (documentType, when DocumentType was expected) was being used for comparison. This meant only the latest document was kept and all previous ones were still being dropped as the condition did not match and returned false.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Updated integration test with previous documents verified it now stores older docs properly.

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
