### PR TITLE
set claimCostsFrom automatically on solicitor journey

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ def versions = [
         lombok                       : '1.16.16',
         pitest                       : '1.4.10',
         postgresql                   : '42.2.9',
-        puppyCrawl                   : '8.28',
+        puppyCrawl                   : '8.29',
         quartz                       : '2.3.2',
         reformHealth                 : '0.0.5',
         reformPropertiesVolume       : '0.0.4',
@@ -92,7 +92,7 @@ allprojects {
 
     checkstyle {
         maxWarnings = 0
-        toolVersion = '8.21'
+        toolVersion = '8.29'
         // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
         configDir = new File(rootDir, './')
     }

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -31,6 +31,11 @@
         <property name="file" value="suppressions.xml"/>
         <property name="optional" value="false"/>
     </module>
+    <module name="LineLength">
+        <property name="max" value="150"/>
+        <property name="ignorePattern"
+                  value="public.*given.+_when.+_then.+|^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
 
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder"/>
@@ -45,11 +50,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="150"/>
-            <property name="ignorePattern"
-                      value="public.*given.+_when.+_then.+|^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>
@@ -200,11 +200,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="nothing"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkScanController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkScanController.java
@@ -29,7 +29,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.impl.BulkScanService;
 
 import java.util.List;
 import java.util.Map;
-
 import javax.validation.Valid;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -28,7 +28,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.CaseOrchestrationServic
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import javax.ws.rs.core.MediaType;
 
 import static java.lang.String.format;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -75,6 +75,8 @@ public class OrchestrationConstants {
     public static final String DN_COSTS_OPTIONS_CCD_FIELD = "DivorceCostsOptionDN";
     public static final String DN_COSTS_ENDCLAIM_VALUE = "endClaim";
     public static final String DIVORCE_COSTS_CLAIM_CCD_FIELD = "D8DivorceCostsClaim";
+    public static final String DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD = "D8DivorceClaimFrom";
+    public static final String DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT = "respondent";
     public static final String DN_COSTS_CLAIM_CCD_FIELD = "DivorceCostsOptionDN";
     public static final String DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD = "CostsClaimGranted";
     public static final String DATETIME_OF_HEARING_CCD_FIELD = "DateAndTimeOfHearing";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/documentgeneration/GenerateDocumentRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/documentgeneration/GenerateDocumentRequest.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.util.Map;
-
 import javax.validation.constraints.NotBlank;
 
 @Data

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/BulkScanFormTransformerFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/transformation/BulkScanFormTransformerFactory.java
@@ -6,7 +6,6 @@ import uk.gov.hmcts.reform.bsp.common.error.UnsupportedFormTypeException;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.PostConstruct;
 
 import static java.lang.String.format;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/BulkScanFormValidatorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/scan/validation/BulkScanFormValidatorFactory.java
@@ -6,7 +6,6 @@ import uk.gov.hmcts.reform.bsp.common.error.UnsupportedFormTypeException;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.PostConstruct;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.AOS_OFFLINE_2_YR_SEP;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD;
+
+@Service
+public class SetClaimCostsFrom implements Task<Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> payload)  {
+        payload.put(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD, DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT);
+        return payload;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
@@ -14,7 +15,7 @@ public class SetClaimCostsFrom implements Task<Map<String, Object>> {
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> payload)  {
-        payload.put(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD, DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT);
+        payload.put(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD, Arrays.asList(DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT));
         return payload;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/CSVExtractorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/CSVExtractorFactory.java
@@ -6,7 +6,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.event.domain.DataExtractionRequ
 
 import java.util.EnumMap;
 import java.util.Map;
-
 import javax.annotation.PostConstruct;
 
 import static java.lang.String.format;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClient.java
@@ -7,7 +7,6 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
-
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/ExtractedDataPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/ExtractedDataPublisher.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskExc
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-
 import javax.mail.MessagingException;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.workflows.dataextraction.FamilyManDataExtractionWorkflow.DATE_TO_EXTRACT_KEY;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
@@ -14,6 +15,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFrom;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetSolicitorCourtDetailsTask;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +63,8 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     private boolean isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(CaseDetails caseDetails) {
         Map<String, Object> caseData = caseDetails.getCaseData();
         boolean isPetitionerClaimingCosts = YES_VALUE.equalsIgnoreCase(String.valueOf(caseData.get(DIVORCE_COSTS_CLAIM_CCD_FIELD)));
-        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD))
+            || CollectionUtils.isEmpty(Arrays.asList(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD)));
         return isPetitionerClaimingCosts && claimCostsFromIsEmpty;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
@@ -3,18 +3,25 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddMiniPetitionDraftTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFrom;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetSolicitorCourtDetailsTask;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @Component
 public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>> {
@@ -22,25 +29,39 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     private final SetSolicitorCourtDetailsTask setSolicitorCourtDetailsTask;
     private final AddMiniPetitionDraftTask addMiniPetitionDraftTask;
     private final CaseFormatterAddDocuments caseFormatterAddDocuments;
+    private final SetClaimCostsFrom setClaimCostsFrom;
 
     @Autowired
     public SolicitorCreateWorkflow(
         SetSolicitorCourtDetailsTask setSolicitorCourtDetailsTask,
         AddMiniPetitionDraftTask addMiniPetitionDraftTask,
-        CaseFormatterAddDocuments caseFormatterAddDocuments) {
+        CaseFormatterAddDocuments caseFormatterAddDocuments,
+        SetClaimCostsFrom setClaimCostsFrom) {
         this.setSolicitorCourtDetailsTask = setSolicitorCourtDetailsTask;
         this.addMiniPetitionDraftTask = addMiniPetitionDraftTask;
         this.caseFormatterAddDocuments = caseFormatterAddDocuments;
+        this.setClaimCostsFrom = setClaimCostsFrom;
     }
 
     public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
-        return this.execute(new Task[]{
-            setSolicitorCourtDetailsTask,
-            addMiniPetitionDraftTask,
-            caseFormatterAddDocuments
-            }, caseDetails.getCaseData(),
+        final List<Task> tasks = new ArrayList<>();
+        if (isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(caseDetails)) {
+            tasks.add(setClaimCostsFrom);
+        }
+        tasks.add(setSolicitorCourtDetailsTask);
+        tasks.add(addMiniPetitionDraftTask);
+        tasks.add(caseFormatterAddDocuments);
+        return this.execute(tasks.toArray(new Task[0]),
+            caseDetails.getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails)
         );
+    }
+
+    private boolean isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(CaseDetails caseDetails) {
+        Map<String, Object> caseData = caseDetails.getCaseData();
+        boolean isPetitionerClaimingCosts = YES_VALUE.equalsIgnoreCase(String.valueOf(caseData.get(DIVORCE_COSTS_CLAIM_CCD_FIELD)));
+        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+        return isPetitionerClaimingCosts && claimCostsFromIsEmpty;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/dataextraction/DataExtractionToFamilyManTest.java
@@ -19,7 +19,6 @@ import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-
 import javax.mail.MessagingException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDocLinkTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDocLinkTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_DRAFT_LINK_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_PETITION;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
@@ -26,6 +27,9 @@ public class SetClaimCostsFromTest {
 
         setClaimCostsFrom.execute(null, payload);
 
-        assertEquals(EXPECTED_VALUE, payload.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+        List<Object> result = (List<Object>) payload.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD);
+
+        assertEquals(result.size(), 1);
+        assertEquals(EXPECTED_VALUE, result.get(0));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetClaimCostsFromTest {
+
+    private static final String EXPECTED_VALUE = DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
+
+    @InjectMocks
+    private SetClaimCostsFrom setClaimCostsFrom;
+
+
+    @Test
+    public void testSetsClaimCostsFromToRespondent() {
+        HashMap<String, Object> payload = new HashMap<>();
+
+        setClaimCostsFrom.execute(null, payload);
+
+        assertEquals(EXPECTED_VALUE, payload.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.dataextraction.DataExtrac
 
 import java.io.File;
 import java.nio.file.Files;
-
 import javax.mail.MessagingException;
 
 import static org.hamcrest.Matchers.instanceOf;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/ExtractedDataPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/ExtractedDataPublisherTest.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.Month;
-
 import javax.mail.MessagingException;
 
 import static org.hamcrest.Matchers.instanceOf;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/AosSubmissionWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/AosSubmissionWorkflowTest.java
@@ -43,7 +43,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
-
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CO_RESPONDENT_NAMED;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DataExtractionWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DataExtractionWorkflowTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/NotifyRespondentOfDARequestedWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/NotifyRespondentOfDARequestedWorkflowTest.java
@@ -5,7 +5,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SeparationFieldsWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SeparationFieldsWorkflowTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE_SEP_DATE;
 
 @RunWith(MockitoJUnitRunner.class)


### PR DESCRIPTION
# Description

Set the value of claimCostsFrom to respondent (by default) on solicitor journey **if** petitioner is claiming costs, and solicitor has not yet specified a value for claimCostsFrom.

Fixes https://tools.hmcts.net/jira/browse/RPET-62

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests included.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
