### PR TITLE
Removed redundant checkstyle config task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,18 +217,6 @@ distributions {
     }
 }
 
-// make build fail on Checkstyle issues (https://github.com/gradle/gradle/issues/881)
-tasks.withType(Checkstyle).each { checkstyleTask ->
-    checkstyleTask.doLast {
-        reports.all { report ->
-            def outputFile = report.destination
-            if (outputFile.exists() && outputFile.text.contains("<error ")) {
-                throw new GradleException("There were checkstyle warnings! For more info check $outputFile")
-            }
-        }
-    }
-}
-
 sourceSets {
     integrationTest {
         java {


### PR DESCRIPTION
Removed redundant Checkstyle config that initially made the build fail on Checkstyle issues. This is since outdated and has been replaced by the following line: 
“maxWarnings = 0”