### PR TITLE
DIV-6489: when empty email - don't try to send

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractor.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConst
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.helper.ExtractorHelper.getMandatoryStringValue;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getOptionalPropertyValueAsString;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CaseDataExtractor {
@@ -19,6 +20,10 @@ public class CaseDataExtractor {
 
     public static String getCaseReference(Map<String, Object> caseData) {
         return getMandatoryStringValue(caseData, CaseDataKeys.CASE_REFERENCE);
+    }
+
+    public static String getPetitionerEmailOrEmpty(Map<String, Object> caseData) {
+        return getOptionalPropertyValueAsString(caseData, CaseDataKeys.PETITIONER_EMAIL, "");
     }
 
     public static String getPetitionerEmail(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DeemedApprovedEmailTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DeemedApprovedEmailTask.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.emails;
 import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.LanguagePreference;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.generics.SendEmailTask;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
@@ -24,7 +23,7 @@ public class DeemedApprovedEmailTask extends SendEmailTask {
     }
 
     @Override
-    protected String getSubject() {
+    protected String getSubject(Map<String, Object> caseData) {
         return SUBJECT;
     }
 
@@ -38,10 +37,5 @@ public class DeemedApprovedEmailTask extends SendEmailTask {
     @Override
     protected EmailTemplateNames getTemplate() {
         return EmailTemplateNames.CITIZEN_DEEMED_APPROVED;
-    }
-
-    @Override
-    protected LanguagePreference getLanguage(Map<String, Object> caseData) {
-        return LanguagePreference.ENGLISH;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTask.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.emails;
 import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.LanguagePreference;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.generics.SendEmailTask;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
@@ -17,14 +16,14 @@ import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.datae
 @Slf4j
 public class DispensedApprovedEmailTask extends SendEmailTask {
 
-    private static final String SUBJECT = "Your ‘dispense with service’ application has been approved\n";
+    private static final String SUBJECT = "Your ‘dispense with service’ application has been approved]";
 
     public DispensedApprovedEmailTask(EmailService emailService) {
         super(emailService);
     }
 
     @Override
-    protected String getSubject() {
+    protected String getSubject(Map<String, Object> caseData) {
         return SUBJECT;
     }
 
@@ -38,10 +37,5 @@ public class DispensedApprovedEmailTask extends SendEmailTask {
     @Override
     protected EmailTemplateNames getTemplate() {
         return EmailTemplateNames.CITIZEN_DISPENSED_APPROVED;
-    }
-
-    @Override
-    protected LanguagePreference getLanguage(Map<String, Object> caseData) {
-        return LanguagePreference.ENGLISH;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTask.java
@@ -16,7 +16,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.datae
 @Slf4j
 public class DispensedApprovedEmailTask extends SendEmailTask {
 
-    private static final String SUBJECT = "Your ‘dispense with service’ application has been approved]";
+    private static final String SUBJECT = "Your ‘dispense with service’ application has been approved";
 
     public DispensedApprovedEmailTask(EmailService emailService) {
         super(emailService);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/ServiceDecisionMadeWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/ServiceDecisionMadeWorkflow.java
@@ -76,14 +76,16 @@ public class ServiceDecisionMadeWorkflow extends DefaultWorkflow<Map<String, Obj
 
         if (isServiceApplicationGranted(caseData)) {
             log.info("CaseID: {} Service application is granted. No PDFs to generate. Emails might be sent.", caseId);
-            if (isServiceApplicationDeemed(caseData)) {
-                log.info("CaseId: {} deemed citizen email task adding.", caseId);
-                tasks.add(deemedApprovedEmailTask);
-            } else if (isServiceApplicationDispensed(caseData)) {
-                log.info("CaseId: {} dispensed citizen email task adding.", caseId);
-                tasks.add(dispensedApprovedEmailTask);
-            } else {
-                log.info("CaseId: {} NOT deemed/dispensed. No email will be sent.", caseId);
+            if (isFinal(decision)) {
+                if (isServiceApplicationDeemed(caseData)) {
+                    log.info("CaseId: {} deemed citizen email task adding.", caseId);
+                    tasks.add(deemedApprovedEmailTask);
+                } else if (isServiceApplicationDispensed(caseData)) {
+                    log.info("CaseId: {} dispensed citizen email task adding.", caseId);
+                    tasks.add(dispensedApprovedEmailTask);
+                } else {
+                    log.info("CaseId: {} NOT deemed/dispensed. No email will be sent.", caseId);
+                }
             }
 
             return tasks.toArray(new Task[] {});

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/CaseDataExtractorTest.java
@@ -3,10 +3,10 @@ package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextract
 import org.junit.Test;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.InvalidDataForTaskException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.EMPTY_MAP;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_FAMILY_MAN_ID;
@@ -23,20 +23,47 @@ public class CaseDataExtractorTest {
     }
 
     @Test(expected = InvalidDataForTaskException.class)
-    public void getPetitionerEmailShouldThrowInvalidDat() {
-        CaseDataExtractor.getPetitionerEmail(EMPTY_MAP);
+    public void getCaseReferenceShouldThrowInvalidDataForTaskException() {
+        CaseDataExtractor.getCaseReference(Collections.emptyMap());
+    }
+
+    @Test
+    public void getPetitionerEmailShouldReturnValidValue() {
+        Map<String, Object> caseData = buildCaseDataWithField(PETITIONER_EMAIL, TEST_EMAIL);
+        assertThat(CaseDataExtractor.getPetitionerEmail(caseData), is(TEST_EMAIL));
+    }
+
+    @Test(expected = InvalidDataForTaskException.class)
+    public void getPetitionerEmailShouldThrowInvalidDataForTaskException() {
+        CaseDataExtractor.getPetitionerEmail(Collections.emptyMap());
     }
 
     @Test
     public void getPetitionerEmailShouldReturnValidValues() {
         Map<String, Object> caseData = buildCaseDataWithField(PETITIONER_EMAIL, TEST_EMAIL);
 
-        assertThat(CaseDataExtractor.getPetitionerEmail(caseData), is(TEST_EMAIL));
+        assertThat(CaseDataExtractor.getPetitionerEmailOrEmpty(caseData), is(TEST_EMAIL));
     }
 
-    @Test(expected = InvalidDataForTaskException.class)
-    public void getCaseReferenceShouldThrowInvalidData() {
-        CaseDataExtractor.getCaseReference(EMPTY_MAP);
+    @Test
+    public void getPetitionerEmailOrEmptyShouldReturnEmptyWhenNoFieldGiven() {
+        Map<String, Object> caseData = new HashMap<>();
+
+        assertThat(CaseDataExtractor.getPetitionerEmailOrEmpty(caseData), is(""));
+    }
+
+    @Test
+    public void getPetitionerEmailOrEmptyShouldReturnEmptyWhenNull() {
+        Map<String, Object> caseData = buildCaseDataWithField(PETITIONER_EMAIL, null);
+
+        assertThat(CaseDataExtractor.getPetitionerEmailOrEmpty(caseData), is(""));
+    }
+
+    @Test
+    public void getPetitionerEmailOrEmptyShouldReturnEmptyWhenEmpty() {
+        Map<String, Object> caseData = buildCaseDataWithField(PETITIONER_EMAIL, "");
+
+        assertThat(CaseDataExtractor.getPetitionerEmailOrEmpty(caseData), is(""));
     }
 
     private static Map<String, Object> buildCaseDataWithField(String field, String value) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTaskTest.java
@@ -7,13 +7,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.LanguagePreference;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.email.EmailTemplateNames;
-import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.service.EmailService;
 
 import java.util.Map;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_USER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CaseDataExtractor.CaseDataKeys.PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.emails.DeemedApprovedEmailTaskTest.buildCaseData;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.emails.DeemedApprovedEmailTaskTest.getExpectedNotificationTemplateVars;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.emails.DeemedApprovedEmailTaskTest.getTaskContext;
@@ -30,17 +31,25 @@ public class DispensedApprovedEmailTaskTest {
     @Test
     public void whenExecuteEmailNotificationTask_thenSendEmail() {
         Map<String, Object> caseData = buildCaseData();
-        TaskContext context = getTaskContext();
-        Map<String, String> notificationTemplateVars = getExpectedNotificationTemplateVars();
 
-        dispensedApprovedEmailTask.execute(context, caseData);
+        dispensedApprovedEmailTask.execute(getTaskContext(), caseData);
 
         verify(emailService).sendEmail(
             TEST_USER_EMAIL,
-            EmailTemplateNames.CITIZEN_DISPENSED_APPROVED.name(),
-            notificationTemplateVars,
-            dispensedApprovedEmailTask.getSubject(),
+            EmailTemplateNames.CITIZEN_DEEMED_APPROVED.name(),
+            getExpectedNotificationTemplateVars(),
+            dispensedApprovedEmailTask.getSubject(caseData),
             LanguagePreference.ENGLISH
         );
+    }
+
+    @Test
+    public void whenEmptyRecipientEmail_thenDoNotSendEmail() {
+        Map<String, Object> caseData = buildCaseData();
+        caseData.remove(PETITIONER_EMAIL);
+
+        dispensedApprovedEmailTask.execute(getTaskContext(), caseData);
+
+        verifyZeroInteractions(emailService);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/emails/DispensedApprovedEmailTaskTest.java
@@ -36,7 +36,7 @@ public class DispensedApprovedEmailTaskTest {
 
         verify(emailService).sendEmail(
             TEST_USER_EMAIL,
-            EmailTemplateNames.CITIZEN_DEEMED_APPROVED.name(),
+            EmailTemplateNames.CITIZEN_DISPENSED_APPROVED.name(),
             getExpectedNotificationTemplateVars(),
             dispensedApprovedEmailTask.getSubject(caseData),
             LanguagePreference.ENGLISH

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/ServiceDecisionMadeWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/ServiceDecisionMadeWorkflowTest.java
@@ -184,6 +184,17 @@ public class ServiceDecisionMadeWorkflowTest {
     }
 
     @Test
+    public void whenApplicationIsGrantedAndDispensedButDraftShouldNotDoAnything()
+        throws WorkflowException {
+        Map<String, Object> caseData = buildCaseData(DISPENSED, YES_VALUE);
+        CaseDetails caseDetails = buildCaseDetails(caseData, AWAITING_SERVICE_CONSIDERATION);
+
+        executeWorkflow(caseDetails, DRAFT);
+
+        runNoTasksAtAll();
+    }
+
+    @Test
     public void whenApplicationIsGrantedAndUnknownTypeShouldNotExecuteAnyTask()
         throws WorkflowException {
         Map<String, Object> caseData = buildCaseData("I don't exist", YES_VALUE);


### PR DESCRIPTION
There is an edge case with cases where petitioner email is null or `""`. Then we shouldn't even try to send email.

Story
https://tools.hmcts.net/jira/browse/DIV-6489