### PR TITLE
BSP-119: Rename AosPackOffline to 2 Year Separation

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/bulk/scan/BulkScanIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/bulk/scan/BulkScanIntegrationTest.java
@@ -34,7 +34,7 @@ public class BulkScanIntegrationTest extends IntegrationTest {
 
 
     private static final String FULL_D_8_FORM_JSON_PATH = "jsonExamples/payloads/bulk/scan/d8/fullD8Form.json";
-    private static final String AOS_OFFLINE_FORM_JSON_PATH = "jsonExamples/payloads/bulk/scan/aos/aosPackOfflineForm.json";
+    private static final String AOS_OFFLINE_FORM_JSON_PATH = "jsonExamples/payloads/bulk/scan/aos/2yearSeparation/aosOffline2yrSep.json";
     private static String VALIDATION_END_POINT = "/forms/{form-type}/validate-ocr";
     private static String TRANSFORMATION_END_POINT = "/transform-exception-record";
     private static String UPDATE_END_POINT = "/update-case";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/BulkScanForms.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/BulkScanForms.java
@@ -4,6 +4,10 @@ public class BulkScanForms {
 
     public static final String D8_FORM = "d8Form";
 
-    // TODO: Confirm with Jeremy if this matches with the form name in BSP configuration spreadsheet
-    public static final String AOS_PACK_OFFLINE = "aosPackOffline";
+    // TODO: Confirm with Jeremy if these matches with the form names in BSP configuration spreadsheet
+    public static final String AOS_OFFLINE_2_YR_SEP = "aosPackOffline2YearSeparation";
+    public static final String AOS_OFFLINE_5_YR_SEP = "aosPackOffline5YearSeparation";
+    public static final String AOS_OFFLINE_BEHAVIOUR = "aosPackOfflineBehaviour";
+    public static final String AOS_OFFLINE_ADULTERY = "aosPackOfflineAdultery";
+    public static final String AOS_OFFLINE_CO_RESP = "aosPackOfflineCoResp";
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/AosOffline2YrSepFormToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/AosOffline2YrSepFormToCaseTransformer.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Component
-public class AosPackOfflineFormToCaseTransformer extends BulkScanFormTransformer {
+public class AosOffline2YrSepFormToCaseTransformer extends BulkScanFormTransformer {
 
     private static final Map<String, String> ocrToCCDMapping;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/BulkScanFormTransformerFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/BulkScanFormTransformerFactory.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 
 import static java.lang.String.format;
-import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.AOS_PACK_OFFLINE;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.AOS_OFFLINE_2_YR_SEP;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.D8_FORM;
 
 @Component
@@ -20,14 +20,14 @@ public class BulkScanFormTransformerFactory {
     private D8FormToCaseTransformer d8FormToCaseTransformer;
 
     @Autowired
-    private AosPackOfflineFormToCaseTransformer aosPackOfflineFormToCaseTransformer;
+    private AosOffline2YrSepFormToCaseTransformer aosOffline2YrSepFormToCaseTransformer;
 
     private static Map<String, BulkScanFormTransformer> bulkScanFormTransformerMap = new HashMap<>();
 
     @PostConstruct
     public void init() {
         bulkScanFormTransformerMap.put(D8_FORM, d8FormToCaseTransformer);
-        bulkScanFormTransformerMap.put(AOS_PACK_OFFLINE, aosPackOfflineFormToCaseTransformer);
+        bulkScanFormTransformerMap.put(AOS_OFFLINE_2_YR_SEP, aosOffline2YrSepFormToCaseTransformer);
     }
 
     public BulkScanFormTransformer getTransformer(String formType) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosOffline2yrSepCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosOffline2yrSepCaseValidator.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.validation;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.validation.BulkScanFormValidator;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -16,7 +17,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @Component
-public class AosPackOfflineCaseValidator extends BulkScanFormValidator {
+public class AosOffline2yrSepCaseValidator extends BulkScanFormValidator {
 
     private static final String DATE_RESP_RECEIVED_DIV_APP_WRONG_LENGTH_ERROR_MESSAGE =
         "DateRespReceivedDivorceApplication must be a valid 8 digit date";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/BulkScanFormValidatorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/BulkScanFormValidatorFactory.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import javax.annotation.PostConstruct;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.AOS_PACK_OFFLINE;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.AOS_OFFLINE_2_YR_SEP;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.D8_FORM;
 
 @Component
@@ -19,7 +19,7 @@ public class BulkScanFormValidatorFactory {
     private D8FormValidator d8FormValidator;
 
     @Autowired
-    private AosPackOfflineCaseValidator aosPackOfflineCaseValidator;
+    private AosOffline2yrSepCaseValidator aosOffline2yrSepCaseValidator;
 
     private static Map<String, BulkScanFormValidator> validators;
 
@@ -27,7 +27,7 @@ public class BulkScanFormValidatorFactory {
     public void initBean() {
         validators = new HashMap<>();
         validators.put(D8_FORM, d8FormValidator);
-        validators.put(AOS_PACK_OFFLINE, aosPackOfflineCaseValidator);
+        validators.put(AOS_OFFLINE_2_YR_SEP, aosOffline2yrSepCaseValidator);
     }
 
     public BulkScanFormValidator getValidator(final String formType) throws UnsupportedFormTypeException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/UpdateBulkScanITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/UpdateBulkScanITest.java
@@ -39,9 +39,9 @@ public class UpdateBulkScanITest {
 
     private static final String UPDATE_URL = "/update-case";
     private static final String AOS_PACK_OFFLINE_FORM_JSON_PATH
-        = "jsonExamples/payloads/bulk/scan/aos/aosPackOfflineForm.json";
+        = "jsonExamples/payloads/bulk/scan/aos/2yearSeparation/aosOffline2yrSep.json";
     private static final String INVALID_AOS_PACK_OFFLINE_FORM_JSON_PATH
-        = "jsonExamples/payloads/bulk/scan/aos/invalidAosPackOfflineForm.json";
+        = "jsonExamples/payloads/bulk/scan/aos/2yearSeparation/invalidAosOffline2yrSep.json";
 
     private String validBody;
     private String invalidBody;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/AosOffline2YrSepFormToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/AosOffline2YrSepFormToCaseTransformerTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.transformati
 import org.junit.Test;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bsp.common.model.validation.in.OcrDataField;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.transformation.AosOffline2YrSepFormToCaseTransformer;
 
 import java.util.List;
 import java.util.Map;
@@ -13,9 +14,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
-public class AosPackOfflineFormToCaseTransformerTest {
+public class AosOffline2YrSepFormToCaseTransformerTest {
 
-    private final AosPackOfflineFormToCaseTransformer classUnderTest = new AosPackOfflineFormToCaseTransformer();
+    private final AosOffline2YrSepFormToCaseTransformer classUnderTest = new AosOffline2YrSepFormToCaseTransformer();
 
     @Test
     public void shouldNotReturnUnexpectedField() {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/BulkScanFormTransformerFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/BulkScanFormTransformerFactoryTest.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.reform.bsp.common.error.UnsupportedFormTypeException;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
-import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.AOS_PACK_OFFLINE;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.AOS_OFFLINE_2_YR_SEP;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.D8_FORM;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -26,7 +26,7 @@ public class BulkScanFormTransformerFactoryTest {
     private D8FormToCaseTransformer d8FormToCaseTransformer;
 
     @Mock
-    private AosPackOfflineFormToCaseTransformer aosPackOfflineFormToCaseTransformer;
+    private AosOffline2YrSepFormToCaseTransformer aosOffline2YrSepFormToCaseTransformer;
 
     @InjectMocks
     private BulkScanFormTransformerFactory bulkScanFormTransformerFactory;
@@ -39,7 +39,7 @@ public class BulkScanFormTransformerFactoryTest {
     @Test
     public void shouldReturnRightTransformationStrategy() {
         assertThat(bulkScanFormTransformerFactory.getTransformer(D8_FORM), is(d8FormToCaseTransformer));
-        assertThat(bulkScanFormTransformerFactory.getTransformer(AOS_PACK_OFFLINE), is(aosPackOfflineFormToCaseTransformer));
+        assertThat(bulkScanFormTransformerFactory.getTransformer(AOS_OFFLINE_2_YR_SEP), is(aosOffline2YrSepFormToCaseTransformer));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosOffline2yrSepCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosOffline2yrSepCaseValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bsp.common.model.validation.in.OcrDataField;
 import uk.gov.hmcts.reform.bsp.common.model.validation.out.OcrValidationResult;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.validation.AosOffline2yrSepCaseValidator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,9 +17,9 @@ import static org.junit.Assert.assertThat;
 import static uk.gov.hmcts.reform.bsp.common.model.validation.out.ValidationStatus.SUCCESS;
 import static uk.gov.hmcts.reform.bsp.common.model.validation.out.ValidationStatus.WARNINGS;
 
-public class AosPackOfflineCaseValidatorTest {
+public class AosOffline2yrSepCaseValidatorTest {
 
-    private final AosPackOfflineCaseValidator classUnderTest = new AosPackOfflineCaseValidator();
+    private final AosOffline2yrSepCaseValidator classUnderTest = new AosOffline2yrSepCaseValidator();
     private List<OcrDataField> listOfAllMandatoryFields;
 
     @Before

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/BulkScanFormValidatorFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/BulkScanFormValidatorFactoryTest.java
@@ -25,7 +25,7 @@ public class BulkScanFormValidatorFactoryTest {
     private D8FormValidator d8FormValidator;
 
     @Mock
-    private AosPackOfflineCaseValidator aosPackOfflineCaseValidator;
+    private AosOffline2yrSepCaseValidator aosOffline2yrSepCaseValidator;
 
     @InjectMocks
     private BulkScanFormValidatorFactory classUnderTest;
@@ -44,11 +44,11 @@ public class BulkScanFormValidatorFactoryTest {
     }
 
     @Test
-    public void shouldReturnValidatorForAosPackOfflineForm() {
-        BulkScanFormValidator validator = classUnderTest.getValidator("aosPackOffline");
+    public void shouldReturnValidatorForAosOffline2YearSeparationForm() {
+        BulkScanFormValidator validator = classUnderTest.getValidator("aosPackOffline2YearSeparation");
 
-        assertThat(validator, is(instanceOf(AosPackOfflineCaseValidator.class)));
-        assertThat(validator, is(aosPackOfflineCaseValidator));
+        assertThat(validator, is(instanceOf(AosOffline2yrSepCaseValidator.class)));
+        assertThat(validator, is(aosOffline2yrSepCaseValidator));
     }
 
     @Test

--- a/src/test/resources/jsonExamples/payloads/bulk/scan/aos/2yearSeparation/aosOffline2yrSep.json
+++ b/src/test/resources/jsonExamples/payloads/bulk/scan/aos/2yearSeparation/aosOffline2yrSep.json
@@ -2,7 +2,7 @@
   "case_type_id": "DIVORCE",
   "id": "LV481297",
   "po_box": "PO 17",
-  "form_type": "aosPackOffline",
+  "form_type": "aosPackOffline2YearSeparation",
   "ocr_data_fields": [
     { "name": "CaseNumber", "value": "1234123412341234" },
     { "name": "AOSReasonForDivorce", "value": "2 years separation with consent" },

--- a/src/test/resources/jsonExamples/payloads/bulk/scan/aos/2yearSeparation/invalidAosOffline2yrSep.json
+++ b/src/test/resources/jsonExamples/payloads/bulk/scan/aos/2yearSeparation/invalidAosOffline2yrSep.json
@@ -2,7 +2,7 @@
   "case_type_id": "DIVORCE",
   "id": "LV481297",
   "po_box": "PO 17",
-  "form_type": "aosPackOffline",
+  "form_type": "aosPackOffline2YearSeparation",
   "ocr_data_fields": [
     { "name": "CaseNumber", "value": "1234123412341234" },
     { "name": "AOSReasonForDivorce", "value": "2 years separation with consent" },

--- a/src/test/resources/jsonExamples/payloads/bulk/scan/aos/5yearSeparation/aosOffline5yrSep.json
+++ b/src/test/resources/jsonExamples/payloads/bulk/scan/aos/5yearSeparation/aosOffline5yrSep.json
@@ -1,0 +1,42 @@
+{"exception_record": {
+  "case_type_id": "DIVORCE",
+  "id": "LV481297",
+  "po_box": "PO 17",
+  "form_type": "aosPackOffline5YearSeparation",
+  "ocr_data_fields": [
+    { "name": "CaseNumber", "value": "1234123412341234" },
+    { "name": "AOSReasonForDivorce", "value": "5 years separation with consent" },
+    { "name": "RespAOS2yrConsent", "value": "Yes" },
+    { "name": "RespConfirmReadPetition", "value": "Yes" },
+    { "name": "DateRespReceivedDivorceApplication", "value": "10102019" },
+    { "name": "RespAdmitOrConsentToFact", "value": "No" },
+    { "name": "RespWillDefendDivorce", "value": "Proceed" },
+    { "name": "RespJurisdictionAgree", "value": "No" },
+    { "name": "RespJurisdictionDisagreeReason", "value": "Some Jurisdiction disagree reason" },
+    { "name": "RespJurisdictionRespCountryOfResidence", "value": "UK" },
+    { "name": "RespLegalProceedingsExist", "value": "Yes" },
+    { "name": "RespLegalProceedingsDescription", "value": "Some Description" },
+    { "name": "RespAgreeToCosts", "value": "No" },
+    { "name": "RespCostsReason", "value": "1234123412341234" },
+    { "name": "RespEmailAddress", "value": "est@somemail.com" },
+    { "name": "RespPhoneNumber", "value": "1234123412341234" },
+    { "name": "RespStatementOfTruth", "value": "Yes" },
+    { "name": "RespConsentToEmail", "value": "No" },
+    { "name": "RespConsiderFinancialSituation", "value": "No" },
+    { "name": "RespHardshipDefenseResponse", "value": "No" },
+    { "name": "RespHardshipDescription", "value": "Some Hardship Description goes here" }
+  ]
+},
+  "case_details": {
+    "id": "1517833758870511",
+    "jurisdiction": "DIVORCE",
+    "state": "AosSubmitted",
+    "case_type_id": "DIVORCE",
+    "case_data": {
+      "D8RespondentFirstName": "Jane",
+      "D8RespondentLastName": "Jamed",
+      "D8PetitionerFirstName": "Gary",
+      "D8PetitionerLastName": "Smith"
+    }
+  }
+}

--- a/src/test/resources/jsonExamples/payloads/bulk/scan/aos/5yearSeparation/invalidAosOffline5yrSep.json
+++ b/src/test/resources/jsonExamples/payloads/bulk/scan/aos/5yearSeparation/invalidAosOffline5yrSep.json
@@ -1,0 +1,41 @@
+{"exception_record": {
+  "case_type_id": "DIVORCE",
+  "id": "LV481297",
+  "po_box": "PO 17",
+  "form_type": "aosPackOffline5YearSeparation",
+  "ocr_data_fields": [
+    { "name": "CaseNumber", "value": "1234123412341234" },
+    { "name": "AOSReasonForDivorce", "value": "5 years separation with consent" },
+    { "name": "RespAOS2yrConsent", "value": "Not a valid answer to this q" },
+    { "name": "RespConfirmReadPetition", "value": "Yes" },
+    { "name": "DateRespReceivedDivorceApplication", "value": "10102019" },
+    { "name": "RespAdmitOrConsentToFact", "value": "Yes" },
+    { "name": "RespWillDefendDivorce", "value": "Proceed" },
+    { "name": "RespJurisdictionAgree", "value": "No" },
+    { "name": "RespJurisdictionDisagreeReason", "value": "Some Jurisdiction disagree reason" },
+    { "name": "RespJurisdictionRespCountryOfResidence", "value": "UK" },
+    { "name": "RespLegalProceedingsDescription", "value": "Some Description" },
+    { "name": "RespAgreeToCosts", "value": "No" },
+    { "name": "RespCostsReason", "value": "Random reason" },
+    { "name": "RespEmailAddress", "value": "est@somemail.com" },
+    { "name": "RespPhoneNumber", "value": "1234123412341234" },
+    { "name": "RespStatementOfTruth", "value": "Yes" },
+    { "name": "RespConsentToEmail", "value": "No" },
+    { "name": "RespHardshipDefenseResponse", "value": "No" },
+    { "name": "RespHardshipDescription", "value": "Some Hardship Description goes here" },
+    { "name": "RespStatementofTruthSignedDate", "value": "10th January 2020" }
+  ]
+},
+  "case_details": {
+    "id": "1517833758870511",
+    "jurisdiction": "DIVORCE",
+    "state": "AosSubmitted",
+    "case_type_id": "DIVORCE",
+    "case_data": {
+      "D8RespondentFirstName": "Jane",
+      "D8RespondentLastName": "Jamed",
+      "D8PetitionerFirstName": "Gary",
+      "D8PetitionerLastName": "Smith"
+    }
+  }
+}


### PR DESCRIPTION
Because AosPackOffline technically covers 5 forms, we've had to rename the initial AosPackOffline to 'AosOffline2YrSep' as this is the first form from AOS we handle.