### PR TITLE
DIV-6196: Add solicitor task to email trigger

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerSubmissionNotificationEmailTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerSubmissionNotificationEmailTask.java
@@ -41,9 +41,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.util.PartyRepresentation
 @RequiredArgsConstructor
 public class SendPetitionerSubmissionNotificationEmailTask implements Task<Map<String, Object>> {
 
-    private static final String SUBMITTED_DESC = "Submission Notification - Petitioner";
-    private static final String AMEND_DESC = "Submission Notification For Amend - Petitioner";
-    private static final String AMEND_SOL_DESC = "Submission Notification For Amend - Solicitor";
+    public static final String SUBMITTED_DESC = "Submission Notification - Petitioner";
+    public static final String AMEND_DESC = "Submission Notification For Amend - Petitioner";
+    public static final String AMEND_SOL_DESC = "Submission Notification For Amend - Solicitor";
 
     private final EmailService emailService;
     private final TaskCommons taskCommons;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflow.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ProcessPbaPayment;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.RemoveMiniPetitionDraftDocumentsTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerSubmissionNotificationEmailTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateSolicitorCaseData;
 
 import java.util.Map;
@@ -16,28 +17,22 @@ import java.util.Map;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
+@RequiredArgsConstructor
 @Component
 public class SolicitorSubmissionWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     private final ValidateSolicitorCaseData validateSolicitorCaseData;
     private final ProcessPbaPayment processPbaPayment;
     private final RemoveMiniPetitionDraftDocumentsTask removeMiniPetitionDraftDocumentsTask;
-
-    @Autowired
-    public SolicitorSubmissionWorkflow(ProcessPbaPayment processPbaPayment,
-                                       ValidateSolicitorCaseData validateSolicitorCaseData,
-                                       RemoveMiniPetitionDraftDocumentsTask removeMiniPetitionDraftDocumentsTask) {
-        this.validateSolicitorCaseData = validateSolicitorCaseData;
-        this.processPbaPayment = processPbaPayment;
-        this.removeMiniPetitionDraftDocumentsTask = removeMiniPetitionDraftDocumentsTask;
-    }
+    private final SendPetitionerSubmissionNotificationEmailTask sendPetitionerSubmissionNotificationEmailTask;
 
     public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException {
 
         return this.execute(new Task[] {
             validateSolicitorCaseData,
             processPbaPayment,
-            removeMiniPetitionDraftDocumentsTask
+            removeMiniPetitionDraftDocumentsTask,
+            sendPetitionerSubmissionNotificationEmailTask
         },
             ccdCallbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflow.java
@@ -28,7 +28,7 @@ public class SolicitorSubmissionWorkflow extends DefaultWorkflow<Map<String, Obj
 
     public Map<String, Object> run(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException {
 
-        return this.execute(new Task[] {
+        return this.execute(new Task[]{
             validateSolicitorCaseData,
             processPbaPayment,
             removeMiniPetitionDraftDocumentsTask,

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentITest.java
@@ -37,6 +37,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_FEE_A
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_FEE_CODE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_FEE_DESCRIPTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_FEE_VERSION;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SERVICE_AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_ACCOUNT_NUMBER;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_FIRM_NAME;
@@ -45,6 +46,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CURRENCY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_CENTRE_SITEID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_PAY_BY_ACCOUNT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITION_ISSUE_ORDER_SUMMARY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE;
@@ -94,7 +97,9 @@ public class ProcessPbaPaymentITest extends MockedFunctionalTest {
         caseData.put(SOLICITOR_HOW_TO_PAY_JSON_KEY, FEE_PAY_BY_ACCOUNT);
         caseData.put(PETITION_ISSUE_ORDER_SUMMARY_JSON_KEY, orderSummary);
         caseData.put(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        caseData.put(D_8_PETITIONER_EMAIL, TEST_PETITIONER_EMAIL);
         caseData.put(DIVORCE_CENTRE_SITEID_JSON_KEY, CourtEnum.EASTMIDLANDS.getSiteId());
+        caseData.put(DIVORCE_UNIT_JSON_KEY, CourtEnum.EASTMIDLANDS.getId());
         caseData.put(SOLICITOR_FEE_ACCOUNT_NUMBER_JSON_KEY, TEST_SOLICITOR_ACCOUNT_NUMBER);
         caseData.put(SOLICITOR_FIRM_JSON_KEY, TEST_SOLICITOR_FIRM_NAME);
         caseData.put(SOLICITOR_REFERENCE_JSON_KEY, TEST_SOLICITOR_REFERENCE);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerSubmissionNotificationEmailTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SendPetitionerSubmissionNotificationEmailTaskTest.java
@@ -120,7 +120,6 @@ public class SendPetitionerSubmissionNotificationEmailTaskTest {
         testData.put(RESP_LAST_NAME_CCD_FIELD, TEST_RESPONDENT_LAST_NAME);
         testData.put(DIVORCE_UNIT_JSON_KEY, TEST_COURT_KEY);
         testData.put(PREVIOUS_CASE_ID_CCD_KEY, Collections.singletonMap(CASE_REFERENCE_KEY, TEST_CASE_ID));
-
     }
 
     private void mockTestCourtsLookup() throws TaskException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflowTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Default
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ProcessPbaPayment;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.RemoveMiniPetitionDraftDocumentsTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SendPetitionerSubmissionNotificationEmailTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateSolicitorCaseData;
 
 import java.util.Collections;
@@ -40,6 +41,9 @@ public class SolicitorSubmissionWorkflowTest {
 
     @Mock
     private RemoveMiniPetitionDraftDocumentsTask removeMiniPetitionDraftDocumentsTask;
+
+    @Mock
+    private SendPetitionerSubmissionNotificationEmailTask sendPetitionerSubmissionNotificationEmailTask;
 
     @InjectMocks
     private SolicitorSubmissionWorkflow solicitorSubmissionWorkflow;
@@ -76,13 +80,20 @@ public class SolicitorSubmissionWorkflowTest {
         when(validateSolicitorCaseData.execute(context, testData)).thenReturn(testData);
         when(processPbaPayment.execute(context, testData)).thenReturn(testData);
         when(removeMiniPetitionDraftDocumentsTask.execute(context, testData)).thenReturn(testData);
+        when(sendPetitionerSubmissionNotificationEmailTask.execute(context, testData)).thenReturn(testData);
 
         assertEquals(testData, solicitorSubmissionWorkflow.run(ccdCallbackRequestRequest, AUTH_TOKEN));
 
-        InOrder inOrder = inOrder(validateSolicitorCaseData, processPbaPayment, removeMiniPetitionDraftDocumentsTask);
+        InOrder inOrder = inOrder(
+            validateSolicitorCaseData,
+            processPbaPayment,
+            removeMiniPetitionDraftDocumentsTask,
+            sendPetitionerSubmissionNotificationEmailTask
+        );
 
         inOrder.verify(validateSolicitorCaseData).execute(context, testData);
         inOrder.verify(processPbaPayment).execute(context, testData);
         inOrder.verify(removeMiniPetitionDraftDocumentsTask).execute(context, testData);
+        inOrder.verify(sendPetitionerSubmissionNotificationEmailTask).execute(context, testData);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorSubmissionWorkflowTest.java
@@ -62,13 +62,13 @@ public class SolicitorSubmissionWorkflowTest {
             .caseData(testData)
             .build();
         ccdCallbackRequestRequest =
-                CcdCallbackRequest.builder()
-                        .eventId(TEST_EVENT_ID)
-                        .token(TEST_TOKEN)
-                        .caseDetails(
-                            caseDetails
-                        )
-                        .build();
+            CcdCallbackRequest.builder()
+                .eventId(TEST_EVENT_ID)
+                .token(TEST_TOKEN)
+                .caseDetails(
+                    caseDetails
+                )
+                .build();
 
         context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);


### PR DESCRIPTION
# Description

This adds the `sendPetitionerSubmissionNotificationEmailTask` to the 

Solicitor
Event: `solicitorStatementOfTruthPaySubmit`
Endpoint: "CallBackURLAboutToSubmitEvent":"${CCD_DEF_COS_URL}/process-pba-payment",
Email triggered: sendPetitionerSubmissionNotificationEmailTask (if represented)

https://tools.hmcts.net/jira/browse/DIV-6196