### PR TITLE
DIV-5411: rename serviceApplicationGranted -> ServiceApplicationGranted

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.divorce.orchestration.domain.model;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CcdFields {
+    public static final String SERVICE_APPLICATION_GRANTED = "ServiceApplicationGranted";
+    public static final String SERVICE_APPLICATION_DECISION_DATE = "ServiceApplicationDecisionDate";
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -146,7 +146,6 @@ public class OrchestrationConstants {
     public static final String DN_REFUSED_ADMIN_ERROR_OPTION = "adminError";
     public static final String DN_APPLICATION_SUBMITTED_DATE = "DNApplicationSubmittedDate";
     public static final String DN_REFUSAL_DRAFT = "DNRefusalDraft";
-    public static final String SERVICE_APPLICATION_GRANTED = "serviceApplicationGranted";
 
     // CCD Events
     public static final String DN_RECEIVED = "dnReceived";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
@@ -15,7 +16,7 @@ import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_DN_APPLICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_APPLICATION_GRANTED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @Component
@@ -48,6 +49,8 @@ public class ServiceJourneyServiceImpl implements ServiceJourneyService {
     }
 
     protected boolean isServiceApplicationGranted(CaseDetails caseDetails) {
-        return YES_VALUE.equalsIgnoreCase((String) caseDetails.getCaseData().get(SERVICE_APPLICATION_GRANTED));
+        return YES_VALUE.equalsIgnoreCase(
+            (String) caseDetails.getCaseData().get(CcdFields.SERVICE_APPLICATION_GRANTED)
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/MakeServiceDecisionDateTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/MakeServiceDecisionDateTask.java
@@ -2,16 +2,15 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.generics.DateFieldSetupTask;
 
 @Component
 @RequiredArgsConstructor
 public class MakeServiceDecisionDateTask extends DateFieldSetupTask {
 
-    public static final String SERVICE_APPLICATION_DECISION_DATE = "ServiceApplicationDecisionDate";
-
     @Override
     protected String getFieldName() {
-        return SERVICE_APPLICATION_DECISION_DATE;
+        return CcdFields.SERVICE_APPLICATION_DECISION_DATE;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionDateTest.java
@@ -5,9 +5,9 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.MakeServiceDecisionDateTask;
 import uk.gov.hmcts.reform.divorce.utils.DateUtils;
 
 import java.time.LocalDate;
@@ -38,7 +38,7 @@ public class MakeServiceDecisionDateTest extends IdamTestSupport {
         );
 
         Map<String, Object> expectedCaseData = ImmutableMap.of(
-            MakeServiceDecisionDateTask.SERVICE_APPLICATION_DECISION_DATE,
+            CcdFields.SERVICE_APPLICATION_DECISION_DATE,
             DateUtils.formatDateFromLocalDate(LocalDate.now())
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImplTest.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
@@ -23,7 +24,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_DN_APPLICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_APPLICATION_GRANTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -61,7 +61,7 @@ public class ServiceJourneyServiceImplTest extends TestCase {
 
     protected void runTestMakeServiceDecision(String decision, String expectedState)
         throws WorkflowException {
-        Map<String, Object> payload = ImmutableMap.of(SERVICE_APPLICATION_GRANTED, decision);
+        Map<String, Object> payload = ImmutableMap.of(CcdFields.SERVICE_APPLICATION_GRANTED, decision);
         CaseDetails caseDetails = CaseDetails.builder().caseData(payload).build();
 
         when(makeServiceDecisionDateWorkflow.run(caseDetails)).thenReturn(payload);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/MakeServiceDecisionDateTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/MakeServiceDecisionDateTaskTest.java
@@ -31,7 +31,7 @@ public class MakeServiceDecisionDateTaskTest extends TestCase {
         assertThat(returnedCaseData.isEmpty(), is(false));
         assertSame(returnedCaseData, caseData);
         assertThat(
-            returnedCaseData.get(MakeServiceDecisionDateTask.SERVICE_APPLICATION_DECISION_DATE),
+            returnedCaseData.get(makeServiceDecisionDateTask.getFieldName()),
             is(DateUtils.formatDateFromLocalDate(LocalDate.now()))
         );
     }


### PR DESCRIPTION
Simple mistake - wrong name of field. Should be capitalised. 

https://tools.hmcts.net/jira/browse/DIV-5411

Extracted these 2 new fields from OrchestrationConstants class and this is the very first step to move all Fields names from this huge mistake into a smaller class with clear purpose.