### PR TITLE
DIV-6237: use bsp-common-lib 0.45

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ plugins {
 def versions = [
         awaitility                   : '4.0.2',
         bcpkixJdk15on                : '1.64',
-        bspCommonLib                 : '0.0.43',
+        bspCommonLib                 : '0.0.45',
         ccdStoreClient               : '4.6.4',
         commonsBeanUtils             : '1.9.4',
         commonsIo                    : '2.6',


### PR DESCRIPTION
This will probably fail as it's using the lib that is compiled in java 11.