### PR TITLE
Code cleanup

### DIFF
--- a/job-scheduler/src/test/java/uk/gov/hmcts/reform/divorce/scheduler/service/CronJobSchedulerTest.java
+++ b/job-scheduler/src/test/java/uk/gov/hmcts/reform/divorce/scheduler/service/CronJobSchedulerTest.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.divorce.scheduler.config.SchedulerConfig;
 import uk.gov.hmcts.reform.divorce.scheduler.exception.JobException;
 import uk.gov.hmcts.reform.divorce.scheduler.model.Schedule;
 
+import java.util.Collections;
+
 import static java.util.Arrays.asList;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,7 +39,7 @@ public class CronJobSchedulerTest {
     public void whenReCreateScheduleIsFalse_thenDoNotCleanSchedules() {
         setEnableDelete(false);
         when(jobService.scheduleJob(any(), anyString())).thenReturn(new JobKey("name"));
-        when(schedulerConfig.getSchedules()).thenReturn(asList(Schedule.builder().enabled(true).cron("cron").build()));
+        when(schedulerConfig.getSchedules()).thenReturn(Collections.singletonList(Schedule.builder().enabled(true).cron("cron").build()));
 
         classToTest.scheduleCronJobs();
 
@@ -79,7 +81,7 @@ public class CronJobSchedulerTest {
         setEnableDelete(true);
 
         doThrow(new JobException("Error message", new Exception())).when(jobService).cleanSchedules(any());
-        when(schedulerConfig.getSchedules()).thenReturn(asList(Schedule.builder().enabled(true).cron("cron").build()));
+        when(schedulerConfig.getSchedules()).thenReturn(Collections.singletonList(Schedule.builder().enabled(true).cron("cron").build()));
 
         try {
             classToTest.scheduleCronJobs();
@@ -94,7 +96,7 @@ public class CronJobSchedulerTest {
     public void givenException_whenCreateSchedule_thenPropagateError() {
         setEnableDelete(true);
 
-        when(schedulerConfig.getSchedules()).thenReturn(asList(Schedule.builder().enabled(true).cron("cron").build()));
+        when(schedulerConfig.getSchedules()).thenReturn(Collections.singletonList(Schedule.builder().enabled(true).cron("cron").build()));
         when(jobService.scheduleJob(any(), anyString())).thenThrow(new JobException("Scheduler error", new Exception()));
 
         classToTest.scheduleCronJobs();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/RetryRule.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/RetryRule.java
@@ -9,7 +9,7 @@ import org.junit.runners.model.Statement;
 public class RetryRule implements TestRule {
     private int retryCount;
 
-    public RetryRule(int retryCount) {
+    private RetryRule(int retryCount) {
         this.retryCount = retryCount;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/bulk/scan/BulkScanIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/bulk/scan/BulkScanIntegrationTest.java
@@ -102,23 +102,21 @@ public class BulkScanIntegrationTest extends IntegrationTest {
 
     private Response validationEndpointRequest(String token, String endpointName, String formType) {
 
-        Response  response = SerenityRest.given()
+        return SerenityRest.given()
             .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
             .header(SERVICE_AUTHORISATION_HEADER, token)
             .relaxedHTTPSValidation()
             .body(validBody)
             .post(cosBaseURL + endpointName, formType);
-        return response;
     }
 
     private Response transformationAndUpdateEndpointRequest(String token, String endpointName) {
 
-        Response  response = SerenityRest.given()
+        return SerenityRest.given()
             .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
             .header(SERVICE_AUTHORISATION_HEADER, token)
             .relaxedHTTPSValidation()
             .body(validBody)
             .post(cosBaseURL + endpointName);
-        return response;
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DaAboutToBeGrantedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DaAboutToBeGrantedTest.java
@@ -20,7 +20,6 @@ public class DaAboutToBeGrantedTest extends IntegrationTest {
     @Autowired
     private CosApiClient cosApiClient;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void givenValidCaseData_whenDaAboutToBeGranted_thenReturnDaAboutToBeGrantedData() {
         CcdCallbackRequest ccdCallbackRequest = ResourceLoader.loadJsonToObject(BASE_CASE_RESPONSE, CcdCallbackRequest.class);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DaRequestedNotifyRespondentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DaRequestedNotifyRespondentTest.java
@@ -18,7 +18,6 @@ public class DaRequestedNotifyRespondentTest extends IntegrationTest {
     @Autowired
     private CosApiClient cosApiClient;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void givenValidCaseData_whenNotifyRespondentOfDARequested_thenReturnDaRequestedByApplicantData() {
         CcdCallbackRequest ccdCallbackRequest = ResourceLoader.loadJsonToObject(BASE_CASE_RESPONSE, CcdCallbackRequest.class);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnPronouncedDocumentsGeneratedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DnPronouncedDocumentsGeneratedTest.java
@@ -26,7 +26,6 @@ public class DnPronouncedDocumentsGeneratedTest extends IntegrationTest {
     @Autowired
     private CosApiClient cosApiClient;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void givenCase_whenGenerateDnPronouncedDocumentsWithNoClaimCosts_thenReturnCallbackResponseWithDecreeNisiDocument() {
         CcdCallbackRequest ccdCallbackRequest = ResourceLoader.loadJsonToObject(BULK_CASE_LINK_CCD_CALLBACK_REQUEST, CcdCallbackRequest.class);
@@ -43,7 +42,6 @@ public class DnPronouncedDocumentsGeneratedTest extends IntegrationTest {
                 hasJsonPath("$.data.D8DocumentsGenerated", hasSize(1)));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void givenCase_whenGenerateDnPronouncedDocumentsWithClaimCosts_thenReturnCallbackResponseWithDecreeNisiDocumentAndCostsOrder() {
         CcdCallbackRequest ccdCallbackRequest = ResourceLoader.loadJsonToObject(COSTS_CLAIM_CCD_CALLBACK_REQUEST, CcdCallbackRequest.class);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DocumentGeneratedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DocumentGeneratedTest.java
@@ -24,7 +24,6 @@ public class DocumentGeneratedTest extends IntegrationTest {
     @Autowired
     private CosApiClient cosApiClient;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void givenCase_whenGenerateDocumentForMiniPetition_thenReturnCallbackResponseWithMiniPetitionDocument() {
         CcdCallbackRequest ccdCallbackRequest = ResourceLoader.loadJsonToObject(CCD_CALLBACK_REQUEST, CcdCallbackRequest.class);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/EditBulkCaseListingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/EditBulkCaseListingTest.java
@@ -29,7 +29,6 @@ public class EditBulkCaseListingTest extends IntegrationTest {
     @Autowired
     private CosApiClient cosApiClient;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void whenEditBulkListingWithJudge_thenReturnUpdatedBulkData() {
         String futureDateTime = LocalDateTime.now().plusWeeks(1).format(DateTimeFormatter.ISO_DATE_TIME);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/RemoveCaseFromListingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/RemoveCaseFromListingTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMemb
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +72,7 @@ public class RemoveCaseFromListingTest extends CcdSubmissionSupport {
         waitForIndividualCasesToUpdate(createCaseWorkerUser(), caseId2);
 
         // when
-        updateCase(bulkCaseId, REMOVE_FROM_BULK_LISTED_EVENT, true, Pair.of(BULK_CASE_ACCEPTED_LIST_KEY, asList(caseLink1)));
+        updateCase(bulkCaseId, REMOVE_FROM_BULK_LISTED_EVENT, true, Pair.of(BULK_CASE_ACCEPTED_LIST_KEY, Collections.singletonList(caseLink1)));
 
         CaseDetails bulkCase = retrieveCaseForCaseworker(createCaseWorkerUser(), bulkCaseId);
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -177,14 +177,13 @@ public abstract class IntegrationTest {
 
             final String userId = idamTestSupportUtil.getUserId(authToken);
 
-            UserDetails userDetails = UserDetails.builder()
+            return UserDetails.builder()
                 .username(username)
                 .emailAddress(username)
                 .password(PASSWORD)
                 .authToken(authToken)
                 .id(userId)
                 .build();
-            return userDetails;
         }
     }
 

--- a/src/integrationTest/resources/draft/complete-case-response.json
+++ b/src/integrationTest/resources/draft/complete-case-response.json
@@ -178,6 +178,5 @@
   "marriageCanDivorce" : "true",
   "respondentContactDetailsConfidential" : "share",
   "financialOrderFor" : [ "petitioner", "children" ],
-  "petitionerConsent": "Yes",
-  "respondentContactDetailsConfidential": "share"
+  "petitionerConsent": "Yes"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/config/FeignRequestInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/config/FeignRequestInterceptor.java
@@ -23,7 +23,7 @@ public class FeignRequestInterceptor implements RequestInterceptor {
         this(RequestIdGenerator::next);
     }
 
-    public FeignRequestInterceptor(Supplier<String> nextRequestId) {
+    private FeignRequestInterceptor(Supplier<String> nextRequestId) {
         this.nextRequestId = nextRequestId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
@@ -18,14 +18,15 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.service.BulkCaseService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.CaseOrchestrationService;
 
-import java.util.Collections;
 import java.util.Map;
+
+import static java.util.Arrays.asList;
 
 @RestController
 @Slf4j
 @AllArgsConstructor
 public class BulkCaseController {
-    
+
     private final CaseOrchestrationService orchestrationService;
 
     private final BulkCaseService bulkCaseService;
@@ -44,19 +45,19 @@ public class BulkCaseController {
     @PostMapping(path = "/bulk/schedule/listing")
     @ApiOperation(value = "Callback to begin processing cases in bulk case for the court hearing")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Bulk case processing has been initiated"),
-            @ApiResponse(code = 400, message = "Bad Request")})
+        @ApiResponse(code = 200, message = "Bulk case processing has been initiated"),
+        @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> scheduleBulkCaseForHearing(
-            @RequestHeader("Authorization")
-            @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
-            @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
+        @RequestHeader("Authorization")
+        @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         CcdCallbackResponse.CcdCallbackResponseBuilder ccdCallbackResponseBuilder = CcdCallbackResponse.builder();
 
         try {
             orchestrationService.processBulkCaseScheduleForHearing(ccdCallbackRequest, authorizationToken);
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -65,17 +66,17 @@ public class BulkCaseController {
     @PostMapping(path = "/bulk/validate/listing")
     @ApiOperation(value = "Callback to validate bulk case data for listing")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Bulk case processing has been initiated"),
-            @ApiResponse(code = 400, message = "Bad Request")})
+        @ApiResponse(code = 200, message = "Bulk case processing has been initiated"),
+        @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> validateBulkCaseListingData(
-            @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         CcdCallbackResponse.CcdCallbackResponseBuilder ccdCallbackResponseBuilder = CcdCallbackResponse.builder();
 
         try {
             orchestrationService.validateBulkCaseListingData(ccdCallbackRequest.getCaseDetails().getCaseData());
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -102,7 +103,7 @@ public class BulkCaseController {
             ccdCallbackResponseBuilder.data(response);
         } catch (WorkflowException exception) {
             log.error("Error validating bulk case with BulkCaseId : {}", ccdCallbackRequest.getCaseDetails().getCaseId(), exception);
-            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -111,20 +112,20 @@ public class BulkCaseController {
     @PostMapping(path = "/bulk/pronounce/submit")
     @ApiOperation(value = "Callback to set required data on case when DN Pronounced")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Required pronouncement data has been set successfully"),
-            @ApiResponse(code = 400, message = "Bad Request")})
+        @ApiResponse(code = 200, message = "Required pronouncement data has been set successfully"),
+        @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> updateCaseDnPronounce(
-            @RequestHeader("Authorization")
-            @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
-            @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        @RequestHeader("Authorization")
+        @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
         CcdCallbackResponse.CcdCallbackResponseBuilder ccdCallbackResponseBuilder = CcdCallbackResponse.builder();
 
         try {
             ccdCallbackResponseBuilder.data(orchestrationService
-                    .updateBulkCaseDnPronounce(ccdCallbackRequest.getCaseDetails(), authorizationToken));
+                .updateBulkCaseDnPronounce(ccdCallbackRequest.getCaseDetails(), authorizationToken));
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -146,7 +147,7 @@ public class BulkCaseController {
             ccdCallbackResponseBuilder.data(orchestrationService
                 .updateBulkCaseAcceptedCases(ccdCallbackRequest.getCaseDetails(), authorizationToken));
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -167,7 +168,7 @@ public class BulkCaseController {
         try {
             ccdCallbackResponseBuilder.data(bulkCaseService.removeFromBulkListed(ccdCallbackRequest, authorizationToken));
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -189,7 +190,7 @@ public class BulkCaseController {
         try {
             orchestrationService.processCancelBulkCasePronouncement(ccdCallbackRequest, authorizationToken);
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
@@ -18,9 +18,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.service.BulkCaseService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.CaseOrchestrationService;
 
+import java.util.Collections;
 import java.util.Map;
-
-import static java.util.Arrays.asList;
 
 @RestController
 @Slf4j
@@ -57,7 +56,7 @@ public class BulkCaseController {
         try {
             orchestrationService.processBulkCaseScheduleForHearing(ccdCallbackRequest, authorizationToken);
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -76,7 +75,7 @@ public class BulkCaseController {
         try {
             orchestrationService.validateBulkCaseListingData(ccdCallbackRequest.getCaseDetails().getCaseData());
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -103,7 +102,7 @@ public class BulkCaseController {
             ccdCallbackResponseBuilder.data(response);
         } catch (WorkflowException exception) {
             log.error("Error validating bulk case with BulkCaseId : {}", ccdCallbackRequest.getCaseDetails().getCaseId(), exception);
-            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -125,7 +124,7 @@ public class BulkCaseController {
             ccdCallbackResponseBuilder.data(orchestrationService
                     .updateBulkCaseDnPronounce(ccdCallbackRequest.getCaseDetails(), authorizationToken));
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -147,7 +146,7 @@ public class BulkCaseController {
             ccdCallbackResponseBuilder.data(orchestrationService
                 .updateBulkCaseAcceptedCases(ccdCallbackRequest.getCaseDetails(), authorizationToken));
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -168,7 +167,7 @@ public class BulkCaseController {
         try {
             ccdCallbackResponseBuilder.data(bulkCaseService.removeFromBulkListed(ccdCallbackRequest, authorizationToken));
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());
@@ -190,7 +189,7 @@ public class BulkCaseController {
         try {
             orchestrationService.processCancelBulkCasePronouncement(ccdCallbackRequest, authorizationToken);
         } catch (WorkflowException exception) {
-            ccdCallbackResponseBuilder.errors(asList(exception.getMessage()));
+            ccdCallbackResponseBuilder.errors(Collections.singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(ccdCallbackResponseBuilder.build());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import javax.ws.rs.core.MediaType;
 
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.BULK_PRINT_ERROR_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_ANSWERS_LINK;
@@ -437,7 +436,7 @@ public class CallbackController {
 
         } catch (WorkflowException exception) {
             log.error("Co-respondent answer received failed. Case id:  {}", caseId, exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -555,7 +554,7 @@ public class CallbackController {
             log.info("Co-respondent answer generated. Case id: {}", caseId);
         } catch (WorkflowException exception) {
             log.error("Co-respondent answer generation failed. Case id:  {}", caseId, exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -584,7 +583,7 @@ public class CallbackController {
             log.info("Generating document {} for case {}.", documentType, caseId);
         } catch (WorkflowException exception) {
             log.error("Document generation failed. Case id:  {}", caseId, exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -761,10 +760,10 @@ public class CallbackController {
             log.info("Processed case successfully. Case id: {}", caseId);
         } catch (CaseOrchestrationServiceException exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
         } catch (Exception exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(asList(GENERIC_ERROR_MESSAGE));
+            callbackResponseBuilder.errors(singletonList(GENERIC_ERROR_MESSAGE));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -790,10 +789,10 @@ public class CallbackController {
             callbackResponseBuilder.data(caseOrchestrationService.decreeNisiDecisionState(ccdCallbackRequest));
         } catch (WorkflowException exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
         } catch (Exception exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(asList(GENERIC_ERROR_MESSAGE));
+            callbackResponseBuilder.errors(singletonList(GENERIC_ERROR_MESSAGE));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -888,7 +887,7 @@ public class CallbackController {
             log.info("Processed decree absolute grant callback request for case ID: {}", caseId);
         } catch (CaseOrchestrationServiceException exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import javax.ws.rs.core.MediaType;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.BULK_PRINT_ERROR_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESP_ANSWERS_LINK;
@@ -436,7 +437,7 @@ public class CallbackController {
 
         } catch (WorkflowException exception) {
             log.error("Co-respondent answer received failed. Case id:  {}", caseId, exception);
-            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
+            callbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -554,7 +555,7 @@ public class CallbackController {
             log.info("Co-respondent answer generated. Case id: {}", caseId);
         } catch (WorkflowException exception) {
             log.error("Co-respondent answer generation failed. Case id:  {}", caseId, exception);
-            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
+            callbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -583,7 +584,7 @@ public class CallbackController {
             log.info("Generating document {} for case {}.", documentType, caseId);
         } catch (WorkflowException exception) {
             log.error("Document generation failed. Case id:  {}", caseId, exception);
-            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
+            callbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -760,10 +761,10 @@ public class CallbackController {
             log.info("Processed case successfully. Case id: {}", caseId);
         } catch (CaseOrchestrationServiceException exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
+            callbackResponseBuilder.errors(asList(exception.getMessage()));
         } catch (Exception exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(singletonList(GENERIC_ERROR_MESSAGE));
+            callbackResponseBuilder.errors(asList(GENERIC_ERROR_MESSAGE));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -789,10 +790,10 @@ public class CallbackController {
             callbackResponseBuilder.data(caseOrchestrationService.decreeNisiDecisionState(ccdCallbackRequest));
         } catch (WorkflowException exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
+            callbackResponseBuilder.errors(asList(exception.getMessage()));
         } catch (Exception exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(singletonList(GENERIC_ERROR_MESSAGE));
+            callbackResponseBuilder.errors(asList(GENERIC_ERROR_MESSAGE));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -887,7 +888,7 @@ public class CallbackController {
             log.info("Processed decree absolute grant callback request for case ID: {}", caseId);
         } catch (CaseOrchestrationServiceException exception) {
             log.error(format(FAILED_TO_EXECUTE_SERVICE_ERROR, caseId), exception);
-            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
+            callbackResponseBuilder.errors(asList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/DecreeAbsoluteController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/DecreeAbsoluteController.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.DecreeAbsoluteService;
 
 import javax.ws.rs.core.MediaType;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 @RestController
 @Slf4j
@@ -45,7 +45,7 @@ public class DecreeAbsoluteController {
             log.info("Emailed Respondent as applicant has requested DA for case {}.", caseId);
         } catch (WorkflowException exception) {
             log.error("Respondent notification email failed to send for applicant requesting DA. Case id: {}", caseId, exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
 
         }
         return ResponseEntity.ok(callbackResponseBuilder.build());
@@ -68,7 +68,7 @@ public class DecreeAbsoluteController {
             log.info("DA request for case id {} was valid.", caseId);
         } catch (WorkflowException exception) {
             log.error("DA request for case id {} was INVALID.", caseId, exception);
-            callbackResponseBuilder.errors(asList(exception.getMessage()));
+            callbackResponseBuilder.errors(singletonList(exception.getMessage()));
         }
 
         return ResponseEntity.ok(callbackResponseBuilder.build());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/pay/CreditAccountPaymentRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/pay/CreditAccountPaymentRequest.java
@@ -47,10 +47,9 @@ public class CreditAccountPaymentRequest {
     private String organisationName;
 
     public void setAmount(String amount) {
-        String value = Optional.ofNullable(amount)
+        this.amount = Optional.ofNullable(amount)
                 .map(Double::parseDouble).map(i -> i / 100)
                 .map(String::valueOf).orElse(amount);
-        this.amount = value;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/pay/PaymentItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/pay/PaymentItem.java
@@ -37,11 +37,10 @@ public class PaymentItem {
     private String version;
 
     public void setCalculatedAmount(String calculatedAmount) {
-        String value = Optional.ofNullable(calculatedAmount)
+        this.calculatedAmount = Optional.ofNullable(calculatedAmount)
                 .map(Double::parseDouble)
                 .map(i -> i / 100).map(String::valueOf)
                 .orElse(calculatedAmount);
-        this.calculatedAmount = value;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosFormValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/AosFormValidator.java
@@ -84,7 +84,7 @@ public abstract class AosFormValidator extends BulkScanFormValidator {
         return (respJurisdictionAgreeField.equals(NO_VALUE) && StringUtils.isEmpty(respJurisdictionDisagreeReasonField));
     }
 
-    private final List<String> validateRespLegalProceedingsDescription(Map<String, String> fieldsMap) {
+    private List<String> validateRespLegalProceedingsDescription(Map<String, String> fieldsMap) {
         List<String> validationWarningMessages = new ArrayList<>();
 
         String respLegalProceedingsExistField = fieldsMap.getOrDefault("RespLegalProceedingsExist", "");

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CoRespondentLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CoRespondentLetterGenerator.java
@@ -38,7 +38,6 @@ public class CoRespondentLetterGenerator implements Task<Map<String, Object>> {
     }
 
     @Override
-    @SuppressWarnings("Duplicates")
     public Map<String, Object> execute(final TaskContext context, final Map<String, Object> caseData) {
         final CaseDetails caseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DnSubmittedEmailNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/DnSubmittedEmailNotificationTask.java
@@ -55,8 +55,8 @@ public class DnSubmittedEmailNotificationTask implements Task<Map<String, Object
         String caseId = context.getTransientObject(CASE_ID_JSON_KEY);
 
         Map<String, String> notificationTemplateVars = new HashMap<>();
-        String template = null;
-        String emailToBeSentTo = null;
+        String template;
+        String emailToBeSentTo;
 
         if (StringUtils.isNotBlank(petSolicitorEmail)) {
             String respFirstName = Objects.toString(data.get(RESP_FIRST_NAME_CCD_FIELD), null);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/ProcessPbaPayment.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/ProcessPbaPayment.java
@@ -51,7 +51,6 @@ public class ProcessPbaPayment implements Task<Map<String, Object>> {
         this.objectMapper = objectMapper;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {
         try {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentAnswersGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentAnswersGenerator.java
@@ -17,7 +17,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_RESPONDENT_ANSWERS;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_RESPONDENT_ANSWERS;
 
 @Component
 public class RespondentAnswersGenerator implements Task<Map<String, Object>> {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentLetterGenerator.java
@@ -33,7 +33,6 @@ public class RespondentLetterGenerator implements Task<Map<String, Object>> {
     }
 
     @Override
-    @SuppressWarnings("Duplicates")
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
         CaseDetails caseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaGrantedNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendDaGrantedNotificationEmail.java
@@ -140,8 +140,8 @@ public class SendDaGrantedNotificationEmail implements Task<Map<String, Object>>
         }
     }
 
-    public void sendEmail(String firstName, String lastName, String emailAddress,
-                          Map<String, Object> caseData, String ccdReference) throws NotificationClientException  {
+    private void sendEmail(String firstName, String lastName, String emailAddress,
+                           Map<String, Object> caseData, String ccdReference) throws NotificationClientException  {
 
         String daGrantedDataCcdField = (String) caseData.get(DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD);
         LocalDate daGrantedDate = LocalDateTime.parse(daGrantedDataCcdField).toLocalDate();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerCertificateOfEntitlementNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerCertificateOfEntitlementNotificationEmail.java
@@ -68,8 +68,8 @@ public class SendPetitionerCertificateOfEntitlementNotificationEmail implements 
         String petitionerFirstName = getMandatoryPropertyValueAsString(payload, D_8_PETITIONER_FIRST_NAME);
         String petitionerLastName = getMandatoryPropertyValueAsString(payload, D_8_PETITIONER_LAST_NAME);
         String courtName = getMandatoryPropertyValueAsString(payload, COURT_NAME_CCD_FIELD);
-        EmailTemplateNames template = null;
-        String emailToBeSentTo = null;
+        EmailTemplateNames template;
+        String emailToBeSentTo;
 
         LocalDate dateOfHearing = CaseDataUtils.getLatestCourtHearingDateFromCaseData(payload);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerClarificationRequestEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerClarificationRequestEmail.java
@@ -66,7 +66,7 @@ public class SendPetitionerClarificationRequestEmail implements Task<Map<String,
             String respLastName = getMandatoryPropertyValueAsString(caseData, RESP_LAST_NAME_CCD_FIELD);
             String solicitorName = getMandatoryPropertyValueAsString(caseData, PET_SOL_NAME);
 
-            templateVars.put(NOTIFICATION_CCD_REFERENCE_KEY, (String) context.getTransientObject(CASE_ID_JSON_KEY));
+            templateVars.put(NOTIFICATION_CCD_REFERENCE_KEY, context.getTransientObject(CASE_ID_JSON_KEY));
             templateVars.put(NOTIFICATION_EMAIL, petSolicitorEmail);
             templateVars.put(NOTIFICATION_PET_NAME, petitionerFirstName + " " + petitionerLastName);
             templateVars.put(NOTIFICATION_RESP_NAME, respFirstName + " " + respLastName);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerUpdateNotificationsEmail.java
@@ -49,20 +49,20 @@ import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.get
 @Slf4j
 public class SendPetitionerUpdateNotificationsEmail implements Task<Map<String, Object>> {
 
-    public static final String GENERIC_UPDATE_EMAIL_DESC = "Generic Update Notification - Petitioner";
-    public static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_EMAIL_DESC =
+    private static final String GENERIC_UPDATE_EMAIL_DESC = "Generic Update Notification - Petitioner";
+    private static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_EMAIL_DESC =
         "Resp does not admit adultery update notification";
-    public static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED_EMAIL_DESC =
+    private static final String AOS_RECEIVED_NO_ADMIT_ADULTERY_CORESP_NOT_REPLIED_EMAIL_DESC =
         "Resp does not admit adultery update notification - no reply from co-resp";
-    public static final String AOS_RECEIVED_NO_CONSENT_2_YEARS_EMAIL_DESC =
+    private static final String AOS_RECEIVED_NO_CONSENT_2_YEARS_EMAIL_DESC =
         "Resp does not consent to 2 year separation update notification";
-    public static final String SOL_APPLICANT_AOS_RECEIVED_EMAIL_DESC =
+    private static final String SOL_APPLICANT_AOS_RECEIVED_EMAIL_DESC =
         "Resp response submission notification sent to solicitor";
-    public static final String SOL_APPLICANT_AOS_NOT_RECEIVED_EMAIL_DESC =
+    private static final String SOL_APPLICANT_AOS_NOT_RECEIVED_EMAIL_DESC =
         "Resp has not responded - notification sent to solicitor";
-    public static final String APPLICANT_AOS_NOT_RECEIVED_EMAIL_DESC =
+    private static final String APPLICANT_AOS_NOT_RECEIVED_EMAIL_DESC =
         "Resp has not responded - notification sent to petitioner";
-    public static final String SOL_GENERIC_UPDATE_EMAIL_DESC =
+    private static final String SOL_GENERIC_UPDATE_EMAIL_DESC =
         "Generic Update Notification - Petitioner solicitor";
 
     private static final String RESP_ANSWER_RECVD_EVENT = "answerReceived";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentCertificateOfEntitlementNotificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendRespondentCertificateOfEntitlementNotificationEmail.java
@@ -74,8 +74,8 @@ public class SendRespondentCertificateOfEntitlementNotificationEmail implements 
         LocalDate limitDateToContactCourt = dateOfHearing.minus(PERIOD_BEFORE_HEARING_DATE_TO_CONTACT_COURT);
 
         Map<String, String> templateParameters = new HashMap<>();
-        EmailTemplateNames template = null;
-        String emailToBeSentTo = null;
+        EmailTemplateNames template;
+        String emailToBeSentTo;
 
         templateParameters.put(DATE_OF_HEARING, formatDateWithCustomerFacingFormat(dateOfHearing));
         templateParameters.put(LIMIT_DATE_TO_CONTACT_COURT,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetSeparationFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetSeparationFields.java
@@ -33,10 +33,10 @@ public class SetSeparationFields implements Task<Map<String, Object>> {
     @Autowired
     private Clock clock;
 
-    public static final Integer TWO = 2;
-    public static final Integer FIVE = 5;
-    public static final Integer SIX = 6;
-    public static final Integer SEVEN = 7;
+    private static final Integer TWO = 2;
+    private static final Integer FIVE = 5;
+    private static final Integer SIX = 6;
+    private static final Integer SEVEN = 7;
     public static final String FACT_CANT_USE = "Based on the given date, the selected fact cannot be used for this divorce application";
 
     @Override
@@ -139,7 +139,7 @@ public class SetSeparationFields implements Task<Map<String, Object>> {
         Long timeTogetherWeeks = getLivingTogetherWeeks(caseData);
         Long timeTogetherDays = getLivingTogetherDays(caseData) % SEVEN;
 
-        StringBuilder permittedSepTime = new StringBuilder("");
+        StringBuilder permittedSepTime = new StringBuilder();
         if (timeTogetherMonths >= SIX) {
             permittedSepTime.append("6 months");
             return permittedSepTime.toString();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/ValidateSolicitorCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/ValidateSolicitorCaseData.java
@@ -13,7 +13,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @Component
 public class ValidateSolicitorCaseData implements Task<Map<String, Object>> {
 
-    @SuppressWarnings("unchecked")
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CMSElasticSearchSupport.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CMSElasticSearchSupport.java
@@ -27,7 +27,7 @@ public class CMSElasticSearchSupport {
         return searchCMSCases(start, pageSize, 0, authToken, builders);
     }
 
-    public Stream<CaseDetails> searchCMSCases(int start, int pageSize, int pagesReturned, String authToken, QueryBuilder... builders) {
+    private Stream<CaseDetails> searchCMSCases(int start, int pageSize, int pagesReturned, String authToken, QueryBuilder... builders) {
         SearchResult finalResult = SearchResult.builder()
             .total(0)
             .cases(new ArrayList<>())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
@@ -74,14 +74,12 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
             tasksToRun.add(populateDocLink);
         }
 
-        Map<String, Object> payloadToReturn = this.execute(
+        return this.execute(
                 tasksToRun.stream().toArray(Task[]::new),
                 caseData,
                 ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
                 ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails)
         );
-
-        return payloadToReturn;
     }
 
     private boolean isDNApproval(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
@@ -74,12 +74,14 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
             tasksToRun.add(populateDocLink);
         }
 
-        return this.execute(
+        Map<String, Object> payloadToReturn = this.execute(
                 tasksToRun.stream().toArray(Task[]::new),
                 caseData,
                 ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
                 ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails)
         );
+
+        return payloadToReturn;
     }
 
     private boolean isDNApproval(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiDecisionStateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiDecisionStateWorkflow.java
@@ -21,15 +21,13 @@ public class DecreeNisiDecisionStateWorkflow extends DefaultWorkflow<Map<String,
 
     public Map<String, Object> run(CaseDetails caseDetails) throws WorkflowException {
 
-        Map<String, Object> payloadToReturn = this.execute(
+        return this.execute(
             new Task[]{
                 setDNDecisionStateTask
             },
             caseDetails.getCaseData(),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseDetails.getCaseId())
             );
-
-        return payloadToReturn;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssueEventWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssueEventWorkflow.java
@@ -107,7 +107,7 @@ public class IssueEventWorkflow extends DefaultWorkflow<Map<String, Object>> {
         tasks.add(resetCoRespondentLinkingFields);
 
         return this.execute(
-            tasks.toArray(new Task[tasks.size()]),
+            tasks.toArray(new Task[0]),
             caseData,
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails)
@@ -121,7 +121,6 @@ public class IssueEventWorkflow extends DefaultWorkflow<Map<String, Object>> {
             || CourtEnum.SERVICE_CENTER.getId().equalsIgnoreCase(court);
     }
 
-    @SuppressWarnings("Duplicates")
     private boolean isAdulteryCaseWithCoRespondent(final Map<String, Object> caseData) {
         final String divorceReason = String.valueOf(caseData.getOrDefault(D_8_REASON_FOR_DIVORCE, EMPTY));
         final String coRespondentNamed = String.valueOf(caseData.getOrDefault(D_8_CO_RESPONDENT_NAMED, EMPTY));

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/RemoveBulkCaseLinkWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/RemoveBulkCaseLinkWorkflow.java
@@ -21,8 +21,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @AllArgsConstructor
 public class RemoveBulkCaseLinkWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
-    static final String UN_LINK_BULK_CASE_EVENT = "unlinkBulkCaseReference";
-
+    private static final String UN_LINK_BULK_CASE_EVENT = "unlinkBulkCaseReference";
     private final UpdateCaseInCCD updateCaseInCCD;
     private final GetCaseWithIdTask getCaseWithId;
     private final ValidatedCaseLinkTask validateBulkCaseLinkTask;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendClarificationSubmittedNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendClarificationSubmittedNotificationWorkflow.java
@@ -30,7 +30,7 @@ public class SendClarificationSubmittedNotificationWorkflow extends DefaultWorkf
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
 
         return this.execute(
-            tasks.toArray(new Task[tasks.size()]),
+            tasks.toArray(new Task[0]),
             ccdCallbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
         );

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendClarificationSubmittedNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendClarificationSubmittedNotificationWorkflow.java
@@ -30,7 +30,7 @@ public class SendClarificationSubmittedNotificationWorkflow extends DefaultWorkf
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
 
         return this.execute(
-            tasks.toArray(new Task[0]),
+            tasks.toArray(new Task[tasks.size()]),
             ccdCallbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
         );

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflow.java
@@ -46,7 +46,7 @@ public class SendDnPronouncedNotificationWorkflow extends DefaultWorkflow<Map<St
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
 
         return this.execute(
-            tasks.toArray(new Task[tasks.size()]),
+            tasks.toArray(new Task[0]),
             ccdCallbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
         );

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/courtallocation/EnumeratedDistributionExplorationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/courtallocation/EnumeratedDistributionExplorationTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -17,7 +17,7 @@ public class EnumeratedDistributionExplorationTest {
     @Test
     public void testUnallocatedPercentageBehaviour_ShouldNeverReturnNull() {
         EnumeratedDistribution<String> enumeratedDistribution =
-            new EnumeratedDistribution<>(asList(new Pair("test", 0.5)));
+            new EnumeratedDistribution<>(singletonList(new Pair("test", 0.5)));
 
         Map<String, Integer> courtAllocation = new HashMap<>();
         for (int i = 0; i < 1000000; i++) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/framework/workflow/RetryableBulkCaseWorkflowTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.BulkWorkflowExecutionResult;
 import uk.gov.hmcts.reform.divorce.orchestration.exception.BulkUpdateException;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
@@ -109,7 +110,7 @@ public class RetryableBulkCaseWorkflowTest {
 
         verify(retryableBulkCaseWorkflow, times(MAX_RETRIES)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
-        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, Collections.singletonList(caseData1));
     }
 
     @Test
@@ -129,7 +130,7 @@ public class RetryableBulkCaseWorkflowTest {
 
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
-        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, Collections.singletonList(caseData1));
     }
 
     @Test
@@ -149,7 +150,7 @@ public class RetryableBulkCaseWorkflowTest {
 
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
-        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, Collections.singletonList(caseData1));
     }
 
     @Test
@@ -215,7 +216,7 @@ public class RetryableBulkCaseWorkflowTest {
 
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
-        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, Collections.singletonList(caseData1));
     }
 
     @Test
@@ -238,7 +239,7 @@ public class RetryableBulkCaseWorkflowTest {
 
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
-        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, Collections.singletonList(caseData1));
     }
 
     @Test
@@ -261,7 +262,7 @@ public class RetryableBulkCaseWorkflowTest {
 
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_1, AUTH_TOKEN);
         verify(retryableBulkCaseWorkflow, times(1)).run(caseDetail, TEST_CASE_ID_2, AUTH_TOKEN);
-        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, asList(caseData1));
+        verify(retryableBulkCaseWorkflow,times(1)).notifyFailedCases(TEST_CASE_ID, Collections.singletonList(caseData1));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/AosOverdueNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/AosOverdueNotificationTest.java
@@ -17,10 +17,10 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackReq
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.service.notify.NotificationClientException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
@@ -130,7 +130,7 @@ public class AosOverdueNotificationTest extends MockedFunctionalTest {
         setUpEmailClientMockThrowsExceptionWith(templateName, testTemplateVars);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder()
-                .data(testData).errors(asList("test exception")).build();
+                .data(testData).errors(Collections.singletonList("test exception")).build();
         expect(status().isOk(), expectedResponse);
         verifySendEmailIsCalledWithUserDataAnd(templateName);
     }
@@ -143,7 +143,7 @@ public class AosOverdueNotificationTest extends MockedFunctionalTest {
         setUpEmailClientMockThrowsExceptionWith(templateName, testTemplateVars);
 
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder()
-                .data(testData).errors(asList("test exception")).build();
+                .data(testData).errors(Collections.singletonList("test exception")).build();
         expect(status().isOk(), expectedResponse);
         verifySendEmailIsCalledWithUserDataAnd(templateName);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/AuthenticateRespondentITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/AuthenticateRespondentITest.java
@@ -62,7 +62,7 @@ public class AuthenticateRespondentITest extends IdamTestSupport {
     @Test
     public void givenUserDoesNotHaveLetterHolderRole_whenAuthenticateRespondent_thenReturnUnauthorized()
         throws Exception {
-        final String userDetailsResponse = getUserDetailsResponse(Arrays.asList("letter-loa1"));
+        final String userDetailsResponse = getUserDetailsResponse(Collections.singletonList("letter-loa1"));
 
         stubUserDetailsEndpoint(HttpStatus.OK, BEARER_AUTH_TOKEN, userDetailsResponse);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CalculateSeparationFieldsITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/CalculateSeparationFieldsITest.java
@@ -45,8 +45,7 @@ public class CalculateSeparationFieldsITest extends MockedFunctionalTest {
             D_8_MENTAL_SEP_DATE, pastDate5Yrs8Mnths,
             D_8_PHYSICAL_SEP_DAIE, pastDate5Yrs9Mnths);
 
-        Map<String, Object> expectedData = new HashMap<>();
-        expectedData.putAll(testCaseData);
+        Map<String, Object> expectedData = new HashMap<>(testCaseData);
         expectedData.put(D_8_SEP_TIME_TOGETHER_PERMITTED, "6 months");
         expectedData.put(D_8_REASON_FOR_DIVORCE_SEP_DATE, pastDate5Yrs8Mnths);
         expectedData.put(D_8_SEP_REF_DATE, pastDate5Yrs6Mnths);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DaAboutToBeGrantedDocumentsGeneration.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DaAboutToBeGrantedDocumentsGeneration.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static java.time.ZoneOffset.UTC;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -125,7 +125,7 @@ public class DaAboutToBeGrantedDocumentsGeneration extends MockedFunctionalTest 
 
         final DocumentUpdateRequest daDocumentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(daDocumentGenerationResponse))
+                .documents(singletonList(daDocumentGenerationResponse))
                 .caseData(CASE_DATA)
                 .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeAbsoluteRequestedRespondentNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeAbsoluteRequestedRespondentNotificationTest.java
@@ -14,7 +14,7 @@ import uk.gov.service.notify.NotificationClientException;
 
 import java.util.Map;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -97,7 +97,7 @@ public class DecreeAbsoluteRequestedRespondentNotificationTest extends MockedFun
 
         String inputJson = JSONObject.valueToString(CASE_DETAILS);
         CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder()
-            .errors(asList("test exception")).build();
+            .errors(singletonList("test exception")).build();
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DecreeNisiAboutToBeGrantedTest.java
@@ -35,7 +35,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static java.time.ZoneOffset.UTC;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.Matchers.allOf;
@@ -231,7 +231,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(documentGenerationResponse))
+                .documents(singletonList(documentGenerationResponse))
                 .caseData(dataInput)
                 .build();
 
@@ -308,12 +308,12 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(documentGenerationResponse))
+                .documents(singletonList(documentGenerationResponse))
                 .caseData(inputData)
                 .build();
 
         expectedCfsResponse.putAll(inputData.entrySet().stream()
-            .filter(x -> x.getKey() != "D8DocumentsGenerated")
+            .filter(x -> !x.getKey().equals("D8DocumentsGenerated"))
             .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue())));
 
         stubGetFeeFromFeesAndPayments(HttpStatus.OK, FeeResponse.builder().amount(TEST_FEE_AMOUNT).build());
@@ -419,7 +419,7 @@ public class DecreeNisiAboutToBeGrantedTest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(documentGenerationResponse))
+                .documents(singletonList(documentGenerationResponse))
                 .caseData(expectedRequestData)
                 .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DnPronouncedDocumentsGenerationITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DnPronouncedDocumentsGenerationITest.java
@@ -20,8 +20,8 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -145,13 +145,13 @@ public class DnPronouncedDocumentsGenerationITest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest dnDocumentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(dnDocumentGenerationResponse))
+                .documents(singletonList(dnDocumentGenerationResponse))
                 .caseData(CASE_DATA)
                 .build();
 
         final DocumentUpdateRequest costsOrderDocumentUpdateRequest =
                 DocumentUpdateRequest.builder()
-                        .documents(asList(costsOrderDocumentGenerationResponse))
+                        .documents(singletonList(costsOrderDocumentGenerationResponse))
                         .caseData(CASE_DATA)
                         .build();
 
@@ -204,7 +204,7 @@ public class DnPronouncedDocumentsGenerationITest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest dnDocumentUpdateRequest =
                 DocumentUpdateRequest.builder()
-                        .documents(asList(dnDocumentGenerationResponse))
+                        .documents(singletonList(dnDocumentGenerationResponse))
                         .caseData(caseData)
                         .build();
 
@@ -257,7 +257,7 @@ public class DnPronouncedDocumentsGenerationITest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest dnDocumentUpdateRequest =
                 DocumentUpdateRequest.builder()
-                        .documents(asList(dnDocumentGenerationResponse))
+                        .documents(singletonList(dnDocumentGenerationResponse))
                         .caseData(caseData)
                         .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DocumentGenerationITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DocumentGenerationITest.java
@@ -18,8 +18,8 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -129,7 +129,7 @@ public class DocumentGenerationITest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(documentGenerationResponse))
+                .documents(singletonList(documentGenerationResponse))
                 .caseData(CASE_DATA)
                 .build();
 
@@ -181,7 +181,7 @@ public class DocumentGenerationITest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest documentUpdateRequest =
                 DocumentUpdateRequest.builder()
-                        .documents(asList(documentGenerationResponse))
+                        .documents(singletonList(documentGenerationResponse))
                         .caseData(caseData)
                         .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/EditBulkCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/EditBulkCaseITest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static java.time.ZoneOffset.UTC;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.Mockito.when;
@@ -100,7 +100,7 @@ public class EditBulkCaseITest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(documentGenerationResponse))
+                .documents(singletonList(documentGenerationResponse))
                 .caseData(caseData)
                 .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/GenerateCoRespondentAnswersITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/GenerateCoRespondentAnswersITest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -70,7 +70,7 @@ public class GenerateCoRespondentAnswersITest extends MockedFunctionalTest {
 
         final DocumentUpdateRequest documentUpdateRequest =
                 DocumentUpdateRequest.builder()
-                        .documents(asList(generatedCoRespondentAnswersResponse))
+                        .documents(singletonList(generatedCoRespondentAnswersResponse))
                         .caseData(ccdCallbackRequest.getCaseDetails().getCaseData())
                         .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeCasesDAOverdueITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeCasesDAOverdueITest.java
@@ -14,7 +14,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.SearchResult;
 import uk.gov.hmcts.reform.divorce.orchestration.service.SearchSourceFactory;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,13 +54,10 @@ public class MakeCasesDAOverdueITest extends MockedFunctionalTest {
     private SearchResult searchResult;
     private List<String> caseIds = new ArrayList<>();
     private List<CaseDetails> cases = new ArrayList<>();
-    String expectedRequestBody;
+    private String expectedRequestBody;
 
     @Autowired
     private MockMvc webClient;
-
-    @Autowired
-    private CcdUtil ccdUtil;
 
     @Before
     public void setup() {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PetitionIssuedITest.java
@@ -36,6 +36,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -254,7 +255,7 @@ public class PetitionIssuedITest extends IdamTestSupport {
 
         final DocumentUpdateRequest documentUpdateRequest =
             DocumentUpdateRequest.builder()
-                .documents(asList(generatedMiniPetitionResponse))
+                .documents(singletonList(generatedMiniPetitionResponse))
                 .caseData(CASE_DATA)
                 .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessBulkCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessBulkCaseITest.java
@@ -168,7 +168,7 @@ public class ProcessBulkCaseITest extends IdamTestSupport {
     @Test
     public void givenSearchWithoutMinimumCases_whenCreateBulkCase_thenBulkCasesIsNotCreated() throws Exception {
         SearchResult result = SearchResult.builder()
-            .cases(Arrays.asList(prepareBulkCase()))
+            .cases(Collections.singletonList(prepareBulkCase()))
             .total(1)
             .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitCoRespondentAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SubmitCoRespondentAosCaseITest.java
@@ -152,8 +152,7 @@ public class SubmitCoRespondentAosCaseITest extends MockedFunctionalTest {
 
     @Test
     public void dueDateIsRecalculatedWhenCoRespondentIsDefending() throws Exception {
-        final Map<String, Object> originalSubmissionData = new HashMap<>();
-        originalSubmissionData.putAll(getCoRespondentSubmitData());
+        final Map<String, Object> originalSubmissionData = new HashMap<>(getCoRespondentSubmitData());
         originalSubmissionData.put(CO_RESPONDENT_DEFENDS_DIVORCE, "YES");
         originalSubmissionData.put(CO_RESPONDENT_DUE_DATE, "01-01-2001");
 
@@ -164,8 +163,7 @@ public class SubmitCoRespondentAosCaseITest extends MockedFunctionalTest {
         final CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).state(AOS_AWAITING).build();
         stubMaintenanceServerEndpointForAosRetrieval(OK, convertObjectToJsonString(caseDetails));
 
-        final Map<String, Object> recalculatedSubmissionData = new HashMap<>();
-        recalculatedSubmissionData.putAll(getCoRespondentSubmitData());
+        final Map<String, Object> recalculatedSubmissionData = new HashMap<>(getCoRespondentSubmitData());
         recalculatedSubmissionData.put(CO_RESPONDENT_DEFENDS_DIVORCE, "YES");
         recalculatedSubmissionData.put(CO_RESPONDENT_DUE_DATE, today.plusDays(21).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
         stubMaintenanceServerEndpointForAosUpdate(OK, recalculatedSubmissionData, caseDataString);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManTest.java
@@ -41,6 +41,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 
 /**
  * This test uses the service (just like the scheduled job will).
@@ -52,7 +53,6 @@ public class DataExtractionToFamilyManTest extends MockedFunctionalTest {
     private static final String DN_DESIRED_STATES = "[\"dnisrefused\", \"dnpronounced\"]";
 
     private static final DateTimeFormatter FILE_NAME_DATE_FORMAT = ofPattern("ddMMyyyy000000");
-    protected static final String TEST_AUTH_TOKEN = "testAuthToken";
 
     private String yesterday;
 
@@ -72,7 +72,7 @@ public class DataExtractionToFamilyManTest extends MockedFunctionalTest {
     public void setUp() {
         maintenanceServiceServer.resetAll();
 
-        when(authUtil.getCaseworkerToken()).thenReturn(TEST_AUTH_TOKEN);
+        when(authUtil.getCaseworkerToken()).thenReturn(AUTH_TOKEN);
         yesterday = LocalDate.now().minusDays(1).format(FILE_NAME_DATE_FORMAT);
 
         //Mock CMS to return a case like Elastic search will
@@ -181,7 +181,7 @@ public class DataExtractionToFamilyManTest extends MockedFunctionalTest {
 
     private void stubJsonResponse(String desiredStates, String caseData) {
         maintenanceServiceServer.stubFor(WireMock.post("/casemaintenance/version/1/search")
-            .withHeader("Authorization", equalTo(TEST_AUTH_TOKEN))
+            .withHeader("Authorization", equalTo(AUTH_TOKEN))
             .withRequestBody(matchingJsonPath("$.query.bool.filter[*].terms.state[*]",
                 equalToJson(desiredStates, true, false)))
             .willReturn(okJson(caseData))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/D8FormValidatorTest.java
@@ -28,9 +28,9 @@ import static uk.gov.hmcts.reform.bsp.common.model.validation.out.ValidationStat
 
 public class D8FormValidatorTest {
 
-    public static final String INVALID_POSTCODE = "SW15 5PUX";
-    public static final String INVALID_EMAIL = "nece28ssito@no.";
-    public static final String NOT_YES_OR_NO = "Tomato";
+    private static final String INVALID_POSTCODE = "SW15 5PUX";
+    private static final String INVALID_EMAIL = "nece28ssito@no.";
+    private static final String NOT_YES_OR_NO = "Tomato";
 
     private final D8FormValidator classUnderTest = new D8FormValidator();
     private List<OcrDataField> mandatoryFieldsWithValues;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/BulkCaseServiceImplTest.java
@@ -152,7 +152,7 @@ public class BulkCaseServiceImplTest {
 
         BulkWorkflowExecutionResult result = BulkWorkflowExecutionResult.builder()
                 .successStatus(true)
-                .failedCases(Arrays.asList(caseDataOne))
+                .failedCases(Collections.singletonList(caseDataOne))
                 .removableCaseIds(ImmutableSet.of(TEST_CASE_ID_ONE))
                 .build();
         when(linkBulkCaseWorkflow.executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN)).thenReturn(result);
@@ -161,8 +161,8 @@ public class BulkCaseServiceImplTest {
         classToTest.handleBulkCaseCreateEvent(event);
 
         Map<String, Object> expectedUpdatePayload = ImmutableMap.of(
-                CASE_LIST_KEY, Arrays.asList(Collections.singletonMap(VALUE_KEY, caseDataTwo)),
-                BULK_CASE_ACCEPTED_LIST_KEY, Arrays.asList(Collections.singletonMap(VALUE_KEY, caseReferenceTwo))
+                CASE_LIST_KEY, Collections.singletonList(Collections.singletonMap(VALUE_KEY, caseDataTwo)),
+                BULK_CASE_ACCEPTED_LIST_KEY, Collections.singletonList(Collections.singletonMap(VALUE_KEY, caseReferenceTwo))
         );
 
         verify(linkBulkCaseWorkflow, times(1)).executeWithRetriesForCreate(caseDetail, TEST_CASE_ID, AUTH_TOKEN);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -1595,7 +1595,7 @@ public class CaseOrchestrationServiceImplTest {
         when(sendClarificationSubmittedNotificationWorkflow.errors()).thenReturn(errorMap);
         assertThat(classUnderTest.sendClarificationSubmittedNotificationEmail(ccdCallbackRequest),
             is(CcdCallbackResponse.builder()
-                .errors(Arrays.asList("ErrorValue"))
+                .errors(Collections.singletonList("ErrorValue"))
                 .build()));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/AmendPetitionForRefusalTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/AmendPetitionForRefusalTest.java
@@ -27,7 +27,6 @@ public class AmendPetitionForRefusalTest {
     @InjectMocks
     private CreateAmendPetitionDraftForRefusalTask classUnderTest;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void givenUserTokenWithoutCase_whenExecuteAmendPetition_thenReturnEmpty() {
         TaskContext context = new DefaultTaskContext();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/AmendPetitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/AmendPetitionTest.java
@@ -27,7 +27,6 @@ public class AmendPetitionTest {
     @InjectMocks
     private CreateAmendPetitionDraft target;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void givenUserTokenWithoutCase_whenExecuteAmendPetition_thenReturnEmpty() {
         TaskContext context = new DefaultTaskContext();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/AuthenticateRespondentUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/AuthenticateRespondentUTest.java
@@ -74,7 +74,7 @@ public class AuthenticateRespondentUTest {
         Mockito.when(idamClient.getUserDetails(BEARER_AUTH_TOKEN))
             .thenReturn(
                 UserDetails.builder()
-                    .roles(Arrays.asList(
+                    .roles(Collections.singletonList(
                         "letter-loa1"
                     ))
                     .build());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CoRespondentLetterGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CoRespondentLetterGeneratorTest.java
@@ -90,7 +90,7 @@ public class CoRespondentLetterGeneratorTest {
         coRespondentLetterGenerator.execute(context, payload);
 
         final LinkedHashSet<GeneratedDocumentInfo> documentCollection =
-            (LinkedHashSet<GeneratedDocumentInfo>)context.getTransientObject(DOCUMENT_COLLECTION);
+            context.getTransientObject(DOCUMENT_COLLECTION);
 
         assertThat(documentCollection, CoreMatchers.is(newLinkedHashSet(expectedCoRespondentInvitation)));
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfoUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/GetInconsistentPaymentInfoUTest.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -102,7 +102,7 @@ public class GetInconsistentPaymentInfoUTest {
     @Test
     public void givenCaseWithoutSuccessfulPayment_whenSetPaymentRefOnSession_thenReturnSameData() throws Exception {
         Map<String, Object> testData = Maps.newHashMap(EXISTING_PAYMENTS,
-            Arrays.asList(ImmutableMap.of(
+            Collections.singletonList(ImmutableMap.of(
                 PAYMENT_REFERENCE, "ref1",
                 PAYMENT_STATUS, "nothing"
             )));
@@ -170,7 +170,7 @@ public class GetInconsistentPaymentInfoUTest {
 
         return ImmutableMap.of(
             IS_DRAFT_KEY, Boolean.FALSE.toString(),
-            D_8_PAYMENTS, Arrays.asList(ImmutableMap.of(
+            D_8_PAYMENTS, Collections.singletonList(ImmutableMap.of(
                 ID, PAYMENT_ID,
                 PAYMENT_VALUE, paymentObject
             )));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PetitionGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PetitionGeneratorTest.java
@@ -72,7 +72,7 @@ public class PetitionGeneratorTest {
         petitionGenerator.execute(context, payload);
 
         final LinkedHashSet<GeneratedDocumentInfo> documentCollection =
-            (LinkedHashSet<GeneratedDocumentInfo>)context.getTransientObject(DOCUMENT_COLLECTION);
+            context.getTransientObject(DOCUMENT_COLLECTION);
 
         assertThat(documentCollection, is(newLinkedHashSet(expectedPetition)));
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentAnswersGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentAnswersGeneratorTest.java
@@ -27,8 +27,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_COLLECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_RESPONDENT_ANSWERS;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_RESPONDENT_ANSWERS;
-
 
 @RunWith(MockitoJUnitRunner.class)
 public class RespondentAnswersGeneratorTest {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchAwaitingPronouncementCasesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SearchAwaitingPronouncementCasesTest.java
@@ -100,7 +100,7 @@ public class SearchAwaitingPronouncementCasesTest {
 
         Object actual = context.getTransientObject(SEARCH_RESULT_KEY);
 
-        assertThat(actual, is(Arrays.asList(cmsSearchResponse)));
+        assertThat(actual, is(Collections.singletonList(cmsSearchResponse)));
 
         int expectedIterations = 2;
 
@@ -145,8 +145,8 @@ public class SearchAwaitingPronouncementCasesTest {
 
         final SearchResult expectedCmsResponseTwo = SearchResult.builder()
                 .total(5)
-                .cases(Arrays.asList(
-                        CaseDetails.builder().caseId(TEST_CASE_ID_3).build()
+                .cases(Collections.singletonList(
+                    CaseDetails.builder().caseId(TEST_CASE_ID_3).build()
                 )).build();
 
         when(caseMaintenanceClient.searchCases(eq(AUTH_TOKEN), contains("\"from\":0"))).thenReturn(cmsSearchResponse);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerCoRespondentRespondedNotificationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerCoRespondentRespondedNotificationEmailTest.java
@@ -59,7 +59,6 @@ public class SendPetitionerCoRespondentRespondedNotificationEmailTest {
     @InjectMocks
     private SendPetitionerCoRespondentRespondedNotificationEmail sendPetitionerCoRespondentRespondedNotificationEmail;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testSolicitorEmailIsSent_WhenCoRespondentSubmits()
         throws IOException, TaskException {
@@ -94,7 +93,6 @@ public class SendPetitionerCoRespondentRespondedNotificationEmailTest {
             coRespRespondedSolicitorEmail);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testRightEmailIsSent_WhenCoRespondentSubmitsAndRespondentHasNot()
         throws IOException, TaskException {
@@ -125,7 +123,6 @@ public class SendPetitionerCoRespondentRespondedNotificationEmailTest {
             coRespRespondedButRespHasNot);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testRightEmailIsSent_WhenCoRespondentSubmitsAndRespondentHasNotDefended()
         throws IOException, TaskException {
@@ -157,7 +154,6 @@ public class SendPetitionerCoRespondentRespondedNotificationEmailTest {
             coRespRespondedWhenAosUndefended);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testRightEmailIsSent_WhenCoRespondentSubmitsAndRespondentHasIsDefending()
         throws IOException, TaskException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCaseUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SubmitRespondentAosCaseUTest.java
@@ -72,8 +72,7 @@ public class SubmitRespondentAosCaseUTest {
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_ANSWER_AOS_EVENT_ID, divorceSession))
             .thenReturn(CASE_UPDATE_RESPONSE);
 
-        Map<String, Object> expectedData = new HashMap<>();
-        expectedData.putAll(divorceSession);
+        Map<String, Object> expectedData = new HashMap<>(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
         expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
@@ -90,8 +89,7 @@ public class SubmitRespondentAosCaseUTest {
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_ANSWER_AOS_EVENT_ID, divorceSession))
             .thenReturn(CASE_UPDATE_RESPONSE);
 
-        Map<String, Object> expectedData = new HashMap<>();
-        expectedData.putAll(divorceSession);
+        Map<String, Object> expectedData = new HashMap<>(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
         expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
@@ -113,8 +111,7 @@ public class SubmitRespondentAosCaseUTest {
 
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_DN_AOS_EVENT_ID, divorceSession))
             .thenReturn(CASE_UPDATE_RESPONSE);
-        Map<String, Object> expectedData = new HashMap<>();
-        expectedData.putAll(divorceSession);
+        Map<String, Object> expectedData = new HashMap<>(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
         expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
@@ -137,8 +134,7 @@ public class SubmitRespondentAosCaseUTest {
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, COMPLETED_AOS_EVENT_ID, divorceSession))
             .thenReturn(CASE_UPDATE_RESPONSE);
 
-        Map<String, Object> expectedData = new HashMap<>();
-        expectedData.putAll(divorceSession);
+        Map<String, Object> expectedData = new HashMap<>(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
         expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 
@@ -160,8 +156,7 @@ public class SubmitRespondentAosCaseUTest {
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, COMPLETED_AOS_EVENT_ID, divorceSession))
             .thenReturn(CASE_UPDATE_RESPONSE);
 
-        Map<String, Object> expectedData = new HashMap<>();
-        expectedData.putAll(divorceSession);
+        Map<String, Object> expectedData = new HashMap<>(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
         expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
         assertEquals(EXPECTED_OUTPUT, classUnderTest.execute(TASK_CONTEXT, divorceSession));
@@ -179,8 +174,7 @@ public class SubmitRespondentAosCaseUTest {
         when(caseMaintenanceClient.updateCase(AUTH_TOKEN, TEST_CASE_ID, AWAITING_DN_AOS_EVENT_ID, divorceSession))
             .thenReturn(CASE_UPDATE_RESPONSE);
 
-        Map<String, Object> expectedData = new HashMap<>();
-        expectedData.putAll(divorceSession);
+        Map<String, Object> expectedData = new HashMap<>(divorceSession);
         expectedData.put(RECEIVED_AOS_FROM_RESP, YES_VALUE);
         expectedData.put(RECEIVED_AOS_FROM_RESP_DATE, FIXED_DATE);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/ValidateSolicitorCaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/ValidateSolicitorCaseDataTest.java
@@ -12,7 +12,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_STATEMENT_OF_TRUTH;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_VALIDATION_ERROR_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.STATEMENT_OF_TRUTH;
@@ -40,7 +42,7 @@ public class ValidateSolicitorCaseDataTest {
         Map<String, Object> result = validateSolicitorCaseData.execute(context, caseData);
 
         assertEquals(result, caseData);
-        assertEquals(false, context.hasTaskFailed());
+        assertFalse(context.hasTaskFailed());
     }
 
     @Test
@@ -51,7 +53,7 @@ public class ValidateSolicitorCaseDataTest {
         Map<String, Object> result = validateSolicitorCaseData.execute(context, caseData);
 
         assertEquals(result, caseData);
-        assertEquals(true, context.hasTaskFailed());
+        assertTrue(context.hasTaskFailed());
         assertNotNull(context.getTransientObject(SOLICITOR_VALIDATION_ERROR_KEY));
     }
 
@@ -63,7 +65,7 @@ public class ValidateSolicitorCaseDataTest {
         Map<String, Object> result = validateSolicitorCaseData.execute(context, caseData);
 
         assertEquals(result, caseData);
-        assertEquals(true, context.hasTaskFailed());
+        assertTrue(context.hasTaskFailed());
         assertNotNull(context.getTransientObject(SOLICITOR_VALIDATION_ERROR_KEY));
     }
 
@@ -75,7 +77,7 @@ public class ValidateSolicitorCaseDataTest {
         Map<String, Object> result = validateSolicitorCaseData.execute(context, caseData);
 
         assertEquals(result, caseData);
-        assertEquals(true, context.hasTaskFailed());
+        assertTrue(context.hasTaskFailed());
         assertNotNull(context.getTransientObject(SOLICITOR_VALIDATION_ERROR_KEY));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionFileCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionFileCreatorTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -98,7 +98,7 @@ public class DataExtractionFileCreatorTest {
 
         verify(cmsElasticSearchSupport).searchCMSCases(eq(0), eq(50), eq(TEST_AUTHORISATION_TOKEN),
             eq(QueryBuilders.termQuery("last_modified", testLastModifiedDate)),
-            eq(QueryBuilders.termsQuery("state", asList(TEST_RELEVANT_STATE.toLowerCase())))
+            eq(QueryBuilders.termsQuery("state", singletonList(TEST_RELEVANT_STATE.toLowerCase())))
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DecreeNisiDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DecreeNisiDataExtractorTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
@@ -55,7 +56,7 @@ public class DecreeNisiDataExtractorTest {
     private static final String TEST_WHO_PAYS_COSTS_CCD_FIELD = "Respondent";
     private static final String TEST_COSTS_CLAIM_GRANTED = "Yes";
     private static final String TEST_DN_DECISION_DATE = "2020-12-15";
-    private static final List<Map<String, Object>> DATE_TIME_OF_HEARINGS = asList(singletonMap("value", ImmutableMap.of(
+    private static final List<Map<String, Object>> DATE_TIME_OF_HEARINGS = singletonList(singletonMap("value", ImmutableMap.of(
         DATE_OF_HEARING_CCD_FIELD, "2020-12-10",
         TIME_OF_HEARING_CCD_FIELD, "15:30"
     )));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CcdUtilUTest.java
@@ -21,6 +21,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EXPECTED_DUE_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EXPECTED_DUE_DATE_FORMATTED;
@@ -73,19 +75,19 @@ public class CcdUtilUTest {
     @Test
     public void givenDateStringInPast_whenIsCcdDateTimeInThePast_thenReturnTrue() {
         String pastDate = LocalDateTime.now(clock).minusMonths(1).toString();
-        assertEquals(true, ccdUtil.isCcdDateTimeInThePast(pastDate));
+        assertTrue(ccdUtil.isCcdDateTimeInThePast(pastDate));
     }
 
     @Test
     public void givenDateStringIsToday_whenIsCcdDateTimeInThePast_thenReturnTrue() {
         String now = LocalDateTime.now(clock).toString();
-        assertEquals(true, ccdUtil.isCcdDateTimeInThePast(now));
+        assertTrue(ccdUtil.isCcdDateTimeInThePast(now));
     }
 
     @Test
     public void givenDateStringInFuture_whenIsCcdDateTimeInThePast_thenReturnFalse() {
         String futureDate = LocalDateTime.now(clock).plusMonths(1).toString();
-        assertEquals(false, ccdUtil.isCcdDateTimeInThePast(futureDate));
+        assertFalse(ccdUtil.isCcdDateTimeInThePast(futureDate));
     }
 
     @Test


### PR DESCRIPTION
Looks like a large PR but it's not really. 
I just went through COS and tidied up code. 

The following are some examples of what this included:
- adjusted access modifiers to be more strict when necessary e.g. public -> private
- Removed redundant and outdated "@SuppressWarnings("...")"
- Replaced "asList" when only used for a single item to Collections.singletonList as this improves performance
- Removed duplicated keys from some test JSON files
- Removed redundant  "X = null;" declarations
- Removed redundant casting from the same types
- Replaced "assertEquals(false, X)" with "assertFalse(X)"