### PR TITLE
BSP-178: Change to D8PetitionerCorrespondenceUseHomeAddress validation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidator.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static uk.gov.hmcts.reform.bsp.common.model.validation.BulkScanValidationPatterns.CCD_EMAIL_REGEX;
 import static uk.gov.hmcts.reform.bsp.common.model.validation.BulkScanValidationPatterns.CCD_PHONE_NUMBER_REGEX;
@@ -53,7 +54,6 @@ public class D8FormValidator extends BulkScanFormValidator {
         "D8PetitionerContactDetailsConfidential",
         "D8PetitionerPostCode",
         "PetitionerSolicitor",
-        "D8PetitionerCorrespondenceUseHomeAddress",
         "D8PetitionerHomeAddressStreet",
         "D8PetitionerHomeAddressTown",
         "D8PetitionerHomeAddressCounty",
@@ -91,7 +91,7 @@ public class D8FormValidator extends BulkScanFormValidator {
         ALLOWED_VALUES_PER_FIELD.put("D8PetitionerContactDetailsConfidential", yesNoValues);
         ALLOWED_VALUES_PER_FIELD.put("D8PaymentMethod", asList("Cheque", "Debit/Credit Card", BLANK));
         ALLOWED_VALUES_PER_FIELD.put("PetitionerSolicitor", yesNoValues);
-        ALLOWED_VALUES_PER_FIELD.put("D8PetitionerCorrespondenceUseHomeAddress", yesNoValues);
+        ALLOWED_VALUES_PER_FIELD.put("D8PetitionerCorrespondenceUseHomeAddress", asList(YES_VALUE, NO_VALUE, BLANK));
         ALLOWED_VALUES_PER_FIELD.put("D8PetitionerNameDifferentToMarriageCert", yesNoValues);
         ALLOWED_VALUES_PER_FIELD.put("D8RespondentCorrespondenceSendToSol", yesNoValues);
         ALLOWED_VALUES_PER_FIELD.put("D8MarriedInUk", yesNoValues);
@@ -179,13 +179,18 @@ public class D8FormValidator extends BulkScanFormValidator {
     }
 
     private static List<String> validateD8PetitionerCorrespondenceAddress(Map<String, String> fieldsMap) {
-        List<String> fieldsToCheck = Arrays.asList(
-            "D8PetitionerCorrespondenceAddressStreet",
-            "D8PetitionerCorrespondenceAddressTown",
-            "D8PetitionerCorrespondenceAddressCounty",
-            "D8PetitionerCorrespondencePostcode"
-        );
-        return validateFieldsAreNotEmptyOnlyFor(NO_VALUE, "D8PetitionerCorrespondenceUseHomeAddress", fieldsToCheck, fieldsMap);
+        List<String> validationMessages = emptyList();
+
+        if (fieldsMap.get("D8PetitionerCorrespondenceUseHomeAddress") != null) {
+            validationMessages = validateFieldsAreNotEmptyOnlyFor(NO_VALUE, "D8PetitionerCorrespondenceUseHomeAddress", asList(
+                "D8PetitionerCorrespondenceAddressStreet",
+                "D8PetitionerCorrespondenceAddressTown",
+                "D8PetitionerCorrespondenceAddressCounty",
+                "D8PetitionerCorrespondencePostcode"
+            ), fieldsMap);
+        }
+
+        return validationMessages;
     }
 
     private static List<String> validateFieldsAreNotEmptyOnlyFor(String valueForWhichFieldsShouldNotBeEmpty, String conditionField,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidator.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bsp.common.error.FormFieldValidationException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidatorTest.java
@@ -53,7 +53,6 @@ public class D8FormValidatorTest {
             new OcrDataField("D8ReasonForDivorceSeparationDate", "20/11/2008"),
             new OcrDataField("D8PetitionerPostCode", "HD7 5UZ"),
             new OcrDataField("PetitionerSolicitor", "Yes"),
-            new OcrDataField("D8PetitionerCorrespondenceUseHomeAddress", "Yes"),
             new OcrDataField("D8PetitionerHomeAddressStreet", "19 West Park Road"),
             new OcrDataField("D8PetitionerHomeAddressTown", "Smethwick"),
             new OcrDataField("D8PetitionerHomeAddressCounty", "West Midlands"),
@@ -186,7 +185,7 @@ public class D8FormValidatorTest {
             postcodeIsUsually6or7CharactersLong("PetitionerSolicitorAddressPostCode"),
             notInAValidFormat("PetitionerSolicitorPhone"),
             notInAValidFormat("PetitionerSolicitorEmail"),
-            mustBeYesOrNo("D8PetitionerCorrespondenceUseHomeAddress"),
+            "D8PetitionerCorrespondenceUseHomeAddress must be \"Yes\", \"No\" or left blank",
             postcodeIsUsually6or7CharactersLong("D8PetitionerCorrespondencePostcode"),
             postcodeIsUsually6or7CharactersLong("D8ReasonForDivorceAdultery3rdPartyPostCode"),
             mustBeYesOrNo("D8PetitionerNameDifferentToMarriageCert"),
@@ -244,8 +243,7 @@ public class D8FormValidatorTest {
             .map(emptyValueOcrDataField)
             .collect(Collectors.toList());
 
-        mandatoryFieldsWithValues.addAll(nonMandatoryFieldsWithEmptyValues);
-        OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(mandatoryFieldsWithValues);
+        OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, nonMandatoryFieldsWithEmptyValues));
         assertThat(validationResult.getStatus(), is(SUCCESS));
         assertThat(validationResult.getWarnings(), is(emptyList()));
         assertThat(validationResult.getErrors(), is(emptyList()));
@@ -276,8 +274,9 @@ public class D8FormValidatorTest {
 
     @Test
     public void shouldFailIfUsingMultipleValidPaymentMethods() {
-        mandatoryFieldsWithValues.add(new OcrDataField("D8HelpWithFeesReferenceNumber", "123456"));
-        OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(mandatoryFieldsWithValues);
+        OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, asList(
+            new OcrDataField("D8HelpWithFeesReferenceNumber", "123456")
+        )));
 
         assertThat(validationResult.getStatus(), is(WARNINGS));
         assertThat(validationResult.getWarnings(), hasItem(
@@ -303,12 +302,11 @@ public class D8FormValidatorTest {
         String[] validPhoneNumbers = {"07231334455", "+44 20 8356 3333", "01213334444", "0909 8790000",
             "(0131) 496 0645", "0044 117496 0813", "07700 90 09 99"};
         for (String validPhoneNumber : validPhoneNumbers) {
-            List<OcrDataField> mandatoryFieldsCopy = new ArrayList<>(mandatoryFieldsWithValues);
-            mandatoryFieldsCopy.add(new OcrDataField("D8PetitionerPhoneNumber", validPhoneNumber));
-            mandatoryFieldsCopy.add(new OcrDataField("D8RespondentPhoneNumber", validPhoneNumber));
-            mandatoryFieldsCopy.add(new OcrDataField("PetitionerSolicitorPhone", validPhoneNumber));
-
-            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(mandatoryFieldsCopy);
+            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, asList(
+                new OcrDataField("D8PetitionerPhoneNumber", validPhoneNumber),
+                new OcrDataField("D8RespondentPhoneNumber", validPhoneNumber),
+                new OcrDataField("PetitionerSolicitorPhone", validPhoneNumber)
+            )));
 
             assertThat(validationResult.getStatus(), is(SUCCESS));
             assertThat(validationResult.getWarnings(), is(emptyList()));
@@ -320,12 +318,11 @@ public class D8FormValidatorTest {
     public void shouldFailPhoneNumberNotMatchingCustomValidationRules() {
         String[] invalidPhoneNumbers = {"0723155", "+44 2083", "044(121)", "newphonewhodis", "se14Tp"};
         for (String invalidPhoneNumber : invalidPhoneNumbers) {
-            List<OcrDataField> mandatoryFieldsCopy = new ArrayList<>(mandatoryFieldsWithValues);
-            mandatoryFieldsCopy.add(new OcrDataField("D8PetitionerPhoneNumber", invalidPhoneNumber));
-            mandatoryFieldsCopy.add(new OcrDataField("D8RespondentPhoneNumber", invalidPhoneNumber));
-            mandatoryFieldsCopy.add(new OcrDataField("PetitionerSolicitorPhone", invalidPhoneNumber));
-
-            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(mandatoryFieldsCopy);
+            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, asList(
+                new OcrDataField("D8PetitionerPhoneNumber", invalidPhoneNumber),
+                new OcrDataField("D8RespondentPhoneNumber", invalidPhoneNumber),
+                new OcrDataField("PetitionerSolicitorPhone", invalidPhoneNumber)
+            )));
 
             assertThat(validationResult.getStatus(), is(WARNINGS));
             assertThat(validationResult.getWarnings(), hasItems(
@@ -341,12 +338,11 @@ public class D8FormValidatorTest {
     public void shouldPassEmailsMatchingCustomValidationRules() {
         String[] validEmailAddresses = {"aaa@gmail.com", "john.doe@mail.pl", "akjl2489.rq23@a.co.uk"};
         for (String validEmailAddress : validEmailAddresses) {
-            List<OcrDataField> mandatoryFieldsCopy = new ArrayList<>(mandatoryFieldsWithValues);
-            mandatoryFieldsCopy.add(new OcrDataField("D8PetitionerEmail", validEmailAddress));
-            mandatoryFieldsCopy.add(new OcrDataField("PetitionerSolicitorEmail", validEmailAddress));
-            mandatoryFieldsCopy.add(new OcrDataField("D8RespondentEmailAddress", validEmailAddress));
-
-            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(mandatoryFieldsCopy);
+            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, asList(
+                new OcrDataField("D8PetitionerEmail", validEmailAddress),
+                new OcrDataField("PetitionerSolicitorEmail", validEmailAddress),
+                new OcrDataField("D8RespondentEmailAddress", validEmailAddress)
+            )));
 
             assertThat(validationResult.getStatus(), is(SUCCESS));
             assertThat(validationResult.getWarnings(), is(emptyList()));
@@ -358,12 +354,11 @@ public class D8FormValidatorTest {
     public void shouldFailEmailsNotMatchingCustomValidationRules() {
         String[] invalidEmailAddresses = {"aaa@gmail.", "john.doe@mai", "akjl2489.rq23@", " @ ", "adada@sfwe"};
         for (String invalidEmailAddress : invalidEmailAddresses) {
-            List<OcrDataField> mandatoryFieldsCopy = new ArrayList<>(mandatoryFieldsWithValues);
-            mandatoryFieldsCopy.add(new OcrDataField("D8PetitionerEmail", invalidEmailAddress));
-            mandatoryFieldsCopy.add(new OcrDataField("PetitionerSolicitorEmail", invalidEmailAddress));
-            mandatoryFieldsCopy.add(new OcrDataField("D8RespondentEmailAddress", invalidEmailAddress));
-
-            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(mandatoryFieldsCopy);
+            OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, asList(
+                new OcrDataField("D8PetitionerEmail", invalidEmailAddress),
+                new OcrDataField("PetitionerSolicitorEmail", invalidEmailAddress),
+                new OcrDataField("D8RespondentEmailAddress", invalidEmailAddress)
+            )));
 
             assertThat(validationResult.getStatus(), is(WARNINGS));
             assertThat(validationResult.getWarnings(), hasItems(
@@ -739,6 +734,21 @@ public class D8FormValidatorTest {
             "\"D8PetitionerCorrespondenceAddressCounty\" should be empty if \"D8PetitionerCorrespondenceUseHomeAddress\" is \"Yes\"",
             "\"D8PetitionerCorrespondencePostcode\" should be empty if \"D8PetitionerCorrespondenceUseHomeAddress\" is \"Yes\""
         ));
+    }
+
+    @Test
+    public void shouldPassIfD8PetitionerCorrespondenceUseHomeAddressIsEmptyRegardlessOfCorrespondenceAddress() {
+        OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, asList(
+            new OcrDataField("D8PetitionerCorrespondenceUseHomeAddress", ""),
+            new OcrDataField("D8PetitionerCorrespondenceAddressStreet", "20 correspondence road"),
+            new OcrDataField("D8PetitionerCorrespondenceAddressTown", ""),
+            new OcrDataField("D8PetitionerCorrespondenceAddressCounty", "South Midlands"),
+            new OcrDataField("D8PetitionerCorrespondencePostcode", "")
+        )));
+
+        assertThat(validationResult.getStatus(), is(SUCCESS));
+        assertThat(validationResult.getErrors(), is(emptyList()));
+        assertThat(validationResult.getWarnings(), is(emptyList()));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidatorTest.java
@@ -239,11 +239,12 @@ public class D8FormValidatorTest {
             "D8RespondentSolicitorAddressPostCode",
             "D8LegalProceedingsDetailsCaseNumber",
             "D8LegalProceedingsDetails"
-        )
-            .map(emptyValueOcrDataField)
-            .collect(Collectors.toList());
+        ).map(emptyValueOcrDataField).collect(Collectors.toList());
 
-        OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(createMergedList(mandatoryFieldsWithValues, nonMandatoryFieldsWithEmptyValues));
+        OcrValidationResult validationResult = classUnderTest.validateBulkScanForm(
+            createMergedList(mandatoryFieldsWithValues, nonMandatoryFieldsWithEmptyValues)
+        );
+
         assertThat(validationResult.getStatus(), is(SUCCESS));
         assertThat(validationResult.getWarnings(), is(emptyList()));
         assertThat(validationResult.getErrors(), is(emptyList()));


### PR DESCRIPTION
# Description

D8PetitionerCorrespondenceUseHomeAddress should be able to accept empty values.

## Type of change

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
