### PR TITLE
Hotfix to update max http connections to 25

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/config/HttpConnectionConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/config/HttpConnectionConfiguration.java
@@ -75,7 +75,8 @@ public class HttpConnectionConfiguration {
             new ByteArrayHttpMessageConverter(),
             new StringHttpMessageConverter()));
 
-        restTemplate.setRequestFactory(getClientHttpRequestFactory(healthHttpConnectTimeout, healthHttpConnectRequestTimeout, healthHttpMaxConnections));
+        restTemplate.setRequestFactory(getClientHttpRequestFactory(healthHttpConnectTimeout, healthHttpConnectRequestTimeout,
+            healthHttpMaxConnections));
 
         return restTemplate;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -347,6 +347,7 @@ http:
     timeout: 60000
     request:
       timeout: 60000
+    max-connections: 25
 
 health:
   check:
@@ -355,6 +356,7 @@ health:
         timeout: 5000
         request:
           timeout: 5000
+        max-connections: 25
 
 documentation:
   swagger:


### PR DESCRIPTION
# Description

Updating maximum number of HTTP connections per REST template to 25. There are two REST templates, one for health check and one for other connections, so total number per COS would be 50 connections.

Default per REST template is 10. Seen quite a lot of timeout exception in PROD logs due to connection poll running out.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
