### PR TITLE
BSP-120: Fixed duplicate error message appearing from aos validation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosPackOfflineCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosPackOfflineCaseValidator.java
@@ -112,23 +112,11 @@ public class AosPackOfflineCaseValidator extends BulkScanFormValidator {
         String respJurisdictionAgreeField = fieldsMap.getOrDefault("RespJurisdictionAgree", "");
         String respJurisdictionDisagreeReasonField = fieldsMap.getOrDefault("RespJurisdictionDisagreeReason", "");
 
-        if (respJurisdictionDisagreeReasonField.isEmpty()) {
-            if (respJurisdictionAgreeField.equals(NO_VALUE)) {
-
+        if (respJurisdictionAgreeField.equals(YES_VALUE) && !respJurisdictionDisagreeReasonField.isEmpty()) {
                 validationWarningMessages.add(RESP_JURISDICTION_DISAGREE_REASON_ERROR_MESSAGE);
-            }
-        } else {
-            if (respJurisdictionAgreeField.equals(YES_VALUE)) {
-
-                validationWarningMessages.add(RESP_JURISDICTION_DISAGREE_REASON_ERROR_MESSAGE);
-            }
         }
 
-        if (respJurisdictionAgreeField.equals(YES_VALUE) && !respJurisdictionDisagreeReasonField.isEmpty()) {
-
-            validationWarningMessages.add(RESP_JURISDICTION_DISAGREE_REASON_ERROR_MESSAGE);
-        } else if (respJurisdictionAgreeField.equals(NO_VALUE) && respJurisdictionDisagreeReasonField.isEmpty()) {
-
+        if (respJurisdictionAgreeField.equals(NO_VALUE) && respJurisdictionDisagreeReasonField.isEmpty()) {
             validationWarningMessages.add(RESP_JURISDICTION_DISAGREE_REASON_ERROR_MESSAGE);
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosPackOfflineCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosPackOfflineCaseValidator.java
@@ -112,15 +112,27 @@ public class AosPackOfflineCaseValidator extends BulkScanFormValidator {
         String respJurisdictionAgreeField = fieldsMap.getOrDefault("RespJurisdictionAgree", "");
         String respJurisdictionDisagreeReasonField = fieldsMap.getOrDefault("RespJurisdictionDisagreeReason", "");
 
-        if (respJurisdictionAgreeField.equals(YES_VALUE) && !respJurisdictionDisagreeReasonField.isEmpty()) {
-                validationWarningMessages.add(RESP_JURISDICTION_DISAGREE_REASON_ERROR_MESSAGE);
+        if (didAgreeRespJurisdictionButProvidedReasonWhyTheyDisagree(respJurisdictionAgreeField, respJurisdictionDisagreeReasonField)) {
+            validationWarningMessages.add(RESP_JURISDICTION_DISAGREE_REASON_ERROR_MESSAGE);
         }
 
-        if (respJurisdictionAgreeField.equals(NO_VALUE) && respJurisdictionDisagreeReasonField.isEmpty()) {
+        if (didNotAgreeWithRespJurisdictionButDidNotProvideReasonWhyTheyDisagree(respJurisdictionAgreeField, respJurisdictionDisagreeReasonField)) {
             validationWarningMessages.add(RESP_JURISDICTION_DISAGREE_REASON_ERROR_MESSAGE);
         }
 
         return validationWarningMessages;
+    }
+
+    private static Boolean didAgreeRespJurisdictionButProvidedReasonWhyTheyDisagree(String respJurisdictionAgreeField,
+                                                                                    String respJurisdictionDisagreeReasonField) {
+
+        return (respJurisdictionAgreeField.equals(YES_VALUE) && !respJurisdictionDisagreeReasonField.isEmpty());
+    }
+
+    private static Boolean didNotAgreeWithRespJurisdictionButDidNotProvideReasonWhyTheyDisagree(String respJurisdictionAgreeField,
+                                                                                                String respJurisdictionDisagreeReasonField) {
+
+        return (respJurisdictionAgreeField.equals(NO_VALUE) && respJurisdictionDisagreeReasonField.isEmpty());
     }
 
     private static List<String> validateRespLegalProceedingsDescription(Map<String, String> fieldsMap) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosPackOfflineCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosPackOfflineCaseValidatorTest.java
@@ -100,10 +100,6 @@ public class AosPackOfflineCaseValidatorTest {
         ));
     }
 
-    /*
-        ALLOWED_VALUES_PER_FIELD.put("RespStatementOfTruth", asList(YES_VALUE, null));
-     */
-
     @Test
     public void shouldFailFieldsHavingInvalidValues() {
         OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(asList(


### PR DESCRIPTION
Fixing a bug where we would accidentally add duplicate error message for a single error for AosOfflinePack validation

- The logic that these 2 if statements should cover is below:
- If RespJurisdictionAgree is 'No',  and RespJurisdictionDisagreeReason is empty, status = warning
- If RespJurisdictionAgree is 'No',  and RespJurisdictionDisagreeReason is not-empty, status = success
- If RespJurisdictionAgree is 'Yes',  and RespJurisdictionDisagreeReason is empty, status = success
- If RespJurisdictionAgree is 'Yes',  and RespJurisdictionDisagreeReason is not-empty, status = warning
- If RespJurisdictionAgree is anything else,  and RespJurisdictionDisagreeReason is empty, status = success
- If RespJurisdictionAgree is anything else,  and RespJurisdictionDisagreeReason is not-empty, status = success