### PR TITLE
DIV-5860: Enabling Integration test for data migration to run with no manual steps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,8 @@ def versions = [
         hibernateTypes               : '2.4.0',
         flyway                       : '5.2.4',
         elasticsearch                : '7.3.0',
-        divCommonLib                 : '1.0.7'
+        divCommonLib                 : '1.0.7',
+        dumbster                     : '1.7.1'
 ]
 
 allprojects {
@@ -325,6 +326,8 @@ dependencies {
     compile group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: versions.gradlePitest
     compile group: 'org.codehaus.sonar-plugins', name: 'sonar-pitest-plugin', version: versions.sonarPitest
 
+    compile group: 'com.github.kirviq', name: 'dumbster', version: versions.dumbster
+
     compile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson) {
         force = true
     }
@@ -440,7 +443,7 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
 
     setTestClassesDirs(sourceSets.integrationTest.output.classesDirs)
     setClasspath(sourceSets.integrationTest.runtimeClasspath)
-    if(System.getenv('CHANGE_TITLE')?.startsWith('[FAST]')) {
+    if (System.getenv('CHANGE_TITLE')?.startsWith('[FAST]')) {
         useJUnit {
             excludeCategories 'uk.gov.hmcts.reform.divorce.category.ExtendedTest'
         }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/dataextraction/FamilyManDataExtractionIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/dataextraction/FamilyManDataExtractionIT.java
@@ -99,6 +99,7 @@ public class FamilyManDataExtractionIT extends RetrieveCaseSupport {
     private void checkEmailHasBeenSent() {
         if (isTestRunningLocally()) {
             assertThat(simpleSmtpServer.getReceivedEmails(), hasSize(greaterThan(0)));
+            simpleSmtpServer.reset();
         }
     }
 


### PR DESCRIPTION
# Description

Starting a local SMTP server when running tests locally.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Integration tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
