### PR TITLE
DIV-6237: populate name of newly created file

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
@@ -66,6 +66,7 @@ public abstract class BasePayloadSpecificDocumentGenerationTask implements Task<
 
     protected GeneratedDocumentInfo populateMetadataForGeneratedDocument(GeneratedDocumentInfo documentInfo) {
         documentInfo.setDocumentType(getDocumentType());
+        documentInfo.setFileName(getDocumentType());
 
         return documentInfo;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeServiceDecisionTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.DeemedServ
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.OrderToDispenseGenerationTask;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.time.LocalDate.now;
@@ -138,7 +139,8 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
         return caseData;
     }
 
-    private CcdCallbackResponse buildExpectedResponse(Map<String, Object> caseData, String templateId, String documentType) {
+    private CcdCallbackResponse buildExpectedResponse(
+        Map<String, Object> caseData, String templateId, String documentType) {
         Map<String, Object> caseDataBeforeGeneratingPdf = new HashMap<>(caseData);
         addServiceApplicationDecisionDate(caseDataBeforeGeneratingPdf);
 
@@ -155,14 +157,25 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
 
         Map<String, Object> expectedCaseData = new HashMap<>(caseDataBeforeGeneratingPdf);
 
-        expectedCaseData.put(D8DOCUMENTS_GENERATED, singletonList(
-            createCollectionMemberDocumentAsMap(getDocumentStoreTestUrl(generatedDocumentId), documentType, null)
-        ));
+        expectedCaseData.put(
+            D8DOCUMENTS_GENERATED,
+            buildCollectionWithOneDocument(generatedDocumentId, documentType)
+        );
 
         return CcdCallbackResponse.builder()
             .state(CcdStates.AWAITING_DN_APPLICATION)
             .data(expectedCaseData)
             .build();
+    }
+
+    private List<Map<String, Object>> buildCollectionWithOneDocument(
+        String generatedDocumentId, String documentType) {
+
+        return singletonList(
+            createCollectionMemberDocumentAsMap(
+                getDocumentStoreTestUrl(generatedDocumentId), documentType, documentType
+            )
+        );
     }
 
     private Map<String, Object> addServiceApplicationDecisionDate(Map<String, Object> caseDataBeforeGeneratingPdf) {


### PR DESCRIPTION
File name field was not populated and then it was displayed as "null.pdf" in ccd ui.

It was caused because we have used it before only for documents that were sending to bulk printing and never stored in CCD.

New feature should not break anything in bulk printing (if `null` hasn't String should be also fine).

https://tools.hmcts.net/jira/browse/DIV-6237
https://tools.hmcts.net/jira/browse/DIV-6238