### PR TITLE
DIV-5622: Get Document types method modified to fix error (Respondent solicitor cover letter not sent)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SendDnPronouncedNotificationWorkflow.java
@@ -104,12 +104,12 @@ public class SendDnPronouncedNotificationWorkflow extends DefaultWorkflow<Map<St
                     tasks.add(costOrderCoRespondentCoverLetterGenerationTask);
 
                 }
-                log.info("CaseID: {} - Documents sent to bulk print", caseDetails.getCaseId());
+                log.info("CaseID: {} - Add tasks to send documents to bulk print", caseDetails.getCaseId());
                 tasks.add(fetchPrintDocsFromDmStore);
                 tasks.add(bulkPrinterTask);
 
             } else {
-                log.info("CaseID: {} - Cost claim not granted. Nothing was sent to bulk print", caseDetails.getCaseId());
+                log.info("CaseID: {} - Cost claim not granted. Nothing will be sent to bulk print", caseDetails.getCaseId());
             }
         } else {
             log.info("Features.PAPER_UPDATE = off. Nothing was sent to bulk print");


### PR DESCRIPTION
# Description

The method getDocumentTypes() has been modified to fix an issue seen in the logs. 
The respondent solicitor cover letter was not sent as it was not added to the list of document types 
to print.

Fixes https://tools.hmcts.net/jira/browse/DIV-5622

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
