### PR TITLE
DIV-6198: Call update case with empty case data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -205,6 +205,7 @@ public class OrchestrationConstants {
     public static final String CASE_ID_JSON_KEY = "caseId";
     public static final String PREVIOUS_CASE_ID_JSON_KEY = "previousCaseId";
     public static final String NEW_AMENDED_PETITION_DRAFT_KEY = "newAmendedPetitionDraft";
+    public static final String NEW_SUBMITTED_CASE_KEY = "newSubmittedCase";
     public static final String CASE_STATE_JSON_KEY = "state";
     public static final String CREATED_DATE_JSON_KEY = "createdDate";
     public static final String ID = "id";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTask.java
@@ -6,9 +6,11 @@ import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_SUBMITTED_CASE_KEY;
 
 @Component
 public class SolicitorSubmitCaseToCCDTask implements Task<Map<String, Object>> {
@@ -22,9 +24,13 @@ public class SolicitorSubmitCaseToCCDTask implements Task<Map<String, Object>> {
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
-        return caseMaintenanceClient.solicitorSubmitCase(
+        final Map<String, Object> submittedCase = caseMaintenanceClient.solicitorSubmitCase(
                 caseData,
                 context.getTransientObject(AUTH_TOKEN_JSON_KEY).toString()
         );
+
+        context.setTransientObject(NEW_SUBMITTED_CASE_KEY, submittedCase);
+        // return empty as next step (update case state) needs no data (empty)
+        return new HashMap<>();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTaskTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -17,9 +18,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_SUBMITTED_CASE_KEY;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SolicitorSubmitCaseToCCDTaskTaskTest {
+public class SolicitorSubmitCaseToCCDTaskTest {
 
     @Mock
     private CaseMaintenanceClient caseMaintenanceClient;
@@ -38,7 +40,8 @@ public class SolicitorSubmitCaseToCCDTaskTaskTest {
 
         when(caseMaintenanceClient.solicitorSubmitCase(testData, AUTH_TOKEN)).thenReturn(resultData);
 
-        assertEquals(resultData, solicitorSubmitCaseToCCD.execute(context, testData));
+        assertEquals(new HashMap<>(), solicitorSubmitCaseToCCD.execute(context, testData));
+        assertEquals(resultData, context.getTransientObject(NEW_SUBMITTED_CASE_KEY));
 
         verify(caseMaintenanceClient).solicitorSubmitCase(testData, AUTH_TOKEN);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflowTest.java
@@ -81,8 +81,8 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflowTest {
         when(createAmendPetitionDraftForRefusalFromCaseIdTask.execute(context, testData)).thenReturn(newDivorceCaseData);
         when(formatDivorceSessionToCaseData.execute(context, newDivorceCaseData)).thenReturn(newCCDCaseData);
         when(validateCaseDataTask.execute(context, newCCDCaseData)).thenReturn(newCCDCaseData);
-        when(solicitorSubmitCaseToCCDTask.execute(context, newCCDCaseData)).thenReturn(newCCDCaseData);
-        when(updateCaseInCCD.execute(context, newCCDCaseData)).thenReturn(testData);
+        when(solicitorSubmitCaseToCCDTask.execute(context, newCCDCaseData)).thenReturn(testData);
+        when(updateCaseInCCD.execute(context, testData)).thenReturn(testData);
 
         assertEquals(testData, createNewAmendedCaseAndSubmitToCCDWorkflow.run(caseDetails, AUTH_TOKEN));
 
@@ -94,7 +94,7 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflowTest {
         inOrder.verify(formatDivorceSessionToCaseData).execute(context, newDivorceCaseData);
         inOrder.verify(validateCaseDataTask).execute(context, newCCDCaseData);
         inOrder.verify(solicitorSubmitCaseToCCDTask).execute(context, newCCDCaseData);
-        inOrder.verify(updateCaseInCCD).execute(context, newCCDCaseData);
+        inOrder.verify(updateCaseInCCD).execute(context, testData);
     }
 
 }


### PR DESCRIPTION
# Description

Testing the new functionality of amending a case with a solicitor (for refusal) on swagger, I saw it was failing on the last task: 'update case'. This is because I was sending some case data to that event (as if it needed to update fields also) whereas it should only update the case state.
I updated the previous task to return empty hashmap so that update case only updates the case state

Fixes https://tools.hmcts.net/jira/browse/DIV-6198

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
