### PR TITLE
DIV-6198: Setting amended case id in old case when amending case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -122,6 +122,8 @@ public class OrchestrationConstants {
     public static final String PREVIOUS_CASE_ID_CCD_KEY = "PreviousCaseId";
     public static final String WELSH_NEXT_EVENT = "WelshNextEvent";
     public static final String WELSH_PREVIOUS_STATE = "WelshPreviousState";
+    public static final String AMENDED_CASE_ID_CCD_KEY = "AmendedCaseId";
+    public static final String CASE_REFERENCE_CCD_KEY = "CaseReference";
 
     //This is misspelled in the CCD definition file
     public static final String D_8_REASON_FOR_DIVORCE_SEPARATION_DAY = "D8ReasonForDivorceSeperationDay";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetAmendedCaseIdTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetAmendedCaseIdTask.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseLink;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AMENDED_CASE_ID_CCD_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
+
+@Component
+@RequiredArgsConstructor
+public class SetAmendedCaseIdTask implements Task<Map<String, Object>> {
+
+
+    @Override
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
+        String newCaseId = caseData.get(ID).toString();
+        Map<String, Object> oldCase = context.getTransientObject(CCD_CASE_DATA);
+
+        oldCase.put(AMENDED_CASE_ID_CCD_KEY, new CaseLink(newCaseId));
+
+        return caseData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/CreateNewAmendedCaseAndSubmitToCCDWorkflow.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CopyPetitionerSolicitorDetailsTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CreateAmendPetitionDraftForRefusalFromCaseIdTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FormatDivorceSessionToCaseData;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetAmendedCaseIdTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SolicitorSubmitCaseToCCDTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateCaseDataTask;
 
@@ -30,17 +31,20 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflow extends DefaultWorkflow<
     private final CopyPetitionerSolicitorDetailsTask copyPetitionerSolicitorDetailsTask;
     private final ValidateCaseDataTask validateCaseDataTask;
     private final SolicitorSubmitCaseToCCDTask solicitorSubmitCaseToCCD;
+    private final SetAmendedCaseIdTask setAmendedCaseIdTask;
 
     @Autowired
     public CreateNewAmendedCaseAndSubmitToCCDWorkflow(
         CreateAmendPetitionDraftForRefusalFromCaseIdTask amendPetitionDraftForRefusalFromCaseId,
         FormatDivorceSessionToCaseData formatDivorceSessionToCaseData, CopyPetitionerSolicitorDetailsTask copyPetitionerSolicitorDetailsTask,
-        ValidateCaseDataTask validateCaseDataTask, SolicitorSubmitCaseToCCDTask solicitorSubmitCaseToCCD) {
+        ValidateCaseDataTask validateCaseDataTask, SolicitorSubmitCaseToCCDTask solicitorSubmitCaseToCCD,
+        SetAmendedCaseIdTask setAmendedCaseIdTask) {
         this.createAmendPetitionDraftForRefusalFromCaseId = amendPetitionDraftForRefusalFromCaseId;
         this.formatDivorceSessionToCaseData = formatDivorceSessionToCaseData;
         this.copyPetitionerSolicitorDetailsTask = copyPetitionerSolicitorDetailsTask;
         this.validateCaseDataTask = validateCaseDataTask;
         this.solicitorSubmitCaseToCCD = solicitorSubmitCaseToCCD;
+        this.setAmendedCaseIdTask = setAmendedCaseIdTask;
     }
 
     public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
@@ -50,7 +54,8 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflow extends DefaultWorkflow<
                 formatDivorceSessionToCaseData,
                 copyPetitionerSolicitorDetailsTask,
                 validateCaseDataTask,
-                solicitorSubmitCaseToCCD
+                solicitorSubmitCaseToCCD,
+                setAmendedCaseIdTask
             },
             new HashMap<>(),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseDetails.getCaseId()),
@@ -59,6 +64,6 @@ public class CreateNewAmendedCaseAndSubmitToCCDWorkflow extends DefaultWorkflow<
             ImmutablePair.of(CASE_EVENT_ID_JSON_KEY, AMEND_PETITION_FOR_REFUSAL_EVENT)
         );
 
-        return caseDetails.getCaseData();
+        return getContext().getTransientObject(CCD_CASE_DATA);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CopyPetitionerSolicitorDetailsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/CopyPetitionerSolicitorDetailsTaskTest.java
@@ -36,7 +36,7 @@ public class CopyPetitionerSolicitorDetailsTaskTest {
     private CopyPetitionerSolicitorDetailsTask copyPetitionerSolicitorDetailsTask;
 
     @Test
-    public void executeShouldCallCaseMaintenanceClientSolicitorSubmitEndpoint() {
+    public void executeShouldCopyPetitionerSolicitorDetailsToNewCase() {
         Map<String, String> oldCaseData = new HashMap<>();
         final Map<String, Object> newCaseData = new HashMap<>();
         final TaskContext context = new DefaultTaskContext();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetAmendedCaseIdTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetAmendedCaseIdTaskTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseLink;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AMENDED_CASE_ID_CCD_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CCD_CASE_DATA;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetAmendedCaseIdTaskTest {
+
+    @InjectMocks
+    private SetAmendedCaseIdTask setAmendedCaseIdTask;
+
+    @Test
+    public void executeShouldSetAmendedCaseId() {
+        final Map<String, Object> oldCaseData = new HashMap<>();
+        final Map<String, Object> newCaseData = new HashMap<>(ImmutableMap.of(ID, TEST_CASE_ID));
+        final Map<String, Object> expectedCaseData = new HashMap<>(ImmutableMap.of(
+            AMENDED_CASE_ID_CCD_KEY, new CaseLink(TEST_CASE_ID)
+        ));
+
+        final TaskContext context = new DefaultTaskContext();
+        context.setTransientObject(CCD_CASE_DATA, oldCaseData);
+
+        setAmendedCaseIdTask.execute(context, newCaseData);
+
+        assertEquals(expectedCaseData, context.getTransientObject(CCD_CASE_DATA));
+
+    }
+}


### PR DESCRIPTION
# Description

A new task is created so that when a case is amended (by a petitioner solicitor), a link to the new amended case is displayed in the 'old' case, under the 'linked cases' tab.

Fixes https://tools.hmcts.net/jira/browse/DIV-6436

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
