### PR TITLE
DIV-6137: more unit tests and clean up

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoERespondentCoverLetterGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoERespondentCoverLetterGenerationTaskTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.Gender;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.DnCourt;
 import uk.gov.hmcts.reform.divorce.orchestration.exception.CourtDetailsNotFound;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.InvalidDataForTaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest;
@@ -70,6 +71,17 @@ public class CoERespondentCoverLetterGenerationTaskTest extends BasePayloadSpeci
     public void setup() throws CourtDetailsNotFound {
         when(ctscContactDetailsDataProviderService.getCtscContactDetails()).thenReturn(CTSC_CONTACT);
         when(courtLookupService.getDnCourtByKey(eq(COURT_ID))).thenReturn(getCourt());
+    }
+
+    @Test(expected = InvalidDataForTaskException.class)
+    public void executeShouldThrowInvalidDataForTaskException() throws TaskException, CourtDetailsNotFound {
+        String invalidCourt = "I don't exist!";
+        Map<String, Object> caseData = buildCaseDataRespondent();
+        caseData.put(COURT_NAME, invalidCourt);
+
+        when(courtLookupService.getDnCourtByKey(eq(invalidCourt))).thenThrow(new CourtDetailsNotFound(invalidCourt));
+
+        coERespondentCoverLetterGenerationTask.execute(prepareTaskContext(), caseData);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentCoverLetterGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentCoverLetterGenerationTaskTest.java
@@ -39,7 +39,7 @@ public class DnGrantedRespondentCoverLetterGenerationTaskTest extends BasePayloa
     }
 
     @Test
-    public void executeShouldPopulateFieldInContextWhenCoRespondentIsNotRepresented() throws TaskException {
+    public void executeShouldPopulateFieldInContextWhenRespondentIsNotRepresented() throws TaskException {
         TaskContext context = prepareTaskContext();
         Map<String, Object> caseData = buildCaseDataWhenRespondentNotRepresented();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentSolicitorCoverLetterGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentSolicitorCoverLetterGenerationTaskTest.java
@@ -43,10 +43,9 @@ public class DnGrantedRespondentSolicitorCoverLetterGenerationTaskTest extends B
     }
 
     @Test
-    public void executeShouldPopulateFieldInContextWhenCoRespondentIsNotRepresented() throws TaskException {
+    public void executeShouldPopulateFieldInContextWhenRespondentIsRepresented() throws TaskException {
         TaskContext context = prepareTaskContext();
-        Map<String, Object> caseData = buildCaseDataWhenRespondentNotRepresented();
-        caseData.put(RESP_SOL_REPRESENTED, YES_VALUE);
+        Map<String, Object> caseData = buildCaseDataWhenRespondentIsRepresented();
 
         Map<String, Object> returnedCaseData = dnGrantedRespondentSolicitorCoverLetterGenerationTask.execute(context, caseData);
 
@@ -76,11 +75,12 @@ public class DnGrantedRespondentSolicitorCoverLetterGenerationTaskTest extends B
             ).build();
     }
 
-    private Map<String, Object> buildCaseDataWhenRespondentNotRepresented() {
+    private Map<String, Object> buildCaseDataWhenRespondentIsRepresented() {
         Map<String, Object> caseData = AddresseeDataExtractorTest.buildCaseDataWithRespondentSolicitor();
 
         caseData.put(PETITIONER_FIRST_NAME, TEST_PETITIONER_FIRST_NAME);
         caseData.put(PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME);
+        caseData.put(RESP_SOL_REPRESENTED, YES_VALUE);
 
         caseData.put(DATETIME_OF_HEARING_CCD_FIELD, createHearingDatesList());
 


### PR DESCRIPTION
Address lacking scenarios from sonar:
1. https://sonarcloud.io/component_measures?id=div-case-orchestration-service&metric=new_coverage&pullRequest=866&selected=div-case-orchestration-service%3Asrc%2Fmain%2Fjava%2Fuk%2Fgov%2Fhmcts%2Freform%2Fdivorce%2Forchestration%2Ftasks%2Fbulk%2Fprinting%2FCoERespondentCoverLetterGenerationTask.java&view=list
2. https://sonarcloud.io/component_measures?id=div-case-orchestration-service&metric=new_coverage&pullRequest=866&selected=div-case-orchestration-service%3Asrc%2Fmain%2Fjava%2Fuk%2Fgov%2Fhmcts%2Freform%2Fdivorce%2Forchestration%2Fworkflows%2FSendDnPronouncedNotificationWorkflow.java&view=list

and rename wrongly named methods in unit tests (coRespondent -> respondent)