### PR TITLE
DIV-6237: added task to generate Order to Dispense

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ plugins {
 def versions = [
         awaitility                   : '4.0.2',
         bcpkixJdk15on                : '1.64',
-        bspCommonLib                 : '0.0.43',
+        bspCommonLib                 : '0.0.46',
         ccdStoreClient               : '4.6.4',
         commonsBeanUtils             : '1.9.4',
         commonsIo                    : '2.6',

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -1139,9 +1139,14 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> makeServiceDecision(
+        @RequestHeader(AUTHORIZATION_HEADER)
+        @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
-        return ResponseEntity.ok(serviceJourneyService.makeServiceDecision(ccdCallbackRequest.getCaseDetails()));
+        return ResponseEntity.ok(
+            serviceJourneyService
+                .makeServiceDecision(ccdCallbackRequest.getCaseDetails(), authorizationToken)
+        );
     }
 
     private List<String> getErrors(Map<String, Object> response) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CcdFields {
+    public static final String SERVICE_APPLICATION_TYPE = "ServiceApplicationType";
     public static final String SERVICE_APPLICATION_GRANTED = "ServiceApplicationGranted";
     public static final String SERVICE_APPLICATION_DECISION_DATE = "ServiceApplicationDecisionDate";
+    public static final String RECEIVED_SERVICE_APPLICATION_DATE = "ReceivedServiceApplicationDate";
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/document/ApplicationServiceTypes.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/document/ApplicationServiceTypes.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.divorce.orchestration.domain.model.document;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApplicationServiceTypes {
+    public static final String DISPENSED = "dispensed";
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/document/OrderToDispense.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/document/OrderToDispense.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.divorce.orchestration.domain.model.document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import uk.gov.hmcts.reform.bsp.common.model.document.CtscContactDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
+
+@Data
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@ToString(callSuper = true)
+public class OrderToDispense extends DocmosisTemplateVars {
+
+    @JsonProperty("documentIssuedOn")
+    private String documentIssuedOn;
+
+    @JsonProperty("receivedServiceApplicationDate")
+    private String receivedServiceApplicationDate;
+
+    @JsonProperty("serviceApplicationDecisionDate")
+    private String serviceApplicationDecisionDate;
+
+    @Builder(builderMethodName = "orderToDispenseBuilder")
+    public OrderToDispense(
+        CtscContactDetails ctscContactDetails,
+        String caseReference,
+        String letterDate,
+        String petitionerFullName,
+        String respondentFullName,
+        String documentIssuedOn,
+        String receivedServiceApplicationDate,
+        String serviceApplicationDecisionDate) {
+        super(ctscContactDetails, caseReference, letterDate, petitionerFullName, respondentFullName);
+        this.documentIssuedOn = documentIssuedOn;
+        this.receivedServiceApplicationDate = receivedServiceApplicationDate;
+        this.serviceApplicationDecisionDate = serviceApplicationDecisionDate;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/ServiceJourneyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/ServiceJourneyService.java
@@ -8,7 +8,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import java.util.Map;
 
 public interface ServiceJourneyService {
-    CcdCallbackResponse makeServiceDecision(CaseDetails caseDetails) throws WorkflowException;
+    CcdCallbackResponse makeServiceDecision(CaseDetails caseDetails, String authorisation) throws WorkflowException;
 
     Map<String, Object> receivedServiceAddedDate(CcdCallbackRequest ccdCallbackRequest) throws WorkflowException;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractor.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.helper.ExtractorHelper.getMandatoryStringValue;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CaseDataExtractor {
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CaseDataKeys {
+        public static final String CASE_REFERENCE = OrchestrationConstants.D_8_CASE_REFERENCE;
+    }
+
+    public static String getCaseReference(Map<String, Object> caseData) {
+        return getMandatoryStringValue(caseData, CaseDataKeys.CASE_REFERENCE);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CtscContactDetailsDataProviderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CtscContactDetailsDataProviderService.java
@@ -11,7 +11,7 @@ public class CtscContactDetailsDataProviderService {
     private String serviceCentre;
 
     @Value("${court.locations.serviceCentre.divorceCentreName}")
-    private String careOf;
+    private String centreName;
 
     @Value("${court.locations.serviceCentre.poBox}")
     private String poBox;
@@ -34,7 +34,8 @@ public class CtscContactDetailsDataProviderService {
     public CtscContactDetails getCtscContactDetails() {
         return CtscContactDetails.builder()
             .serviceCentre(serviceCentre)
-            .careOf("c/o " + careOf)
+            .centreName(centreName)
+            .careOf("c/o " + centreName)
             .poBox(poBox)
             .town(town)
             .postcode(postcode)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/DatesDataExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/DatesDataExtractor.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextract
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.InvalidDataForTaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
@@ -24,6 +25,8 @@ public class DatesDataExtractor {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class CaseDataKeys {
         public static final String DA_GRANTED_DATE = OrchestrationConstants.DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD;
+        public static final String RECEIVED_SERVICE_APPLICATION_DATE = CcdFields.RECEIVED_SERVICE_APPLICATION_DATE;
+        public static final String SERVICE_APPLICATION_DECISION_DATE = CcdFields.SERVICE_APPLICATION_DECISION_DATE;
     }
 
     public static String getHearingDate(Map<String, Object> caseData) {
@@ -38,6 +41,18 @@ public class DatesDataExtractor {
 
     public static String getLetterDate() {
         return formatDateWithCustomerFacingFormat(LocalDate.now(ZONE_ID));
+    }
+
+    public static String getReceivedServiceApplicationDate(Map<String, Object> caseData) {
+        return formatDateWithCustomerFacingFormat(
+            getMandatoryStringValue(caseData, CaseDataKeys.RECEIVED_SERVICE_APPLICATION_DATE)
+        );
+    }
+
+    public static String getServiceApplicationDecisionDate(Map<String, Object> caseData) {
+        return formatDateWithCustomerFacingFormat(
+            getMandatoryStringValue(caseData, CaseDataKeys.SERVICE_APPLICATION_DECISION_DATE)
+        );
     }
 
     public static String getDaGrantedDate(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImpl.java
@@ -28,7 +28,7 @@ public class ServiceJourneyServiceImpl implements ServiceJourneyService {
     private final ReceivedServiceAddedDateWorkflow receivedServiceAddedDateWorkflow;
 
     @Override
-    public CcdCallbackResponse makeServiceDecision(CaseDetails caseDetails) throws WorkflowException {
+    public CcdCallbackResponse makeServiceDecision(CaseDetails caseDetails, String authorisation) throws WorkflowException {
         CcdCallbackResponse.CcdCallbackResponseBuilder builder = CcdCallbackResponse.builder();
 
         if (isServiceApplicationGranted(caseDetails)) {
@@ -37,7 +37,7 @@ public class ServiceJourneyServiceImpl implements ServiceJourneyService {
             builder.state(SERVICE_APPLICATION_NOT_APPROVED);
         }
 
-        builder.data(makeServiceDecisionDateWorkflow.run(caseDetails));
+        builder.data(makeServiceDecisionDateWorkflow.run(caseDetails, authorisation));
 
         return builder.build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
@@ -21,13 +20,21 @@ import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.get
  * It should be used as a base class to prepare data models with set of data needed to generate PDFs.
  * These documents will then be added to the case data.
  */
-@AllArgsConstructor
 @Slf4j
 public abstract class BasePayloadSpecificDocumentGenerationTask implements Task<Map<String, Object>> {
 
-    final CtscContactDetailsDataProviderService ctscContactDetailsDataProviderService;
+    protected final CtscContactDetailsDataProviderService ctscContactDetailsDataProviderService;
     private final PdfDocumentGenerationService pdfDocumentGenerationService;
     private final CcdUtil ccdUtil;
+
+    public BasePayloadSpecificDocumentGenerationTask(
+        CtscContactDetailsDataProviderService ctscContactDetailsDataProviderService,
+        PdfDocumentGenerationService pdfDocumentGenerationService,
+        CcdUtil ccdUtil) {
+        this.ctscContactDetailsDataProviderService = ctscContactDetailsDataProviderService;
+        this.pdfDocumentGenerationService = pdfDocumentGenerationService;
+        this.ccdUtil = ccdUtil;
+    }
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) throws TaskException {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
@@ -47,7 +47,7 @@ public abstract class BasePayloadSpecificDocumentGenerationTask implements Task<
         return ccdUtil.addNewDocumentsToCaseData(caseData, singletonList(documentInfo));
     }
 
-    protected abstract DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException;
+    protected abstract DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData);
 
     protected GeneratedDocumentInfo generatePdf(TaskContext context, DocmosisTemplateVars templateModel) throws TaskException {
         log.info("Case {}: Generating document from {}", getCaseId(context), getTemplateId());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoECoRespondentCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoECoRespondentCoverLetterGenerationTask.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.Docmosi
 import uk.gov.hmcts.reform.divorce.orchestration.exception.CourtDetailsNotFound;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.InvalidDataForTaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CoECoverLetterDataExtractor;
@@ -47,8 +46,7 @@ public class CoECoRespondentCoverLetterGenerationTask extends BasePayloadSpecifi
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData)
-        throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return CoECoverLetter.coECoverLetterBuilder()
             .caseReference(getCaseId(context))
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoERespondentCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoERespondentCoverLetterGenerationTask.java
@@ -8,7 +8,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.Docmosi
 import uk.gov.hmcts.reform.divorce.orchestration.exception.CourtDetailsNotFound;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.InvalidDataForTaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CoECoverLetterDataExtractor;
@@ -44,7 +43,7 @@ public class CoERespondentCoverLetterGenerationTask extends BasePayloadSpecificD
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return CoERespondentCoverLetter.coERespondentCoverLetterBuilder()
             .petitionerFullName(FullNamesDataExtractor.getPetitionerFullName(caseData))
             .respondentFullName(FullNamesDataExtractor.getRespondentFullName(caseData))

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoERespondentSolicitorLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CoERespondentSolicitorLetterGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.CoERespondentSolicitorCoverLetter;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CoECoverLetterDataExtractor;
@@ -38,19 +37,19 @@ public class CoERespondentSolicitorLetterGenerationTask extends BasePayloadSpeci
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return CoERespondentSolicitorCoverLetter.coERespondentSolicitorCoverLetterBuilder()
-                .petitionerFullName(FullNamesDataExtractor.getPetitionerFullName(caseData))
-                .respondentFullName(FullNamesDataExtractor.getRespondentFullName(caseData))
-                .caseReference(getCaseId(context))
-                .letterDate(DatesDataExtractor.getLetterDate())
-                .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
-                .hearingDate(DatesDataExtractor.getHearingDate(caseData))
-                .costClaimGranted(CoECoverLetterDataExtractor.isCostsClaimGranted(caseData))
-                .deadlineToContactCourtBy(DatesDataExtractor.getDeadlineToContactCourtBy(caseData))
-                .addressee(AddresseeDataExtractor.getRespondentSolicitor(caseData))
-                .solicitorReference(SolicitorDataExtractor.getSolicitorReference(caseData))
-                .build();
+            .petitionerFullName(FullNamesDataExtractor.getPetitionerFullName(caseData))
+            .respondentFullName(FullNamesDataExtractor.getRespondentFullName(caseData))
+            .caseReference(getCaseId(context))
+            .letterDate(DatesDataExtractor.getLetterDate())
+            .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
+            .hearingDate(DatesDataExtractor.getHearingDate(caseData))
+            .costClaimGranted(CoECoverLetterDataExtractor.isCostsClaimGranted(caseData))
+            .deadlineToContactCourtBy(DatesDataExtractor.getDeadlineToContactCourtBy(caseData))
+            .addressee(AddresseeDataExtractor.getRespondentSolicitor(caseData))
+            .solicitorReference(SolicitorDataExtractor.getSolicitorReference(caseData))
+            .build();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CostOrderCoRespondentCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CostOrderCoRespondentCoverLetterGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.CoRespondentCostOrderCoverLetter;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
@@ -36,7 +35,7 @@ public class CostOrderCoRespondentCoverLetterGenerationTask extends BasePayloadS
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return CoRespondentCostOrderCoverLetter.coRespondentCostOrderCoverLetterBuilder()
             .caseReference(getCaseId(context))
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CostOrderCoRespondentSolicitorCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/CostOrderCoRespondentSolicitorCoverLetterGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.CoRespondentCostOrderCoverLetter;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
@@ -36,7 +35,7 @@ public class CostOrderCoRespondentSolicitorCoverLetterGenerationTask extends Bas
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return CoRespondentCostOrderCoverLetter.coRespondentCostOrderCoverLetterBuilder()
             .caseReference(getCaseId(context))
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DaGrantedCitizenLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DaGrantedCitizenLetterGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.BasicCoverLetter;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
@@ -36,7 +35,7 @@ public class DaGrantedCitizenLetterGenerationTask extends BasePayloadSpecificDoc
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return BasicCoverLetter.basicCoverLetterBuilder()
             .caseReference(getCaseId(context))
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DaGrantedSolicitorLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DaGrantedSolicitorLetterGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DaGrantedRespondentSolicitorCoverLetter;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
@@ -37,7 +36,7 @@ public class DaGrantedSolicitorLetterGenerationTask extends BasePayloadSpecificD
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return DaGrantedRespondentSolicitorCoverLetter.daGrantedRespondentSolicitorCoverLetterBuilder()
             .caseReference(getCaseId(context))
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentCoverLetterGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.CoEBasicCoverLetter;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CoECoverLetterDataExtractor;
@@ -36,7 +35,7 @@ public class DnGrantedRespondentCoverLetterGenerationTask extends BasePayloadSpe
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return CoEBasicCoverLetter.coEBasicCoverLetterBuilder()
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
             .addressee(AddresseeDataExtractor.getRespondent(caseData))

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentSolicitorCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/DnGrantedRespondentSolicitorCoverLetterGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.CoERespondentSolicitorCoverLetter;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CoECoverLetterDataExtractor;
@@ -37,7 +36,7 @@ public class DnGrantedRespondentSolicitorCoverLetterGenerationTask extends BaseP
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return CoERespondentSolicitorCoverLetter.coERespondentSolicitorCoverLetterBuilder()
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
             .addressee(AddresseeDataExtractor.getRespondentSolicitor(caseData))

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTask.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.OrderToDispense;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor;
@@ -35,7 +34,7 @@ public class OrderToDispenseGenerationTask extends BasePayloadSpecificDocumentGe
     }
 
     @Override
-    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return OrderToDispense.orderToDispenseBuilder()
             .caseReference(getCaseId(context))
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTask.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.Docmosi
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.OrderToDispense;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CaseDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor;
@@ -14,8 +15,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BasePayload
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
 import java.util.Map;
-
-import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
 
 @Component
 public class OrderToDispenseGenerationTask extends BasePayloadSpecificDocumentGenerationTask {
@@ -36,7 +35,7 @@ public class OrderToDispenseGenerationTask extends BasePayloadSpecificDocumentGe
     @Override
     protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return OrderToDispense.orderToDispenseBuilder()
-            .caseReference(getCaseId(context))
+            .caseReference(CaseDataExtractor.getCaseReference(caseData))
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
             .petitionerFullName(FullNamesDataExtractor.getPetitionerFullName(caseData))
             .respondentFullName(FullNamesDataExtractor.getRespondentFullName(caseData))

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTask.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.DocmosisTemplateVars;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.OrderToDispense;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BasePayloadSpecificDocumentGenerationTask;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
+
+@Component
+public class OrderToDispenseGenerationTask extends BasePayloadSpecificDocumentGenerationTask {
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class FileMetadata {
+        public static final String TEMPLATE_ID = "FL-DIV-DEC-ENG-00531.docx";
+        public static final String DOCUMENT_TYPE = "dispenseWithServiceGranted";
+    }
+
+    public OrderToDispenseGenerationTask(
+        CtscContactDetailsDataProviderService ctscContactDetailsDataProviderService,
+        PdfDocumentGenerationService pdfDocumentGenerationService,
+        CcdUtil ccdUtil) {
+        super(ctscContactDetailsDataProviderService, pdfDocumentGenerationService, ccdUtil);
+    }
+
+    @Override
+    protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) throws TaskException {
+        return OrderToDispense.orderToDispenseBuilder()
+            .caseReference(getCaseId(context))
+            .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
+            .petitionerFullName(FullNamesDataExtractor.getPetitionerFullName(caseData))
+            .respondentFullName(FullNamesDataExtractor.getRespondentFullName(caseData))
+            .documentIssuedOn(DatesDataExtractor.getLetterDate())
+            .receivedServiceApplicationDate(DatesDataExtractor.getReceivedServiceApplicationDate(caseData))
+            .serviceApplicationDecisionDate(DatesDataExtractor.getServiceApplicationDecisionDate(caseData))
+            .build();
+    }
+
+    @Override
+    public String getTemplateId() {
+        return FileMetadata.TEMPLATE_ID;
+    }
+
+    @Override
+    public String getDocumentType() {
+        return FileMetadata.DOCUMENT_TYPE;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/MakeServiceDecisionDateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/MakeServiceDecisionDateWorkflow.java
@@ -42,10 +42,10 @@ public class MakeServiceDecisionDateWorkflow extends DefaultWorkflow<Map<String,
         tasks.add(makeServiceDecisionDateTask);
 
         if (isServiceApplicationDispensed(caseDetails.getCaseData())) {
-            log.info("CaseID: {} application type = disperse. Order to dispense will be generated", caseId);
+            log.info("CaseID: {} application type = dispensed. Order to Dispense will be generated", caseId);
             tasks.add(orderToDispenseGenerationTask);
         } else {
-            log.info("CaseID: {} application type is not disperse. No pdf will be generated", caseId);
+            log.info("CaseID: {} application type is not dispensed. No pdf will be generated", caseId);
         }
 
         return this.execute(

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/MakeServiceDecisionDateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/MakeServiceDecisionDateWorkflow.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
 @Component
@@ -30,7 +31,7 @@ public class MakeServiceDecisionDateWorkflow extends DefaultWorkflow<Map<String,
         this.orderToDispenseGenerationTask = orderToDispenseGenerationTask;
     }
 
-    public Map<String, Object> run(CaseDetails caseDetails) throws WorkflowException {
+    public Map<String, Object> run(CaseDetails caseDetails, String auth) throws WorkflowException {
 
         String caseId = caseDetails.getCaseId();
 
@@ -50,7 +51,8 @@ public class MakeServiceDecisionDateWorkflow extends DefaultWorkflow<Map<String,
         return this.execute(
             tasks.toArray(new Task[0]),
             caseDetails.getCaseData(),
-            ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
+            ImmutablePair.of(CASE_ID_JSON_KEY, caseId),
+            ImmutablePair.of(AUTH_TOKEN_JSON_KEY, auth)
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/MakeServiceDecisionDateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/MakeServiceDecisionDateWorkflow.java
@@ -1,38 +1,60 @@
 package uk.gov.hmcts.reform.divorce.orchestration.workflows.servicejourney;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.MakeServiceDecisionDateTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.OrderToDispenseGenerationTask;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class MakeServiceDecisionDateWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     private final MakeServiceDecisionDateTask makeServiceDecisionDateTask;
+    private final OrderToDispenseGenerationTask orderToDispenseGenerationTask;
+
+    public MakeServiceDecisionDateWorkflow(MakeServiceDecisionDateTask makeServiceDecisionDateTask,
+                                           OrderToDispenseGenerationTask orderToDispenseGenerationTask) {
+        this.makeServiceDecisionDateTask = makeServiceDecisionDateTask;
+        this.orderToDispenseGenerationTask = orderToDispenseGenerationTask;
+    }
 
     public Map<String, Object> run(CaseDetails caseDetails) throws WorkflowException {
 
         String caseId = caseDetails.getCaseId();
 
-        log.info("CaseID: {} Service Application Decision Date workflow is going to be executed.", caseId);
+        log.info("CaseID: {} Make Service Decision workflow is going to be executed.", caseId);
+
+        List<Task<Map<String, Object>>> tasks = new ArrayList<>();
+
+        tasks.add(makeServiceDecisionDateTask);
+
+        if (isServiceApplicationDispensed(caseDetails.getCaseData())) {
+            log.info("CaseID: {} application type = disperse. Order to dispense will be generated", caseId);
+            tasks.add(orderToDispenseGenerationTask);
+        } else {
+            log.info("CaseID: {} application type is not disperse. No pdf will be generated", caseId);
+        }
 
         return this.execute(
-            new Task[] {
-                makeServiceDecisionDateTask
-            },
+            tasks.toArray(new Task[0]),
             caseDetails.getCaseData(),
             ImmutablePair.of(CASE_ID_JSON_KEY, caseId)
         );
+    }
+
+    protected boolean isServiceApplicationDispensed(Map<String, Object> caseData) {
+        return "dispensed".equals(caseData.get(CcdFields.SERVICE_APPLICATION_TYPE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
@@ -1433,7 +1433,7 @@ public class CallbackControllerTest {
 
     @Test
     public void testMakeServiceDecisionStateChange() throws WorkflowException {
-        when(serviceJourneyService.makeServiceDecision(any()))
+        when(serviceJourneyService.makeServiceDecision(any(), anyString()))
             .thenReturn(CcdCallbackResponse.builder().build());
 
         CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder()
@@ -1442,7 +1442,7 @@ public class CallbackControllerTest {
                 .build())
             .build();
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.makeServiceDecision(ccdCallbackRequest);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.makeServiceDecision(AUTH_TOKEN, ccdCallbackRequest);
 
         assertThat(response.getStatusCode(), equalTo(OK));
         assertThat(response.getBody().getErrors(), is(nullValue()));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DnPronouncedDocumentsGenerationITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/DnPronouncedDocumentsGenerationITest.java
@@ -37,9 +37,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTes
 
 public class DnPronouncedDocumentsGenerationITest extends MockedFunctionalTest {
     private static final String API_URL = "/generate-dn-pronouncement-documents";
-    private static final String ADD_DOCUMENTS_CONTEXT_PATH = "/caseformatter/version/1/add-documents";
-    private static final String GENERATE_DOCUMENT_CONTEXT_PATH = "/version/1/generatePDF";
-    private  static final String COSTS_ORDER_TEMPLATE_ID = "FL-DIV-DEC-ENG-00060.docx";
+    private static final String COSTS_ORDER_TEMPLATE_ID = "FL-DIV-DEC-ENG-00060.docx";
     private static final String DECREE_NISI_TEMPLATE_ID = "FL-DIV-GNO-ENG-00021.docx";
 
     private static final Map<String, Object> CASE_DATA = ImmutableMap.of(

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionDateTest.java
@@ -5,22 +5,46 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
-import uk.gov.hmcts.reform.divorce.utils.DateUtils;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.OrderToDispense;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor;
+import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.OrderToDispenseGenerationTask;
 
-import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.time.LocalDate.now;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RECEIVED_SERVICE_APPLICATION_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_DECISION_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DISPENSED;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.CaseDataTestHelper.createCollectionMemberDocumentAsMap;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateFromLocalDate;
 
 public class MakeServiceDecisionDateTest extends IdamTestSupport {
 
@@ -29,24 +53,105 @@ public class MakeServiceDecisionDateTest extends IdamTestSupport {
     @Autowired
     private MockMvc webClient;
 
+    @Autowired
+    private CtscContactDetailsDataProviderService ctscContactDetailsDataProviderService;
+
     @Test
-    public void givenCaseData_whenCalledEndpoint_thenExpectReceivedServiceAddedDateInResponde() throws Exception {
-        CcdCallbackRequest input = new CcdCallbackRequest(
-            AUTH_TOKEN,
-            "event",
-            CaseDetails.builder().caseData(new HashMap<>()).caseId(TEST_CASE_ID).build()
-        );
+    public void shouldPopulateReceivedServiceAddedDateInResponse() throws Exception {
+        CcdCallbackRequest input = buildRequest();
 
         Map<String, Object> expectedCaseData = ImmutableMap.of(
-            CcdFields.SERVICE_APPLICATION_DECISION_DATE,
-            DateUtils.formatDateFromLocalDate(LocalDate.now())
+            SERVICE_APPLICATION_DECISION_DATE,
+            formatDateFromLocalDate(now())
         );
 
         webClient.perform(post(API_URL)
+            .header(AUTHORIZATION, AUTH_TOKEN)
             .content(convertObjectToJsonString(input))
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(containsString(convertObjectToJsonString(expectedCaseData))));
+    }
+
+    @Test
+    public void shouldGenerateOderInDispenseAndAddItToResponse() throws Exception {
+        Map<String, Object> caseData = buildInputCaseData();
+        CcdCallbackRequest input = buildRequest(caseData);
+        CcdCallbackResponse expectedResponse = buildExpectedResponse(caseData);
+
+        webClient.perform(post(API_URL)
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(convertObjectToJsonString(input))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(convertObjectToJsonString(expectedResponse)));
+    }
+
+    private Map<String, Object> buildInputCaseData() {
+        Map<String, Object> caseData = new HashMap<>();
+
+        caseData.put(PETITIONER_FIRST_NAME, TEST_PETITIONER_FIRST_NAME);
+        caseData.put(PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME);
+        caseData.put(RESPONDENT_FIRST_NAME, TEST_RESPONDENT_FIRST_NAME);
+        caseData.put(RESPONDENT_LAST_NAME, TEST_RESPONDENT_LAST_NAME);
+        caseData.put(RECEIVED_SERVICE_APPLICATION_DATE, "2010-10-10");
+        caseData.put(SERVICE_APPLICATION_TYPE, DISPENSED);
+        return caseData;
+    }
+
+    private CcdCallbackResponse buildExpectedResponse(Map<String, Object> caseData) {
+        Map<String, Object> caseDataBeforeGeneratingPdf = new HashMap<>(caseData);
+        caseDataBeforeGeneratingPdf.put(SERVICE_APPLICATION_DECISION_DATE, formatDateFromLocalDate(now()));
+
+        String orderToDispenseDocumentId = stubDocumentGeneratorServiceBaseOnContextPath(
+            OrderToDispenseGenerationTask.FileMetadata.TEMPLATE_ID,
+            singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
+                ImmutableMap.of(
+                    "id", TEST_CASE_ID,
+                    "case_data", buildOrderToDispense(caseDataBeforeGeneratingPdf)
+                )
+            ),
+            OrderToDispenseGenerationTask.FileMetadata.DOCUMENT_TYPE
+        );
+
+        Map<String, Object> expectedCaseData = new HashMap<>(caseDataBeforeGeneratingPdf);
+
+        expectedCaseData.put(D8DOCUMENTS_GENERATED, singletonList(
+            createCollectionMemberDocumentAsMap(
+                getDocumentStoreTestUrl(orderToDispenseDocumentId),
+                OrderToDispenseGenerationTask.FileMetadata.DOCUMENT_TYPE,
+                null)
+        ));
+
+        return CcdCallbackResponse.builder()
+            .state(CcdStates.SERVICE_APPLICATION_NOT_APPROVED)
+            .data(expectedCaseData)
+            .build();
+    }
+
+    private OrderToDispense buildOrderToDispense(Map<String, Object> caseData) {
+        return OrderToDispense.orderToDispenseBuilder()
+            .caseReference(TEST_CASE_ID)
+            .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
+            .petitionerFullName(FullNamesDataExtractor.getPetitionerFullName(caseData))
+            .respondentFullName(FullNamesDataExtractor.getRespondentFullName(caseData))
+            .documentIssuedOn(DatesDataExtractor.getLetterDate())
+            .receivedServiceApplicationDate(DatesDataExtractor.getReceivedServiceApplicationDate(caseData))
+            .serviceApplicationDecisionDate(DatesDataExtractor.getServiceApplicationDecisionDate(caseData))
+            .build();
+    }
+
+    private CcdCallbackRequest buildRequest(Map<String, Object> caseData) {
+        return new CcdCallbackRequest(
+            AUTH_TOKEN,
+            "event",
+            CaseDetails.builder().caseData(caseData).caseId(TEST_CASE_ID).build()
+        );
+    }
+
+    private CcdCallbackRequest buildRequest() {
+        return buildRequest(new HashMap<>());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionTest.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_FAMILY_MAN_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_LAST_NAME;
@@ -38,6 +39,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.S
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DISPENSED;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CaseDataExtractor.CaseDataKeys.CASE_REFERENCE;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CaseDataExtractor.getCaseReference;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_FIRST_NAME;
@@ -92,12 +95,16 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
     private Map<String, Object> buildInputCaseData() {
         Map<String, Object> caseData = new HashMap<>();
 
+        caseData.put(CASE_REFERENCE, TEST_CASE_FAMILY_MAN_ID);
+
         caseData.put(PETITIONER_FIRST_NAME, TEST_PETITIONER_FIRST_NAME);
         caseData.put(PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME);
         caseData.put(RESPONDENT_FIRST_NAME, TEST_RESPONDENT_FIRST_NAME);
         caseData.put(RESPONDENT_LAST_NAME, TEST_RESPONDENT_LAST_NAME);
+
         caseData.put(RECEIVED_SERVICE_APPLICATION_DATE, "2010-10-10");
         caseData.put(SERVICE_APPLICATION_TYPE, DISPENSED);
+
         return caseData;
     }
 
@@ -109,7 +116,7 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
             OrderToDispenseGenerationTask.FileMetadata.TEMPLATE_ID,
             singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY,
                 ImmutableMap.of(
-                    "id", TEST_CASE_ID,
+                    "id", getCaseReference(caseDataBeforeGeneratingPdf),
                     "case_data", buildOrderToDispense(caseDataBeforeGeneratingPdf)
                 )
             ),
@@ -133,7 +140,7 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
 
     private OrderToDispense buildOrderToDispense(Map<String, Object> caseData) {
         return OrderToDispense.orderToDispenseBuilder()
-            .caseReference(TEST_CASE_ID)
+            .caseReference(TEST_CASE_FAMILY_MAN_ID)
             .ctscContactDetails(ctscContactDetailsDataProviderService.getCtscContactDetails())
             .petitionerFullName(FullNamesDataExtractor.getPetitionerFullName(caseData))
             .respondentFullName(FullNamesDataExtractor.getRespondentFullName(caseData))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionTest.java
@@ -46,7 +46,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.testutil.CaseDataTestHel
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateFromLocalDate;
 
-public class MakeServiceDecisionDateTest extends IdamTestSupport {
+public class MakeServiceDecisionTest extends IdamTestSupport {
 
     private static final String API_URL = "/make-service-decision";
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractorTest.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.InvalidDataForTaskException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.EMPTY_MAP;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_FAMILY_MAN_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CaseDataExtractor.CaseDataKeys.CASE_REFERENCE;
+
+public class CaseDataExtractorTest {
+
+    @Test
+    public void getCaseReferenceShouldReturnValidValues() {
+        Map<String, Object> caseData = buildCaseDataWithField(CASE_REFERENCE, TEST_CASE_FAMILY_MAN_ID);
+
+        assertThat(CaseDataExtractor.getCaseReference(caseData), is(TEST_CASE_FAMILY_MAN_ID));
+    }
+
+    @Test(expected = InvalidDataForTaskException.class)
+    public void getCaseReferenceShouldThrowInvalidDat() {
+        CaseDataExtractor.getCaseReference(EMPTY_MAP);
+    }
+
+    private static Map<String, Object> buildCaseDataWithField(String field, String value) {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(field, value);
+
+        return caseData;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/DatesDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/DatesDataExtractorTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.EMPTY_MAP;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -23,6 +24,8 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CoECoverLetterDataExtractor.CaseDataKeys.COSTS_CLAIM_GRANTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor.CaseDataKeys.DA_GRANTED_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor.CaseDataKeys.RECEIVED_SERVICE_APPLICATION_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor.CaseDataKeys.SERVICE_APPLICATION_DECISION_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor.getDeadlineToContactCourtBy;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.DatesDataExtractor.getHearingDate;
 
@@ -38,6 +41,33 @@ public class DatesDataExtractorTest {
     public void getDaGrantedDateReturnsValidValueWhenItExists() {
         Map<String, Object> caseData = buildCaseDataWithField(DA_GRANTED_DATE, VALID_DATE_FROM_CCD);
         assertThat(DatesDataExtractor.getDaGrantedDate(caseData), is(EXPECTED_DATE));
+    }
+
+    @Test(expected = InvalidDataForTaskException.class)
+    public void getDaGrantedDateThrowsInvalidDataForTaskExceptionWhenNoFieldFound() {
+        assertThat(DatesDataExtractor.getDaGrantedDate(EMPTY_MAP), is(EXPECTED_DATE));
+    }
+
+    @Test
+    public void getReceivedServiceApplicationDateReturnsValidValueWhenItExists() {
+        Map<String, Object> caseData = buildCaseDataWithField(RECEIVED_SERVICE_APPLICATION_DATE, VALID_DATE_FROM_CCD);
+        assertThat(DatesDataExtractor.getReceivedServiceApplicationDate(caseData), is(EXPECTED_DATE));
+    }
+
+    @Test(expected = InvalidDataForTaskException.class)
+    public void getReceivedServiceApplicationDateThrowsInvalidDataForTaskExceptionWhenNoFieldFound() {
+        assertThat(DatesDataExtractor.getDaGrantedDate(EMPTY_MAP), is(EXPECTED_DATE));
+    }
+
+    @Test
+    public void getServiceApplicationDecisionDateReturnsValidValueWhenItExists() {
+        Map<String, Object> caseData = buildCaseDataWithField(SERVICE_APPLICATION_DECISION_DATE, VALID_DATE_FROM_CCD);
+        assertThat(DatesDataExtractor.getServiceApplicationDecisionDate(caseData), is(EXPECTED_DATE));
+    }
+
+    @Test(expected = InvalidDataForTaskException.class)
+    public void getServiceApplicationDecisionDateThrowsInvalidDataForTaskExceptionWhenNoFieldFound() {
+        assertThat(DatesDataExtractor.getReceivedServiceApplicationDate(EMPTY_MAP), is(EXPECTED_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/ServiceJourneyServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_DN_APPLICATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
@@ -64,9 +65,9 @@ public class ServiceJourneyServiceImplTest extends TestCase {
         Map<String, Object> payload = ImmutableMap.of(CcdFields.SERVICE_APPLICATION_GRANTED, decision);
         CaseDetails caseDetails = CaseDetails.builder().caseData(payload).build();
 
-        when(makeServiceDecisionDateWorkflow.run(caseDetails)).thenReturn(payload);
+        when(makeServiceDecisionDateWorkflow.run(caseDetails, AUTH_TOKEN)).thenReturn(payload);
 
-        CcdCallbackResponse response = classUnderTest.makeServiceDecision(caseDetails);
+        CcdCallbackResponse response = classUnderTest.makeServiceDecision(caseDetails, AUTH_TOKEN);
 
         assertThat(response.getState(), is(expectedState));
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTaskTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.bulk.print.Docmosi
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
@@ -72,7 +71,7 @@ public class BasePayloadSpecificDocumentGenerationTaskTest {
     }
 
     @Test
-    public void makeSureAbstractClassExecutesDesiredBehaviour() throws TaskException {
+    public void makeSureAbstractClassExecutesDesiredBehaviour() {
         BasePayloadSpecificDocumentGenerationTask testDocGenerationTask =
             new BasePayloadSpecificDocumentGenerationTask(ctscContactDetailsDataProviderService, pdfDocumentGenerationService, ccdUtil) {
                 @Override

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTaskTest.java
@@ -17,17 +17,18 @@ import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_FAMILY_MAN_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FULL_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FULL_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CaseDataExtractor.CaseDataKeys.CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_LAST_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrintTestData.CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrintTestData.CTSC_CONTACT;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrintTestData.prepareTaskContext;
 
@@ -53,7 +54,7 @@ public class OrderToDispenseGenerationTaskTest extends BasePayloadSpecificDocume
             .ctscContactDetails(CTSC_CONTACT)
             .petitionerFullName(TEST_PETITIONER_FULL_NAME)
             .respondentFullName(TEST_RESPONDENT_FULL_NAME)
-            .caseReference(CASE_ID)
+            .caseReference(TEST_CASE_FAMILY_MAN_ID)
             .serviceApplicationDecisionDate(DateUtils.formatDateWithCustomerFacingFormat(TEST_SERVICE_DECISION_DATE))
             .receivedServiceApplicationDate(DateUtils.formatDateWithCustomerFacingFormat(TEST_RECEIVED_DATE))
             .documentIssuedOn(DateUtils.formatDateWithCustomerFacingFormat(LocalDate.now()))
@@ -74,6 +75,8 @@ public class OrderToDispenseGenerationTaskTest extends BasePayloadSpecificDocume
 
     private Map<String, Object> buildCaseData() {
         Map<String, Object> caseData = new HashMap<>();
+
+        caseData.put(CASE_REFERENCE, TEST_CASE_FAMILY_MAN_ID);
 
         caseData.put(PETITIONER_FIRST_NAME, TEST_PETITIONER_FIRST_NAME);
         caseData.put(PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTaskTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.OrderToDispense;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BasePayloadSpecificDocumentGenerationTaskTest;
+import uk.gov.hmcts.reform.divorce.utils.DateUtils;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FULL_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FULL_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.PETITIONER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_FIRST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrintTestData.CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrintTestData.CTSC_CONTACT;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BulkPrintTestData.prepareTaskContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OrderToDispenseGenerationTaskTest extends BasePayloadSpecificDocumentGenerationTaskTest {
+
+    public static final String TEST_RECEIVED_DATE = "2010-10-10";
+    public static final String TEST_SERVICE_DECISION_DATE = "2010-10-11";
+    public static final String TEST_DOCUMENT_ISSUED_ON = "2020-12-12";
+    @InjectMocks
+    private OrderToDispenseGenerationTask orderToDispenseGenerationTask;
+
+    @Before
+    public void setup() {
+        when(ctscContactDetailsDataProviderService.getCtscContactDetails()).thenReturn(CTSC_CONTACT);
+    }
+
+    @Test
+    public void executeShouldPopulateDate() throws TaskException {
+        Map<String, Object> caseData = buildCaseData();
+
+        OrderToDispense orderToDispense = OrderToDispense.orderToDispenseBuilder()
+            .ctscContactDetails(CTSC_CONTACT)
+            .petitionerFullName(TEST_PETITIONER_FULL_NAME)
+            .respondentFullName(TEST_RESPONDENT_FULL_NAME)
+            .caseReference(CASE_ID)
+            .serviceApplicationDecisionDate(DateUtils.formatDateWithCustomerFacingFormat(TEST_SERVICE_DECISION_DATE))
+            .receivedServiceApplicationDate(DateUtils.formatDateWithCustomerFacingFormat(TEST_RECEIVED_DATE))
+            .documentIssuedOn(DateUtils.formatDateWithCustomerFacingFormat(LocalDate.now()))
+            .build();
+
+        Map<String, Object> returnedCaseData = orderToDispenseGenerationTask.execute(prepareTaskContext(), caseData);
+
+        runCommonVerifications(
+            caseData,
+            returnedCaseData,
+            orderToDispenseGenerationTask.getDocumentType(),
+            orderToDispenseGenerationTask.getTemplateId(),
+            orderToDispense
+        );
+    }
+
+    private Map<String, Object> buildCaseData() {
+        Map<String, Object> caseData = new HashMap<>();
+
+        caseData.put(PETITIONER_FIRST_NAME, TEST_PETITIONER_FIRST_NAME);
+        caseData.put(PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME);
+        caseData.put(RESPONDENT_FIRST_NAME, TEST_RESPONDENT_FIRST_NAME);
+        caseData.put(RESPONDENT_LAST_NAME, TEST_RESPONDENT_LAST_NAME);
+
+        caseData.put(CcdFields.RECEIVED_SERVICE_APPLICATION_DATE, TEST_RECEIVED_DATE);
+        caseData.put(CcdFields.SERVICE_APPLICATION_DECISION_DATE, TEST_SERVICE_DECISION_DATE);
+
+        return caseData;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/OrderToDispenseGenerationTaskTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FULL_NAME;
@@ -45,7 +46,7 @@ public class OrderToDispenseGenerationTaskTest extends BasePayloadSpecificDocume
     }
 
     @Test
-    public void executeShouldPopulateDate() throws TaskException {
+    public void executeShouldGenerateAFile() throws TaskException {
         Map<String, Object> caseData = buildCaseData();
 
         OrderToDispense orderToDispense = OrderToDispense.orderToDispenseBuilder()
@@ -67,6 +68,8 @@ public class OrderToDispenseGenerationTaskTest extends BasePayloadSpecificDocume
             orderToDispenseGenerationTask.getTemplateId(),
             orderToDispense
         );
+
+        assertNotNull(returnedCaseData);
     }
 
     private Map<String, Object> buildCaseData() {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/MakeServiceDecisionDateWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/MakeServiceDecisionDateWorkflowTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.MakeServiceDecisionDateTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.OrderToDispenseGenerationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.servicejourney.MakeServiceDecisionDateWorkflow;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.workflows.servicejourney.MakeSe
 import java.util.HashMap;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DISPENSED;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.mockTasksExecution;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.verifyTaskWasCalled;
@@ -34,37 +36,37 @@ public class MakeServiceDecisionDateWorkflowTest extends TestCase {
     private MakeServiceDecisionDateWorkflow makeServiceDecisionDateWorkflow;
 
     @Test
-    public void shouldCallOnlyMakeServiceDecisionDateTaskWhenNoApplicationServiceType() throws Exception {
+    public void shouldCallOnlyMakeServiceDecisionDateTaskWhenNoApplicationServiceType() throws WorkflowException {
         Map<String, Object> caseData = new HashMap<>();
         mockTasksExecution(caseData, makeServiceDecisionDateTask);
 
-        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build());
+        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build(), AUTH_TOKEN);
 
         verifyTaskWasCalled(caseData, makeServiceDecisionDateTask);
         verifyTasksWereNeverCalled(orderToDispenseGenerationTask);
     }
 
     @Test
-    public void shouldCallOnlyMakeServiceDecisionDateTaskWhenApplicationServiceTypeIsNotDispensed() throws Exception {
+    public void shouldCallOnlyMakeServiceDecisionDateTaskWhenApplicationServiceTypeIsNotDispensed() throws WorkflowException {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put(CcdFields.SERVICE_APPLICATION_TYPE, "anything else");
 
         mockTasksExecution(caseData, makeServiceDecisionDateTask);
 
-        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build());
+        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build(), AUTH_TOKEN);
 
         verifyTaskWasCalled(caseData, makeServiceDecisionDateTask);
         verifyTasksWereNeverCalled(orderToDispenseGenerationTask);
     }
 
     @Test
-    public void shouldCallBothTasksWhenApplicationServiceTypeIsDispensed() throws Exception {
+    public void shouldCallBothTasksWhenApplicationServiceTypeIsDispensed() throws WorkflowException {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put(CcdFields.SERVICE_APPLICATION_TYPE, DISPENSED);
 
         mockTasksExecution(caseData, makeServiceDecisionDateTask, orderToDispenseGenerationTask);
 
-        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build());
+        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build(), AUTH_TOKEN);
 
         verifyTasksCalledInOrder(caseData, makeServiceDecisionDateTask, orderToDispenseGenerationTask);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/MakeServiceDecisionDateWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/MakeServiceDecisionDateWorkflowTest.java
@@ -6,15 +6,20 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.MakeServiceDecisionDateTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.OrderToDispenseGenerationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.servicejourney.MakeServiceDecisionDateWorkflow;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DISPENSED;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.mockTasksExecution;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.verifyTaskWasCalled;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.verifyTasksCalledInOrder;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.verifyTasksWereNeverCalled;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MakeServiceDecisionDateWorkflowTest extends TestCase {
@@ -22,16 +27,45 @@ public class MakeServiceDecisionDateWorkflowTest extends TestCase {
     @Mock
     private MakeServiceDecisionDateTask makeServiceDecisionDateTask;
 
+    @Mock
+    private OrderToDispenseGenerationTask orderToDispenseGenerationTask;
+
     @InjectMocks
     private MakeServiceDecisionDateWorkflow makeServiceDecisionDateWorkflow;
 
     @Test
-    public void runShouldBeExecuted() throws Exception {
+    public void shouldCallOnlyMakeServiceDecisionDateTaskWhenNoApplicationServiceType() throws Exception {
         Map<String, Object> caseData = new HashMap<>();
         mockTasksExecution(caseData, makeServiceDecisionDateTask);
 
         makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build());
 
         verifyTaskWasCalled(caseData, makeServiceDecisionDateTask);
+        verifyTasksWereNeverCalled(orderToDispenseGenerationTask);
+    }
+
+    @Test
+    public void shouldCallOnlyMakeServiceDecisionDateTaskWhenApplicationServiceTypeIsNotDispensed() throws Exception {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(CcdFields.SERVICE_APPLICATION_TYPE, "anything else");
+
+        mockTasksExecution(caseData, makeServiceDecisionDateTask);
+
+        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build());
+
+        verifyTaskWasCalled(caseData, makeServiceDecisionDateTask);
+        verifyTasksWereNeverCalled(orderToDispenseGenerationTask);
+    }
+
+    @Test
+    public void shouldCallBothTasksWhenApplicationServiceTypeIsDispensed() throws Exception {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(CcdFields.SERVICE_APPLICATION_TYPE, DISPENSED);
+
+        mockTasksExecution(caseData, makeServiceDecisionDateTask, orderToDispenseGenerationTask);
+
+        makeServiceDecisionDateWorkflow.run(CaseDetails.builder().caseData(caseData).build());
+
+        verifyTasksCalledInOrder(caseData, makeServiceDecisionDateTask, orderToDispenseGenerationTask);
     }
 }


### PR DESCRIPTION
Added a task for `POST /make-service-decision` callback to generate Order to Dispense when application service type is `dispensed`.

Story:
https://tools.hmcts.net/jira/browse/DIV-6237