### PR TITLE
BSP-91: Added D8MarriagePetitionerName and D8MarriageRespondentName fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformations/D8FormToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformations/D8FormToCaseTransformer.java
@@ -47,6 +47,10 @@ public class D8FormToCaseTransformer extends ExceptionRecordToCaseTransformer {
         erToCcdFieldsMap.put("D8RespondentLastName", "D8RespondentLastName");
         erToCcdFieldsMap.put("D8RespondentPhoneNumber", "D8RespondentPhoneNumber");
 
+        // Section 4 - Details of marriage/civil partnership
+        erToCcdFieldsMap.put("D8MarriagePetitionerName", "D8MarriagePetitionerName");
+        erToCcdFieldsMap.put("D8MarriageRespondentName", "D8MarriageRespondentName");
+
         return erToCcdFieldsMap;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidator.java
@@ -17,7 +17,10 @@ public class NewDivorceCaseValidator extends BulkScanFormValidator {
         "D8LegalProcess",
         "D8ScreenHasMarriageCert",
         "D8RespondentFirstName",
-        "D8RespondentLastName"
+        "D8RespondentLastName",
+        "D8MarriagePetitionerName",
+        "D8MarriageRespondentName"
+
     );
 
     private static final Map<String, List<String>> ALLOWED_VALUES_PER_FIELD = new HashMap<>();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidator.java
@@ -29,7 +29,6 @@ public class NewDivorceCaseValidator extends BulkScanFormValidator {
         "D8RespondentLastName",
         "D8MarriagePetitionerName",
         "D8MarriageRespondentName"
-
     );
 
     private static final Map<String, List<String>> ALLOWED_VALUES_PER_FIELD = new HashMap<>();
@@ -63,17 +62,17 @@ public class NewDivorceCaseValidator extends BulkScanFormValidator {
         String hwfReferenceNumber = fieldsMap.getOrDefault("D8HelpWithFeesReferenceNumber", "");
         String d8PaymentMethod = fieldsMap.getOrDefault("D8PaymentMethod", "");
 
-        boolean multiplePaymentMethodsProvided =
+        boolean isMultiplePaymentMethodsProvided =
                 ((StringUtils.isNotEmpty(hwfReferenceNumber) && StringUtils.isNotEmpty(d8PaymentMethod)));
 
-        boolean noPaymentMethodProvided = StringUtils.isEmpty(hwfReferenceNumber)
+        boolean isNoPaymentMethodProvided = StringUtils.isEmpty(hwfReferenceNumber)
                 && StringUtils.isEmpty(d8PaymentMethod);
 
-        if (noPaymentMethodProvided) {
+        if (isNoPaymentMethodProvided) {
             validationWarningMessages.add(EMPTY_PAYMENT_METHOD_ERROR_MESSAGE);
         }
 
-        if (multiplePaymentMethodsProvided) {
+        if (isMultiplePaymentMethodsProvided) {
             validationWarningMessages.add(MULTIPLE_PAYMENT_METHODS_ERROR_MESSAGE);
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/TransformationBulkScanITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/TransformationBulkScanITest.java
@@ -56,7 +56,7 @@ public class TransformationBulkScanITest {
                     hasJsonPath("$.case_creation_details", allOf(
                         hasJsonPath("case_type_id", is("DIVORCE")),
                         hasJsonPath("event_id", is("bulkScanCaseCreate")),
-                        hasJsonPath("case_data.*", hasSize(12)),
+                        hasJsonPath("case_data.*", hasSize(14)),
                         hasJsonPath("case_data", allOf(
                             hasJsonPath("D8HelpWithFeesReferenceNumber", is("123456")),
                             hasJsonPath("D8PaymentMethod", is("card")),
@@ -69,7 +69,9 @@ public class TransformationBulkScanITest {
                             hasJsonPath("D8CertificateInEnglish", is("True")),
                             hasJsonPath("D8RespondentFirstName", is("Jane")),
                             hasJsonPath("D8RespondentLastName", is("Doe")),
-                            hasJsonPath("D8RespondentPhoneNumber", is("22222222222"))
+                            hasJsonPath("D8RespondentPhoneNumber", is("22222222222")),
+                            hasJsonPath("D8MarriagePetitionerName", is("Christopher O'John")),
+                            hasJsonPath("D8MarriageRespondentName", is("Jane Doe"))
                         ))
                     ))
                 )));
@@ -92,7 +94,7 @@ public class TransformationBulkScanITest {
                     hasJsonPath("$.case_creation_details", allOf(
                         hasJsonPath("case_type_id", is("DIVORCE")),
                         hasJsonPath("event_id", is("bulkScanCaseCreate")),
-                        hasJsonPath("case_data.*", hasSize(7)),
+                        hasJsonPath("case_data.*", hasSize(9)),
                         hasJsonPath("case_data", allOf(
                             hasJsonPath("D8HelpWithFeesReferenceNumber", is("123456")),
                             hasJsonPath("D8PaymentMethod", is("card")),
@@ -101,6 +103,8 @@ public class TransformationBulkScanITest {
                             hasJsonPath("D8PetitionerPhoneNumber", is("1111111111")),
                             hasJsonPath("D8PetitionerEmail", is("test.testerson@mailinator.com")),
                             hasJsonPath("D8LegalProcess", is("Divorce")),
+                            hasJsonPath("D8MarriagePetitionerName", is("Christopher O'John")),
+                            hasJsonPath("D8MarriageRespondentName", is("Jane Doe")),
                             hasNoJsonPath("D8CertificateInEnglish")
                         ))
                     ))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidatorTest.java
@@ -24,7 +24,10 @@ public class NewDivorceCaseValidatorTest {
             new OcrDataField("D8LegalProcess", "Dissolution"),
             new OcrDataField("D8ScreenHasMarriageCert", "True"),
             new OcrDataField("D8RespondentFirstName", "Louis"),
-            new OcrDataField("D8RespondentLastName", "Griffin")
+            new OcrDataField("D8RespondentLastName", "Griffin"),
+            new OcrDataField("D8MarriagePetitionerName", "Peter Griffin"),
+            new OcrDataField("D8MarriageRespondentName", "Louis Griffin")
+
         ));
 
         assertThat(validationResult.getStatus(), is(SUCCESS));
@@ -44,7 +47,9 @@ public class NewDivorceCaseValidatorTest {
             "Mandatory field \"D8LegalProcess\" is missing",
             "Mandatory field \"D8ScreenHasMarriageCert\" is missing",
             "Mandatory field \"D8RespondentFirstName\" is missing",
-            "Mandatory field \"D8RespondentLastName\" is missing"
+            "Mandatory field \"D8RespondentLastName\" is missing",
+            "Mandatory field \"D8MarriagePetitionerName\" is missing",
+            "Mandatory field \"D8MarriageRespondentName\" is missing"
         ));
     }
 
@@ -54,7 +59,9 @@ public class NewDivorceCaseValidatorTest {
             new OcrDataField("D8PetitionerFirstName", "Kratos"),
             new OcrDataField("D8PetitionerLastName", ""),
             new OcrDataField("D8RespondentFirstName", ""),
-            new OcrDataField("D8RespondentLastName", "")
+            new OcrDataField("D8RespondentLastName", ""),
+            new OcrDataField("D8MarriagePetitionerName", ""),
+            new OcrDataField("D8MarriageRespondentName", "")
         ));
 
         assertThat(validationResult.getStatus(), is(WARNINGS));
@@ -62,7 +69,9 @@ public class NewDivorceCaseValidatorTest {
         assertThat(validationResult.getWarnings(), hasItems(
             "Mandatory field \"D8PetitionerLastName\" is missing",
             "Mandatory field \"D8RespondentFirstName\" is missing",
-            "Mandatory field \"D8RespondentLastName\" is missing"
+            "Mandatory field \"D8RespondentLastName\" is missing",
+            "Mandatory field \"D8MarriagePetitionerName\" is missing",
+            "Mandatory field \"D8MarriageRespondentName\" is missing"
         ));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidatorTest.java
@@ -103,7 +103,9 @@ public class NewDivorceCaseValidatorTest {
                 new OcrDataField("D8HelpWithFeesReferenceNumber", "123456"),
                 new OcrDataField("D8ScreenHasMarriageCert", "True"),
                 new OcrDataField("D8RespondentFirstName", "Louis"),
-                new OcrDataField("D8RespondentLastName", "Griffin")
+                new OcrDataField("D8RespondentLastName", "Griffin"),
+                new OcrDataField("D8MarriagePetitionerName", "Peter Griffin"),
+                new OcrDataField("D8MarriageRespondentName", "Louis Griffin")
         ));
 
         assertThat(validationResult.getStatus(), is(SUCCESS));
@@ -120,7 +122,9 @@ public class NewDivorceCaseValidatorTest {
                 new OcrDataField("D8HelpWithFeesReferenceNumber", "ABCDEF"),
                 new OcrDataField("D8ScreenHasMarriageCert", "True"),
                 new OcrDataField("D8RespondentFirstName", "Louis"),
-                new OcrDataField("D8RespondentLastName", "Griffin")
+                new OcrDataField("D8RespondentLastName", "Griffin"),
+                new OcrDataField("D8MarriagePetitionerName", "Peter Griffin"),
+                new OcrDataField("D8MarriageRespondentName", "Louis Griffin")
         ));
 
         assertThat(validationResult.getStatus(), is(WARNINGS));
@@ -140,7 +144,9 @@ public class NewDivorceCaseValidatorTest {
                 new OcrDataField("D8HelpWithFeesReferenceNumber", "123456"),
                 new OcrDataField("D8ScreenHasMarriageCert", "True"),
                 new OcrDataField("D8RespondentFirstName", "Louis"),
-                new OcrDataField("D8RespondentLastName", "Griffin")
+                new OcrDataField("D8RespondentLastName", "Griffin"),
+                new OcrDataField("D8MarriagePetitionerName", "Peter Griffin"),
+                new OcrDataField("D8MarriageRespondentName", "Louis Griffin")
         ));
 
         assertThat(validationResult.getStatus(), is(WARNINGS));
@@ -158,7 +164,9 @@ public class NewDivorceCaseValidatorTest {
                 new OcrDataField("D8LegalProcess", "Dissolution"),
                 new OcrDataField("D8ScreenHasMarriageCert", "True"),
                 new OcrDataField("D8RespondentFirstName", "Louis"),
-                new OcrDataField("D8RespondentLastName", "Griffin")
+                new OcrDataField("D8RespondentLastName", "Griffin"),
+                new OcrDataField("D8MarriagePetitionerName", "Peter Griffin"),
+                new OcrDataField("D8MarriageRespondentName", "Louis Griffin")
         ));
 
         assertThat(validationResult.getStatus(), is(WARNINGS));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/NewDivorceCaseValidatorTest.java
@@ -28,7 +28,6 @@ public class NewDivorceCaseValidatorTest {
             new OcrDataField("D8RespondentLastName", "Griffin"),
             new OcrDataField("D8MarriagePetitionerName", "Peter Griffin"),
             new OcrDataField("D8MarriageRespondentName", "Louis Griffin")
-
         ));
 
         assertThat(validationResult.getStatus(), is(SUCCESS));

--- a/src/test/resources/jsonExamples/payloads/bulk/scan/fullD8Form.json
+++ b/src/test/resources/jsonExamples/payloads/bulk/scan/fullD8Form.json
@@ -14,6 +14,8 @@
     { "name": "D8CertificateInEnglish", "value": "True" },
     { "name": "D8RespondentFirstName", "value": "Jane" },
     { "name": "D8RespondentLastName", "value": "Doe" },
-    { "name": "D8RespondentPhoneNumber", "value": "22222222222" }
+    { "name": "D8RespondentPhoneNumber", "value": "22222222222" },
+    { "name": "D8MarriagePetitionerName", "value": "Christopher O'John" },
+    { "name": "D8MarriageRespondentName", "value": "Jane Doe" }
   ]
 }

--- a/src/test/resources/jsonExamples/payloads/bulk/scan/partialD8Form.json
+++ b/src/test/resources/jsonExamples/payloads/bulk/scan/partialD8Form.json
@@ -9,6 +9,8 @@
     { "name": "D8PetitionerLastName", "value": "O'John" },
     { "name": "D8PetitionerPhoneNumber", "value": "1111111111" },
     { "name": "D8PetitionerEmail", "value": "test.testerson@mailinator.com" },
-    { "name": "D8LegalProcess", "value": "Divorce" }
+    { "name": "D8LegalProcess", "value": "Divorce" },
+    { "name": "D8MarriagePetitionerName", "value": "Christopher O'John" },
+    { "name": "D8MarriageRespondentName", "value": "Jane Doe" }
   ]
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/BSP-91

Added the following 2 fields for Section 4 ('Details of marriage/civil partnership') from the D8 Form.
- D8MarriagePetitionerName
- D8MarriageRespondentName

Both fields are mandatory.

The following transformations were applied:
D8MarriagePetitionerName -> D8MarriagePetitionerName
D8MarriageRespondentName -> D8MarriageRespondentName