### PR TITLE
DIV-5293 use right CCD field when searching for cases eligible for DA Overdue

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchCasesDAOverdueTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchCasesDAOverdueTaskTest.java
@@ -39,7 +39,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static wiremock.org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SearchCasesDAOverdueTest {
+public class SearchCasesDAOverdueTaskTest {
 
     private static final String DN_GRANTED_DATE = String.format("data.%s", DECREE_NISI_GRANTED_DATE_CCD_FIELD);
 
@@ -92,7 +92,7 @@ public class SearchCasesDAOverdueTest {
 
         verify(cmsElasticSearchSupport).searchCMSCases(eq(start), eq(pageSize), eq(AUTH_TOKEN),
             eq(QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AWAITING_DA)),
-            eq(QueryBuilders.rangeQuery(DN_GRANTED_DATE).lte(buildCoolOffPeriodInDNBoundary(timeSinceDAWasPronounced))));
+            eq(QueryBuilders.rangeQuery(DN_GRANTED_DATE).lte(buildDateQueryExpression(timeSinceDAWasPronounced))));
     }
 
     @Test
@@ -153,8 +153,6 @@ public class SearchCasesDAOverdueTest {
 
     @Test
     public void execute_exceptionDuringSearch_searchStops() throws TaskException {
-        final int totalSearchResults = 20;
-
         when(cmsElasticSearchSupport.searchCMSCases(
             eq(start),
             eq(pageSize),
@@ -182,7 +180,7 @@ public class SearchCasesDAOverdueTest {
         return streamBuilder.build();
     }
 
-    private static String buildCoolOffPeriodInDNBoundary(final String coolOffPeriodInDN) {
+    private String buildDateQueryExpression(final String coolOffPeriodInDN) {
         String timeUnit = String.valueOf(coolOffPeriodInDN.charAt(coolOffPeriodInDN.length() - 1));
         return String.format("now/%s-%s", timeUnit, coolOffPeriodInDN);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchCasesDAOverdueTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchCasesDAOverdueTest.java
@@ -34,14 +34,14 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseCon
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AWAITING_DA;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATE_CASE_NO_LONGER_ELIGIBLE_FOR_DA_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DA_OVERDUE_PERIOD_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_NISI_GRANTED_DATE_CCD_FIELD;
 import static wiremock.org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SearchAwaitingDATest {
+public class SearchCasesDAOverdueTest {
 
-    private static final String DA_OVERDUE_DATE = String.format("data.%s", DATE_CASE_NO_LONGER_ELIGIBLE_FOR_DA_CCD_FIELD);
+    private static final String DN_GRANTED_DATE = String.format("data.%s", DECREE_NISI_GRANTED_DATE_CCD_FIELD);
 
     @Mock
     private CMSElasticSearchSupport cmsElasticSearchSupport;
@@ -92,7 +92,7 @@ public class SearchAwaitingDATest {
 
         verify(cmsElasticSearchSupport).searchCMSCases(eq(start), eq(pageSize), eq(AUTH_TOKEN),
             eq(QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AWAITING_DA)),
-            eq(QueryBuilders.rangeQuery(DA_OVERDUE_DATE).lte(buildCoolOffPeriodInDNBoundary(timeSinceDAWasPronounced))));
+            eq(QueryBuilders.rangeQuery(DN_GRANTED_DATE).lte(buildCoolOffPeriodInDNBoundary(timeSinceDAWasPronounced))));
     }
 
     @Test


### PR DESCRIPTION
Use right CCD date field when searching for cases are eligible for DA Overdue (i.e. 12 months since DN pronounced )


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
