### PR TITLE
Changed dependabot to weekly to stop spam

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,4 +2,4 @@ version: 1
 update_configs:
   - package_manager: "java:gradle"
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: "monthly"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,4 +2,4 @@ version: 1
 update_configs:
   - package_manager: "java:gradle"
     directory: "/"
-    update_schedule: "monthly"
+    update_schedule: "weekly"


### PR DESCRIPTION
Stop us getting spammed daily about new versions - rather than removing it altogether, by setting it to weekly we can still regularly have the latest dependencies without too many PRs or resources being taken up