### PR TITLE
Rpet 62 respondent unable to dispute costs

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,6 +36,7 @@
         <property name="ignorePattern"
                   value="public.*given.+_when.+_then.+|^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
+
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
@@ -50,7 +51,6 @@
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
-
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap"/>

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -75,6 +75,8 @@ public class OrchestrationConstants {
     public static final String DN_COSTS_OPTIONS_CCD_FIELD = "DivorceCostsOptionDN";
     public static final String DN_COSTS_ENDCLAIM_VALUE = "endClaim";
     public static final String DIVORCE_COSTS_CLAIM_CCD_FIELD = "D8DivorceCostsClaim";
+    public static final String DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD = "D8DivorceClaimFrom";
+    public static final String DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT = "respondent";
     public static final String DN_COSTS_CLAIM_CCD_FIELD = "DivorceCostsOptionDN";
     public static final String DIVORCE_COSTS_CLAIM_GRANTED_CCD_FIELD = "CostsClaimGranted";
     public static final String DATETIME_OF_HEARING_CCD_FIELD = "DateAndTimeOfHearing";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD;
+
+@Service
+public class SetClaimCostsFrom implements Task<Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> payload)  {
+        payload.put(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD, DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT);
+        return payload;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFrom.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
@@ -14,7 +15,7 @@ public class SetClaimCostsFrom implements Task<Map<String, Object>> {
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> payload)  {
-        payload.put(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD, DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT);
+        payload.put(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD, Arrays.asList(DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT));
         return payload;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
@@ -15,7 +14,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFrom;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetSolicitorCourtDetailsTask;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -63,8 +61,7 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     private boolean isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(CaseDetails caseDetails) {
         Map<String, Object> caseData = caseDetails.getCaseData();
         boolean isPetitionerClaimingCosts = YES_VALUE.equalsIgnoreCase(String.valueOf(caseData.get(DIVORCE_COSTS_CLAIM_CCD_FIELD)));
-        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD))
-            || CollectionUtils.isEmpty(Arrays.asList(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD)));
+        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
         return isPetitionerClaimingCosts && claimCostsFromIsEmpty;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
@@ -14,6 +15,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFrom;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetSolicitorCourtDetailsTask;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +63,8 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     private boolean isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(CaseDetails caseDetails) {
         Map<String, Object> caseData = caseDetails.getCaseData();
         boolean isPetitionerClaimingCosts = YES_VALUE.equalsIgnoreCase(String.valueOf(caseData.get(DIVORCE_COSTS_CLAIM_CCD_FIELD)));
-        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD))
+            || CollectionUtils.isEmpty(Arrays.asList(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD)));
         return isPetitionerClaimingCosts && claimCostsFromIsEmpty;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
@@ -3,18 +3,25 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddMiniPetitionDraftTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CaseFormatterAddDocuments;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFrom;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetSolicitorCourtDetailsTask;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @Component
 public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>> {
@@ -22,25 +29,39 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     private final SetSolicitorCourtDetailsTask setSolicitorCourtDetailsTask;
     private final AddMiniPetitionDraftTask addMiniPetitionDraftTask;
     private final CaseFormatterAddDocuments caseFormatterAddDocuments;
+    private final SetClaimCostsFrom setClaimCostsFrom;
 
     @Autowired
     public SolicitorCreateWorkflow(
         SetSolicitorCourtDetailsTask setSolicitorCourtDetailsTask,
         AddMiniPetitionDraftTask addMiniPetitionDraftTask,
-        CaseFormatterAddDocuments caseFormatterAddDocuments) {
+        CaseFormatterAddDocuments caseFormatterAddDocuments,
+        SetClaimCostsFrom setClaimCostsFrom) {
         this.setSolicitorCourtDetailsTask = setSolicitorCourtDetailsTask;
         this.addMiniPetitionDraftTask = addMiniPetitionDraftTask;
         this.caseFormatterAddDocuments = caseFormatterAddDocuments;
+        this.setClaimCostsFrom = setClaimCostsFrom;
     }
 
     public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
-        return this.execute(new Task[]{
-            setSolicitorCourtDetailsTask,
-            addMiniPetitionDraftTask,
-            caseFormatterAddDocuments
-            }, caseDetails.getCaseData(),
+        final List<Task> tasks = new ArrayList<>();
+        if (isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(caseDetails)) {
+            tasks.add(setClaimCostsFrom);
+        }
+        tasks.add(setSolicitorCourtDetailsTask);
+        tasks.add(addMiniPetitionDraftTask);
+        tasks.add(caseFormatterAddDocuments);
+        return this.execute(tasks.toArray(new Task[0]),
+            caseDetails.getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
             ImmutablePair.of(CASE_DETAILS_JSON_KEY, caseDetails)
         );
+    }
+
+    private boolean isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(CaseDetails caseDetails) {
+        Map<String, Object> caseData = caseDetails.getCaseData();
+        boolean isPetitionerClaimingCosts = YES_VALUE.equalsIgnoreCase(String.valueOf(caseData.get(DIVORCE_COSTS_CLAIM_CCD_FIELD)));
+        boolean claimCostsFromIsEmpty = StringUtils.isEmpty(caseData.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+        return isPetitionerClaimingCosts && claimCostsFromIsEmpty;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
@@ -26,6 +27,9 @@ public class SetClaimCostsFromTest {
 
         setClaimCostsFrom.execute(null, payload);
 
-        assertEquals(EXPECTED_VALUE, payload.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+        List<Object> result = (List<Object>) payload.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD);
+
+        assertEquals(result.size(), 1);
+        assertEquals(EXPECTED_VALUE, result.get(0));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetClaimCostsFromTest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetClaimCostsFromTest {
+
+    private static final String EXPECTED_VALUE = DIVORCE_COSTS_CLAIM_FROM_CCD_CODE_FOR_RESPONDENT;
+
+    @InjectMocks
+    private SetClaimCostsFrom setClaimCostsFrom;
+
+
+    @Test
+    public void testSetsClaimCostsFromToRespondent() {
+        HashMap<String, Object> payload = new HashMap<>();
+
+        setClaimCostsFrom.execute(null, payload);
+
+        assertEquals(EXPECTED_VALUE, payload.get(DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD));
+    }
+}


### PR DESCRIPTION
# Description

Set the value of claimCostsFrom to respondent (by default) on solicitor journey **if** petitioner is claiming costs, and solicitor has not yet specified a value for claimCostsFrom.

Fixes https://tools.hmcts.net/jira/browse/RPET-62

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests included.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
