### PR TITLE
Add API operation annotation to all endpoints to make them clearer

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -1,10 +1,14 @@
 package uk.gov.hmcts.reform.divorce.support.cos;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.hmcts.reform.bsp.common.model.shared.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.output.SuccessfulTransformationResponse;
@@ -20,69 +24,75 @@ import java.util.Map;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-import static org.springframework.web.bind.annotation.RequestMethod.POST;
-import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 
 @FeignClient(name = "case-orchestration-api", url = "${case.orchestration.service.base.uri}",
     configuration = ServiceContextConfiguration.class)
 public interface CosApiClient {
 
-    @RequestMapping(method = POST, value = "/co-respondent-received")
+    @ApiOperation("Handle callback to trigger coRespReceived workflow")
+    @PostMapping(value = "/co-respondent-received")
     Map<String, Object> coRespReceived(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody Map<String, Object> caseDataContent
     );
 
-    @RequestMapping(method = POST, value = "/co-respondent-answered")
+    @ApiOperation("Handle callback to trigger coRespAnswerReceived workflow")
+    @PostMapping(value = "/co-respondent-answered")
     Map<String, Object> coRespAnswerReceived(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest caseDataContent
     );
 
-    @RequestMapping(method = POST, value = "/aos-received")
+    @ApiOperation("Handle callback to trigger aosReceived workflow")
+    @PostMapping(value = "/aos-received")
     Map<String, Object> aosReceived(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody Map<String, Object> caseDataContent
     );
 
-    @RequestMapping(method = POST, value = "/aos-submitted")
+    @ApiOperation("Handle callback to trigger aosSubmitted workflow")
+    @PostMapping(value = "/aos-submitted")
     Map<String, Object> aosSubmitted(
         @RequestBody Map<String, Object> caseDataContent);
 
-    @RequestMapping(method = POST, value = "/aos-solicitor-nominated")
+    @ApiOperation("Handle callback to trigger aosSolicitorNominated workflow")
+    @PostMapping(value = "/aos-solicitor-nominated")
     Map<String, Object> aosSolicitorNominated(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody Map<String, Object> caseDataContent
     );
 
-    @RequestMapping(method = POST, value = "/dn-submitted")
+    @ApiOperation("Handle callback to trigger dnSubmitted workflow")
+    @PostMapping(value = "/dn-submitted")
     Map<String, Object> dnSubmitted(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody Map<String, Object> caseDataContent
     );
 
-    @RequestMapping(method = POST, value = "/da-about-to-be-granted")
+    @ApiOperation("Handle callback to trigger daAboutToBeGranted workflow")
+    @PostMapping(value = "/da-about-to-be-granted")
     Map<String, Object> daAboutToBeGranted(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/da-requested-by-applicant")
+    @ApiOperation("Handle callback to notify respondent that the DA was requested")
+    @PostMapping(value = "/da-requested-by-applicant")
     Map<String, Object> notifyRespondentOfDARequested(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = GET, value = "/draftsapi/version/1",
+    @ApiOperation("Return a draft case")
+    @GetMapping(value = "/draftsapi/version/1",
         headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> getDraft(
         @RequestHeader(AUTHORIZATION) String authorisation
     );
 
-    @RequestMapping(method = PUT, value = "/draftsapi/version/1",
+    @ApiOperation("Delete a save a draft case")
+    @PutMapping(value = "/draftsapi/version/1",
         headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void saveDraft(
         @RequestHeader(AUTHORIZATION) String authorisation,
@@ -90,31 +100,36 @@ public interface CosApiClient {
         @RequestParam(name = "sendEmail") String sendEmail
     );
 
-    @RequestMapping(method = DELETE, value = "/draftsapi/version/1",
+    @ApiOperation("Delete a draft case")
+    @DeleteMapping(value = "/draftsapi/version/1",
         headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void deleteDraft(
         @RequestHeader(AUTHORIZATION) String authorisation
     );
 
-    @RequestMapping(method = POST, value = "/submit")
+    @ApiOperation("Submit a case")
+    @PostMapping(value = "/submit")
     Map<String, Object> submitCase(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody Map<String, Object> caseDataContent
     );
 
-    @RequestMapping(method = POST, value = "/case-linked-for-hearing")
+    @ApiOperation("Handle callback to link a case to a hearing")
+    @PostMapping(value = "/case-linked-for-hearing")
     Map<String, Object> caseLinkedForHearing(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody Map<String, Object> caseDataContent
     );
 
-    @RequestMapping(method = POST, value = "/bulk/pronounce/submit")
+    @ApiOperation("Handle callback to submit Bulk Pronouncement")
+    @PostMapping(value = "/bulk/pronounce/submit")
     Map<String, Object> bulkPronouncement(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/bulk/edit/listing")
+    @ApiOperation("Handle callback to edit bulk listing")
+    @PostMapping(value = "/bulk/edit/listing")
     Map<String, Object> editBulkListing(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest,
@@ -123,7 +138,8 @@ public interface CosApiClient {
         @RequestParam(name = "filename") String filename
     );
 
-    @RequestMapping(method = POST, value = "/generate-document")
+    @ApiOperation("Handle callback to generate documents with provided parameters")
+    @PostMapping(value = "/generate-document")
     Map<String, Object> generateDocument(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest,
@@ -132,72 +148,84 @@ public interface CosApiClient {
         @RequestParam(name = "filename") String filename
     );
 
-    @RequestMapping(method = POST, value = "/generate-dn-pronouncement-documents")
+    @ApiOperation("Handle callback to generate DN Pronouncement Documents")
+    @PostMapping(value = "/generate-dn-pronouncement-documents")
     Map<String, Object> generateDnPronouncedDocuments(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/process-applicant-da-eligibility")
+    @ApiOperation("Handle callback to process Applicants' DA eligibility")
+    @PostMapping(value = "/process-applicant-da-eligibility")
     CcdCallbackResponse processApplicantDAEligibility(
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/submit-da/{caseId}")
+    @ApiOperation("Handle callback submit DA for Case ID")
+    @PostMapping(value = "/submit-da/{caseId}")
     Map<String, Object> submitDaCase(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody Map<String, Object> caseData,
         @PathVariable("caseId") String caseId
     );
 
-    @RequestMapping(method = POST, value = "/issue-aos-pack-offline/parties/{party}")
+    @ApiOperation("Handle callback to issue AOS Pack offline for provided parties")
+    @PostMapping(value = "/issue-aos-pack-offline/parties/{party}")
     Map<String, Object> issueAosPackOffline(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @PathVariable("party") String party,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/personal-service-pack")
+    @ApiOperation("Handle callback to process Personal Service Pack")
+    @PostMapping(value = "/personal-service-pack")
     CcdCallbackResponse processPersonalServicePack(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/remove-dn-outcome-case-flag")
+    @ApiOperation("Handle callback to remove DN 'Outcome Case' flag")
+    @PostMapping(value = "/remove-dn-outcome-case-flag")
     Map<String, Object> removeDnOutcomeCaseFlag(@RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/remove-la-make-decision-fields")
+    @ApiOperation("Handle callback to remove LA 'Make Decision' fields")
+    @PostMapping(value = "/remove-la-make-decision-fields")
     Map<String, Object> removeLegalAdvisorMakeDecisionFields(
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/dn-about-to-be-granted")
+    @ApiOperation("Handle callback for DA about to be granted")
+    @PostMapping(value = "/dn-about-to-be-granted")
     CcdCallbackResponse processDnAboutToBeGranted(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/dn-decision-made")
+    @ApiOperation("Handle callback for DN Decision Made")
+    @PostMapping(value = "/dn-decision-made")
     CcdCallbackResponse dnDecisionMade(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
-    @RequestMapping(method = POST, value = "/forms/{form-type}/validate-ocr")
+    @ApiOperation("Validate bulk scanned fields")
+    @PostMapping(value = "/forms/{form-type}/validate-ocr")
     SuccessfulUpdateResponse validateBulkScannedFields(
         @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
         @PathVariable("form-type") String formType,
         @RequestBody OcrDataValidationRequest request
     );
 
-    @RequestMapping(method = POST, value = "/transform-exception-record")
+    @ApiOperation("Transform bulk scanned fields to CCD format")
+    @PostMapping(value = "/transform-exception-record")
     SuccessfulTransformationResponse transformBulkScannedFields(
         @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
         @RequestBody ExceptionRecord exceptionRecord
     );
 
-    @RequestMapping(method = POST, value = "/update-case")
+    @ApiOperation("Transform bulk scanned fields to CCD format for updating case")
+    @PostMapping(value = "/update-case")
     SuccessfulUpdateResponse transformBulkScannedFieldsForUpdatingCase(
         @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
         @RequestBody BulkScanCaseUpdateRequest request

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.reform.divorce.orchestration.client;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.DocumentUpdateRequest;
 
 import java.util.Map;
@@ -17,87 +17,69 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @FeignClient(name = "formatter-service-client", url = "${case.formatter.service.api.baseurl}")
 public interface CaseFormatterClient {
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/caseformatter/version/1/add-documents",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Add documents to case")
+    @PostMapping(value = "/caseformatter/version/1/add-documents",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> addDocuments(
-        @RequestBody DocumentUpdateRequest documentUpdateRequest);
+        @RequestBody DocumentUpdateRequest documentUpdateRequest
+    );
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/caseformatter/version/1/to-ccd-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Remove all Petition documents from case data")
+    @PostMapping(value = "/caseformatter/version/1/remove-all-petition-documents",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
+    Map<String, Object> removeAllPetitionDocuments(
+        @RequestBody Map<String, Object> caseData
+    );
+
+    @ApiOperation("Remove all documents by document type")
+    @PostMapping(value = "/caseformatter/version/1/remove/documents/{documentType}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
+    Map<String, Object> removeAllDocumentsByType(
+        @PathVariable("documentType") String eventId,
+        @RequestBody Map<String, Object> caseData
+    );
+
+    @ApiOperation("Transform data from Divorce format to CCD format")
+    @PostMapping(value = "/caseformatter/version/1/to-ccd-format",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> transformToCCDFormat(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
         @RequestBody Map<String, Object> transformToCCDFormat
     );
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/caseformatter/version/1/to-divorce-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Transform data to Divorce format")
+    @PostMapping(value = "/caseformatter/version/1/to-divorce-format",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> transformToDivorceFormat(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
         @RequestBody Map<String, Object> transformToDivorceFormat
     );
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/caseformatter/version/1/to-aos-submit-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Transform data to AOS Case Format")
+    @PostMapping(value = "/caseformatter/version/1/to-aos-submit-format",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> transformToAosCaseFormat(
         @RequestBody Map<String, Object> divorceSession
     );
 
-    @RequestMapping(
-            method = RequestMethod.POST,
-            value = "/caseformatter/version/1/to-dn-submit-format",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Transform data to DN Submit Format")
+    @PostMapping(value = "/caseformatter/version/1/to-dn-submit-format",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> transformToDnCaseFormat(
             @RequestBody Map<String, Object> divorceSession
     );
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/caseformatter/version/1/to-dn-clarification-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Transform data to DA Submit Format")
+    @PostMapping(value = "/caseformatter/version/1/to-da-submit-format",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
+    Map<String, Object> transformToDaCaseFormat(
+        @RequestBody Map<String, Object> divorceSession
+    );
+
+    @ApiOperation("Transform data to DN Clarification Format")
+    @PostMapping(value = "/caseformatter/version/1/to-dn-clarification-format",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> transformToDnClarificationCaseFormat(
         @RequestBody Map<String, Object> divorceCaseWrapper
-    );
-
-    @RequestMapping(
-            method = RequestMethod.POST,
-            value = "/caseformatter/version/1/remove-all-petition-documents",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
-    Map<String, Object> removeAllPetitionDocuments(
-            @RequestBody Map<String, Object> caseData
-    );
-
-    @RequestMapping(
-            method = RequestMethod.POST,
-            value = "/caseformatter/version/1/to-da-submit-format",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
-    Map<String, Object> transformToDaCaseFormat(
-            @RequestBody Map<String, Object> divorceSession
-    );
-
-
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/caseformatter/version/1/remove/documents/{documentType}",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
-    Map<String, Object> removeAllDocumentsByType(
-        @PathVariable("documentType") String eventId,
-        @RequestBody Map<String, Object> caseData
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseMaintenanceClient.java
@@ -1,12 +1,15 @@
 package uk.gov.hmcts.reform.divorce.orchestration.client;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.SearchResult;
@@ -19,39 +22,31 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @FeignClient(name = "maintenance-service-client", url = "${case.maintenance.service.api.baseurl}")
 public interface CaseMaintenanceClient {
 
-    @RequestMapping(
-        method = RequestMethod.PUT,
-        value = "/casemaintenance/version/1/amended-petition-draft",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Amend Petition")
+    @PutMapping(value = "/casemaintenance/version/1/amended-petition-draft",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> amendPetition(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken
     );
 
-    @RequestMapping(
-        method = RequestMethod.PUT,
-        value = "/casemaintenance/version/1/amended-petition-draft-refusal",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Amend Petition For Refusal")
+    @PutMapping(value = "/casemaintenance/version/1/amended-petition-draft-refusal",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> amendPetitionForRefusal(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken
     );
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/casemaintenance/version/1/submit",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Submit Case")
+    @PostMapping(value = "/casemaintenance/version/1/submit",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> submitCase(
         @RequestBody Map<String, Object> submitCase,
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken
     );
 
-    @RequestMapping(
-            method = RequestMethod.POST,
-            value = "/casemaintenance/version/1/updateCase/{caseId}/{eventId}",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Update Case")
+    @PostMapping(value = "/casemaintenance/version/1/updateCase/{caseId}/{eventId}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> updateCase(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
         @PathVariable("caseId") String caseId,
@@ -59,105 +54,81 @@ public interface CaseMaintenanceClient {
         @RequestBody Map<String, Object> requestBody
     );
 
-    @RequestMapping(
-        method = RequestMethod.GET,
-        value = "/casemaintenance/version/1/retrieveAosCase",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Retrieve AOS Case")
+    @GetMapping(value = "/casemaintenance/version/1/retrieveAosCase",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     CaseDetails retrieveAosCase(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken
     );
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/casemaintenance/version/1/link-respondent/{caseId}/{letterHolderId}",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Link Respondent with Case ID and Letter Holder ID")
+    @PostMapping(value = "/casemaintenance/version/1/link-respondent/{caseId}/{letterHolderId}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void linkRespondent(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
         @PathVariable("caseId") String caseId,
         @PathVariable("letterHolderId") String letterHolderId);
 
-    @RequestMapping(
-            method = RequestMethod.DELETE,
-            value = "/casemaintenance/version/1/link-respondent/{caseId}",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Unlink Respondent from case")
+    @DeleteMapping(value = "/casemaintenance/version/1/link-respondent/{caseId}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void unlinkRespondent(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
             @PathVariable("caseId") String caseId);
 
-    @RequestMapping(
-            method = RequestMethod.PUT,
-            value = "/casemaintenance/version/1/drafts",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Save draft case")
+    @PutMapping(value = "/casemaintenance/version/1/drafts",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> saveDraft(
             @RequestBody Map<String, Object> draft,
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
             @RequestParam(value = "divorceFormat") boolean divorceFormat);
 
-    @RequestMapping(
-            method = RequestMethod.GET,
-            value = "/casemaintenance/version/1/retrieveCase"
-    )
+    @ApiOperation("Retrieve Petition")
+    @GetMapping(value = "/casemaintenance/version/1/retrieveCase")
     CaseDetails retrievePetition(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken);
 
-    @RequestMapping(
-        method = RequestMethod.GET,
-        value = "/casemaintenance/version/1/case"
-    )
+    @ApiOperation("Get Case")
+    @GetMapping(value = "/casemaintenance/version/1/case")
     CaseDetails getCase(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken);
 
-    @RequestMapping(
-            method = RequestMethod.GET,
-            value = "/casemaintenance/version/1/case/{caseId}"
-    )
+    @ApiOperation("Retrieve Petition by ID")
+    @GetMapping(value = "/casemaintenance/version/1/case/{caseId}")
     CaseDetails retrievePetitionById(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
             @PathVariable("caseId") String caseId);
 
-    @RequestMapping(
-            method = RequestMethod.DELETE,
-            value = "/casemaintenance/version/1/drafts"
-    )
+    @ApiOperation("Delete draft case")
+    @DeleteMapping(value = "/casemaintenance/version/1/drafts")
     Map<String, Object> deleteDraft(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken);
 
-    @RequestMapping(
-            method = RequestMethod.GET,
-            value = "/casemaintenance/version/1/drafts"
-    )
+    @ApiOperation("Get drafts")
+    @GetMapping(value = "/casemaintenance/version/1/drafts")
     Map<String, Object> getDrafts(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken);
 
-    @RequestMapping(
-            method = RequestMethod.POST,
-            value = "/casemaintenance/version/1/search",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Search cases")
+    @PostMapping(value = "/casemaintenance/version/1/search",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     SearchResult searchCases(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
             @RequestBody String query
     );
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/casemaintenance/version/1/bulk/submit",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Submit bulk case")
+    @PostMapping(value = "/casemaintenance/version/1/bulk/submit",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> submitBulkCase(
         @RequestBody Map<String, Object> bulkCase,
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken
     );
 
-    @RequestMapping(
-            method = RequestMethod.POST,
-            value = "/casemaintenance/version/1/bulk/updateCase/{caseId}/{eventId}",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Update bulk case")
+    @PostMapping(value = "/casemaintenance/version/1/bulk/updateCase/{caseId}/{eventId}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     Map<String, Object> updateBulkCase(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
             @PathVariable("caseId") String caseId,
@@ -165,11 +136,9 @@ public interface CaseMaintenanceClient {
             @RequestBody Map<String, Object> requestBody
     );
 
-    @RequestMapping(
-            method = RequestMethod.PUT,
-            value = "/casemaintenance/version/1/add-petitioner-solicitor-role/{caseId}",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Add Petitioner Solicitor Role to case")
+    @PutMapping(value = "/casemaintenance/version/1/add-petitioner-solicitor-role/{caseId}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void addPetitionerSolicitorRole(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken,
             @PathVariable("caseId") String caseId

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/DocumentGeneratorClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/DocumentGeneratorClient.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.divorce.orchestration.client;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GenerateDocumentRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
 
@@ -15,11 +15,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @FeignClient(name = "document-generator-client", url = "${document.generator.service.api.baseurl}")
 public interface DocumentGeneratorClient {
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/version/1/generatePDF",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Generate PDF Document")
+    @PostMapping(value = "/version/1/generatePDF", headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     GeneratedDocumentInfo generatePDF(
         @RequestBody GenerateDocumentRequest generateDocumentRequest,
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationToken);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/FeatureToggleServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/FeatureToggleServiceClient.java
@@ -11,8 +11,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @FeignClient(name = "feature-toggle-service-client", url = "${feature-toggle.service.api.baseurl}")
 public interface FeatureToggleServiceClient {
 
-    @GetMapping(
-        value = "/api/ff4j/store/features/{feature_name}",
+    @GetMapping(value = "/api/ff4j/store/features/{feature_name}",
         headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
     )
     FeatureToggle getToggle(@PathVariable("feature_name") String featureName);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/FeesAndPaymentsClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/FeesAndPaymentsClient.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.divorce.orchestration.client;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.fees.FeeResponse;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -11,18 +11,13 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @FeignClient(name = "fees-and-payments-client", url = "${fees-and-payments.service.api.baseurl}")
 public interface FeesAndPaymentsClient {
 
-    @RequestMapping(
-            method = RequestMethod.GET,
-            value = "/fees-and-payments/version/1/petition-issue-fee",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Returns Petition Issue Fee")
+    @GetMapping(value = "/fees-and-payments/version/1/petition-issue-fee",
+            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     FeeResponse getPetitionIssueFee();
 
-
-    @RequestMapping(
-        method = RequestMethod.GET,
-        value = "/fees-and-payments/version/1/amend-fee",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Returns amend Petitioner Fee")
+    @GetMapping(value = "/fees-and-payments/version/1/amend-fee",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     FeeResponse getAmendPetitioneFee();
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/PaymentClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/PaymentClient.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.reform.divorce.orchestration.client;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.pay.CreditAccountPaymentRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.pay.CreditAccountPaymentResponse;
 
@@ -17,13 +18,15 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @FeignClient(name = "payment-client", url = "${payment.service.api.baseurl}")
 public interface PaymentClient {
 
-    @RequestMapping(method = RequestMethod.POST, value = "/credit-account-payments")
+    @ApiOperation("Handles Solicitor Payment By Account (PBA) Payments")
+    @PostMapping(value = "/credit-account-payments")
     ResponseEntity<CreditAccountPaymentResponse> creditAccountPayment(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
             @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String serviceAuthorisation,
             CreditAccountPaymentRequest creditAccountPaymentRequest);
 
-    @RequestMapping(method = RequestMethod.GET, value = "/card-payments/{paymentRef}")
+    @ApiOperation("Returns payment information for given payment reference")
+    @GetMapping(value = "/card-payments/{paymentRef}")
     Map<String, Object> checkPayment(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
             @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String serviceAuthorisation,


### PR DESCRIPTION
- Added @ApiOperation() to all endpoints with a description of what the endpoint does to make out API more clear
- Replaced "@RequestMapping()" with action specific annotation. For example: "method = POST, value = "/dn-submitted")"