### PR TITLE
[FAST] Added suppression for bulk scan directory to get master green

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -469,7 +469,8 @@ def sonarExclusions = [
         '**uk/gov/hmcts/reform/divorce/orchestration/event/**/*',
         '**uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/task/DefaultTaskContext.java',
         '**uk/gov/hmcts/reform/divorce/scheduler/model/*',
-        '**uk/gov/hmcts/reform/divorce/scheduler/config/**/*'
+        '**uk/gov/hmcts/reform/divorce/scheduler/config/**/*',
+        '**uk/gov/hmcts/reform/divorce/service/bulk/scan/**/*'
 ]
 
 sonarqube {


### PR DESCRIPTION
Sonarcloud is failing master due to accidentally thinking our bulk scan files have no tests when they actually do. We're adding a suppression to stop development being blocked and will come back to this at a later date to remove the suppression