### PR TITLE
DIV-6237: fixed typo 'demeed' -> 'deemed', and add better logs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/document/ApplicationServiceTypes.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/document/ApplicationServiceTypes.java
@@ -6,5 +6,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApplicationServiceTypes {
     public static final String DISPENSED = "dispensed";
-    public static final String DEEMED = "demeed";
+    public static final String DEEMED = "deemed";
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
@@ -42,7 +42,12 @@ public abstract class BasePayloadSpecificDocumentGenerationTask implements Task<
         GeneratedDocumentInfo documentInfo = generatePdf(context, templateModel);
         documentInfo = populateMetadataForGeneratedDocument(documentInfo);
 
-        log.info("Case {}: Document {} generated", getCaseId(context), documentInfo.getDocumentType());
+        log.info(
+            "Case {}: Document {} generated. Name: {}",
+            getCaseId(context),
+            documentInfo.getDocumentType(),
+            documentInfo.getFileName()
+        );
 
         return ccdUtil.addNewDocumentsToCaseData(caseData, singletonList(documentInfo));
     }


### PR DESCRIPTION
typo "demeed", should be: "deemed"/

Plus a bit better log.