### PR TITLE
Add validation for pronouncement date in the future

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnPronouncementDetailsTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnPronouncementDetailsTask.java
@@ -33,7 +33,7 @@ public class SetDnPronouncementDetailsTask implements Task<Map<String,Object>> {
         LocalDateTime hearingDateTime = LocalDateTime.parse((String) caseData.get(COURT_HEARING_DATE_CCD_FIELD));
 
         if (hearingDateTime.isAfter(ccdUtil.getCurrentLocalDateTime())) {
-            throw new TaskException("Hearing date can not be in the future for pronouncement");
+            throw new TaskException("You cannot pronounce a bulk case that has a scheduled pronouncement date that is in the future.");
         }
 
         // Decree Nisi Granted Date is the same date as the Court Hearing Date at the time of Pronouncement

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnPronouncementDetailsTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnPronouncementDetailsTask.java
@@ -30,8 +30,13 @@ public class SetDnPronouncementDetailsTask implements Task<Map<String,Object>> {
             throw new TaskException("Judge who pronounced field must be set.");
         }
 
-        // Decree Nisi Granted Date is the same date as the Court Hearing Date at the time of Pronouncement
         LocalDateTime hearingDateTime = LocalDateTime.parse((String) caseData.get(COURT_HEARING_DATE_CCD_FIELD));
+
+        if (hearingDateTime.isAfter(ccdUtil.getCurrentLocalDateTime())) {
+            throw new TaskException("Hearing date can not be in the future for pronouncement");
+        }
+
+        // Decree Nisi Granted Date is the same date as the Court Hearing Date at the time of Pronouncement
         caseData.put(DECREE_NISI_GRANTED_DATE_CCD_FIELD, DateUtils.formatDateFromDateTime(hearingDateTime));
 
         // Decree Absolute Eligible Date is 6 weeks and 1 day from the Pronouncement date

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtil.java
@@ -87,4 +87,7 @@ public class CcdUtil {
             .orElse(defaultValue);
     }
 
+    public LocalDateTime getCurrentLocalDateTime() {
+        return LocalDateTime.now(clock);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnPronouncementDetailsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetDnPronouncementDetailsTaskTest.java
@@ -34,6 +34,8 @@ public class SetDnPronouncementDetailsTaskTest {
         payload.put(PRONOUNCEMENT_JUDGE_CCD_FIELD, "District Judge");
         payload.put(COURT_HEARING_DATE_CCD_FIELD, "2000-01-01T10:20:55.000");
 
+        when(ccdUtil.getCurrentLocalDateTime()).thenReturn(LocalDate.of(2000, 10, 10).atStartOfDay());
+
         LocalDate courtHearingLocalDate = LocalDate.of(2000, 1, 1);
         when(ccdUtil.parseDecreeAbsoluteEligibleDate(courtHearingLocalDate)).thenCallRealMethod();
 
@@ -51,6 +53,17 @@ public class SetDnPronouncementDetailsTaskTest {
     public void testSetDnPronouncementDetailsThrowsExceptionWithMissingPronouncementJudge() throws TaskException {
         HashMap<String, Object> payload = new HashMap<>();
         payload.put(COURT_HEARING_DATE_CCD_FIELD, "2000-01-01T10:20:55.000");
+
+        setDnPronouncementDetailsTask.execute(null, payload);
+    }
+
+    @Test(expected = TaskException.class)
+    public void testSetDnPronouncementDetailsThrowsExceptionWithFutureHearingDate() throws TaskException {
+        HashMap<String, Object> payload = new HashMap<>();
+        payload.put(PRONOUNCEMENT_JUDGE_CCD_FIELD, "District Judge");
+        payload.put(COURT_HEARING_DATE_CCD_FIELD, "2000-11-11T10:20:55.000");
+
+        when(ccdUtil.getCurrentLocalDateTime()).thenReturn(LocalDate.of(2000, 10, 10).atStartOfDay());
 
         setDnPronouncementDetailsTask.execute(null, payload);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
@@ -126,4 +126,9 @@ public class CcdUtilUTest {
         assertThat(localDateTime.getSecond(), is(0));
     }
 
+    @Test
+    public void shouldReturnCurrentLocalDateTime() {
+        assertEquals(FIXED_DATE_TIME, ccdUtil.getCurrentLocalDateTime());
+    }
+
 }


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-5849

Adds validation to check if the caseworker is attempting to pronounce the bulk case when the hearing date is in the future, so pronouncement could not have happened yet.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
