### PR TITLE
DIV-6198: Removing 'update case' from workflow

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -205,7 +205,6 @@ public class OrchestrationConstants {
     public static final String CASE_ID_JSON_KEY = "caseId";
     public static final String PREVIOUS_CASE_ID_JSON_KEY = "previousCaseId";
     public static final String NEW_AMENDED_PETITION_DRAFT_KEY = "newAmendedPetitionDraft";
-    public static final String NEW_SUBMITTED_CASE_KEY = "newSubmittedCase";
     public static final String CASE_STATE_JSON_KEY = "state";
     public static final String CREATED_DATE_JSON_KEY = "createdDate";
     public static final String ID = "id";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTask.java
@@ -6,11 +6,9 @@ import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_SUBMITTED_CASE_KEY;
 
 @Component
 public class SolicitorSubmitCaseToCCDTask implements Task<Map<String, Object>> {
@@ -24,13 +22,9 @@ public class SolicitorSubmitCaseToCCDTask implements Task<Map<String, Object>> {
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
-        final Map<String, Object> submittedCase = caseMaintenanceClient.solicitorSubmitCase(
+        return caseMaintenanceClient.solicitorSubmitCase(
                 caseData,
                 context.getTransientObject(AUTH_TOKEN_JSON_KEY).toString()
         );
-
-        context.setTransientObject(NEW_SUBMITTED_CASE_KEY, submittedCase);
-        // return empty as next step (update case state) needs no data (empty)
-        return new HashMap<>();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflow.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CreateAmendPetitionDraftForRefusalFromCaseIdTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToCaseData;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SolicitorSubmitCaseToCCDTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateCaseDataTask;
 
 import java.util.HashMap;
@@ -25,7 +24,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class CreateNewAmendedCaseAndSubmitToCCDWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     private final CreateAmendPetitionDraftForRefusalFromCaseIdTask createAmendPetitionDraftForRefusalFromCaseId;
-    private final UpdateCaseInCCD updateCaseInCCD;
     private final FormatDivorceSessionToCaseData formatDivorceSessionToCaseData;
     private final ValidateCaseDataTask validateCaseDataTask;
     private final SolicitorSubmitCaseToCCDTask solicitorSubmitCaseToCCD;
@@ -33,10 +31,9 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflow extends DefaultWorkflow<
     @Autowired
     public CreateNewAmendedCaseAndSubmitToCCDWorkflow(
         CreateAmendPetitionDraftForRefusalFromCaseIdTask amendPetitionDraftForRefusalFromCaseId,
-        UpdateCaseInCCD updateCaseInCCD, FormatDivorceSessionToCaseData formatDivorceSessionToCaseData,
-        ValidateCaseDataTask validateCaseDataTask, SolicitorSubmitCaseToCCDTask solicitorSubmitCaseToCCD) {
+        FormatDivorceSessionToCaseData formatDivorceSessionToCaseData, ValidateCaseDataTask validateCaseDataTask,
+        SolicitorSubmitCaseToCCDTask solicitorSubmitCaseToCCD) {
         this.createAmendPetitionDraftForRefusalFromCaseId = amendPetitionDraftForRefusalFromCaseId;
-        this.updateCaseInCCD = updateCaseInCCD;
         this.formatDivorceSessionToCaseData = formatDivorceSessionToCaseData;
         this.validateCaseDataTask = validateCaseDataTask;
         this.solicitorSubmitCaseToCCD = solicitorSubmitCaseToCCD;
@@ -48,9 +45,7 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflow extends DefaultWorkflow<
                 createAmendPetitionDraftForRefusalFromCaseId,
                 formatDivorceSessionToCaseData,
                 validateCaseDataTask,
-                solicitorSubmitCaseToCCD,
-                updateCaseInCCD
-
+                solicitorSubmitCaseToCCD
             },
             new HashMap<>(),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseDetails.getCaseId()),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorAmendPetitionForRefusalITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorAmendPetitionForRefusalITest.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AMEND_PETITION_FOR_REFUSAL_EVENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PREVIOUS_CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
@@ -41,11 +40,6 @@ public class SolicitorAmendPetitionForRefusalITest extends MockedFunctionalTest 
     private static final String CMS_AMEND_PETITION_CONTEXT_PATH = String.format(
         "/casemaintenance/version/1/amended-petition-draft-refusal/%s",
         CASE_ID
-    );
-    private static final String CMS_UPDATE_CONTEXT_PATH = String.format(
-        "/casemaintenance/version/1/updateCase/%s/%s",
-        CASE_ID,
-        AMEND_PETITION_FOR_REFUSAL_EVENT
     );
 
     private static final ValidationResponse validationResponseOk = ValidationResponse.builder().build();
@@ -86,7 +80,6 @@ public class SolicitorAmendPetitionForRefusalITest extends MockedFunctionalTest 
         stubCmsAmendPetitionDraftEndpoint(HttpStatus.OK, content);
         stubFormatterServerEndpoint(HttpStatus.OK, formattedContent);
         stubMaintenanceServerEndpointForSubmit(HttpStatus.OK, formattedContent);
-        stubCmsUpdateCaseEndpoint(HttpStatus.OK, "");
         when(validationService.validate(any())).thenReturn(validationResponseOk);
 
         webClient.perform(post(API_URL)
@@ -98,14 +91,6 @@ public class SolicitorAmendPetitionForRefusalITest extends MockedFunctionalTest 
 
     private void stubCmsAmendPetitionDraftEndpoint(HttpStatus status, String body) {
         maintenanceServiceServer.stubFor(WireMock.put(CMS_AMEND_PETITION_CONTEXT_PATH)
-            .willReturn(aResponse()
-                .withStatus(status.value())
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
-                .withBody(body)));
-    }
-
-    private void stubCmsUpdateCaseEndpoint(HttpStatus status, String body) {
-        maintenanceServiceServer.stubFor(WireMock.post(CMS_UPDATE_CONTEXT_PATH)
             .willReturn(aResponse()
                 .withStatus(status.value())
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SolicitorSubmitCaseToCCDTaskTest.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -18,7 +17,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_SUBMITTED_CASE_KEY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SolicitorSubmitCaseToCCDTaskTest {
@@ -40,8 +38,7 @@ public class SolicitorSubmitCaseToCCDTaskTest {
 
         when(caseMaintenanceClient.solicitorSubmitCase(testData, AUTH_TOKEN)).thenReturn(resultData);
 
-        assertEquals(new HashMap<>(), solicitorSubmitCaseToCCD.execute(context, testData));
-        assertEquals(resultData, context.getTransientObject(NEW_SUBMITTED_CASE_KEY));
+        assertEquals(resultData, solicitorSubmitCaseToCCD.execute(context, testData));
 
         verify(caseMaintenanceClient).solicitorSubmitCase(testData, AUTH_TOKEN);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflowTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CreateAmendPetitionDraftForRefusalFromCaseIdTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToCaseData;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SolicitorSubmitCaseToCCDTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.UpdateCaseInCCD;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateCaseDataTask;
 
 import java.util.HashMap;
@@ -37,8 +36,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RunWith(MockitoJUnitRunner.class)
 public class CreateNewAmendedCaseAndSubmitToCCDWorkflowTest {
 
-    @Mock
-    private UpdateCaseInCCD updateCaseInCCD;
 
     @Mock
     private CreateAmendPetitionDraftForRefusalFromCaseIdTask createAmendPetitionDraftForRefusalFromCaseIdTask;
@@ -81,20 +78,18 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflowTest {
         when(createAmendPetitionDraftForRefusalFromCaseIdTask.execute(context, testData)).thenReturn(newDivorceCaseData);
         when(formatDivorceSessionToCaseData.execute(context, newDivorceCaseData)).thenReturn(newCCDCaseData);
         when(validateCaseDataTask.execute(context, newCCDCaseData)).thenReturn(newCCDCaseData);
-        when(solicitorSubmitCaseToCCDTask.execute(context, newCCDCaseData)).thenReturn(testData);
-        when(updateCaseInCCD.execute(context, testData)).thenReturn(testData);
+        when(solicitorSubmitCaseToCCDTask.execute(context, newCCDCaseData)).thenReturn(newCCDCaseData);
 
         assertEquals(testData, createNewAmendedCaseAndSubmitToCCDWorkflow.run(caseDetails, AUTH_TOKEN));
 
         InOrder inOrder =
             inOrder(createAmendPetitionDraftForRefusalFromCaseIdTask, formatDivorceSessionToCaseData,
-                validateCaseDataTask, solicitorSubmitCaseToCCDTask, updateCaseInCCD);
+                validateCaseDataTask, solicitorSubmitCaseToCCDTask);
 
         inOrder.verify(createAmendPetitionDraftForRefusalFromCaseIdTask).execute(context, testData);
         inOrder.verify(formatDivorceSessionToCaseData).execute(context, newDivorceCaseData);
         inOrder.verify(validateCaseDataTask).execute(context, newCCDCaseData);
         inOrder.verify(solicitorSubmitCaseToCCDTask).execute(context, newCCDCaseData);
-        inOrder.verify(updateCaseInCCD).execute(context, testData);
     }
 
 }


### PR DESCRIPTION
# Description

I noticed that a function I had in COS (i.e. updating the old case to 'amend petition' state) is already done by the event calling this callback.
Removing that functionality

Fixes https://tools.hmcts.net/jira/browse/DIV-6198

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
