### PR TITLE
Fix for Hibernate vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,10 @@ allprojects {
                 entry 'tomcat-embed-websocket'
                 entry 'tomcat-embed-el'
             }
+            //CVE-2019-14900
+            dependencySet(group: 'org.hibernate', version: '5.4.18.Final') {
+                entry 'hibernate-core'
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

Updated Hibernate-core version to be used to fix the following issue appearing in our builds:

`One or more dependencies were identified with known vulnerabilities in div-case-orchestration-service:

[2020-07-15T10:37:03.329Z] 

[2020-07-15T10:37:03.329Z] hibernate-core-5.3.17.Final.jar (pkg:maven/org.hibernate/hibernate-core@5.3.17.Final, cpe:2.3:a:hibernate:hibernate_orm:5.3.17:*:*:*:*:*:*:*) : CVE-2019-14900`