### PR TITLE
Updated logging to not break azure alert

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/ExtractedDataPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/ExtractedDataPublisher.java
@@ -38,11 +38,12 @@ public class ExtractedDataPublisher implements Task<Void> {
 
         try {
             String destinationEmailAddress = csvExtractor.getDestinationEmailAddress();
-            log.info("Will {} send csv file to {}", csvExtractorPrefix, destinationEmailAddress);
+            log.info("Will send {} csv file to {}", csvExtractorPrefix, destinationEmailAddress);
             emailClient.sendEmailWithAttachment(destinationEmailAddress,
                 attachmentFileName,
                 context.getTransientObject(FILE_TO_PUBLISH));
-            log.info("Sent {} extracted data to {}", csvExtractorPrefix, destinationEmailAddress);
+            // This log is used for azure alerts as can be seen here: https://github.com/hmcts/div-shared-infrastructure/blob/master/alerts.tf#L86
+            log.info("Sent extracted data to {} robot using email: {}", csvExtractorPrefix, destinationEmailAddress);
         } catch (MessagingException e) {
             throw new TaskException("Error sending e-mail with " + csvExtractorPrefix + " data extraction file.", e);
         }


### PR DESCRIPTION
# Description

Updated logging so that we're not getting alerts for "failed" data extractors


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
