### PR TITLE
DIV-6094: Not query respondent answers document for deemed or dispensed approved

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
@@ -13,6 +13,10 @@ import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_DRAFT_LINK_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ANSWERS_LINK;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationDeemed;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationDispensed;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationGranted;
 
 @Component
 public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Object>> {
@@ -25,10 +29,21 @@ public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Obj
     }
 
     public Map<String, Object> run(CaseDetails caseDetails, final String documentType, final String docLinkFieldName) throws WorkflowException {
+        if (isRespondentAnswersRequestedButNotRequired(caseDetails.getCaseData(), docLinkFieldName)) {
+            return caseDetails.getCaseData();
+        }
+
         return this.execute(new Task[] {
             populateDocLink
         }, caseDetails.getCaseData(),
             ImmutablePair.of(DOCUMENT_TYPE, documentType),
             ImmutablePair.of(DOCUMENT_DRAFT_LINK_FIELD, docLinkFieldName));
+    }
+
+    private boolean isRespondentAnswersRequestedButNotRequired(Map<String, Object> caseData, String docLinkFieldName) {
+        boolean isRespondentAnswersRequested = RESP_ANSWERS_LINK.equals(docLinkFieldName);
+        boolean isValidServiceApplicationGranted =
+            isServiceApplicationGranted(caseData) && (isServiceApplicationDeemed(caseData) || isServiceApplicationDispensed(caseData));
+        return isRespondentAnswersRequested && isValidServiceApplicationGranted;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -12,16 +12,24 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLink;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_GRANTED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_DRAFT_LINK_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE_PETITION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_LINK;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ANSWERS_LINK;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SolicitorDnFetchDocWorkflowTest {
@@ -53,6 +61,78 @@ public class SolicitorDnFetchDocWorkflowTest {
         when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
 
         assertThat(solicitorDnFetchDocWorkflow.run(caseDetails, DOCUMENT_TYPE_PETITION, MINI_PETITION_LINK), is(caseData));
+
+        verify(populateDocLink).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void runShouldReturnCaseDataAndNotExecuteTasksWhenServiceApplicationIsGrantedAndIsRequestingRespondentAnswers() throws Exception {
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(SERVICE_APPLICATION_TYPE, DEEMED);
+        caseData.put(SERVICE_APPLICATION_GRANTED, YES_VALUE);
+        taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
+
+        CaseDetails caseDetails = CaseDetails.builder()
+            .caseData(caseData)
+            .build();
+
+        assertThat(solicitorDnFetchDocWorkflow.run(caseDetails, DOCUMENT_TYPE_PETITION, RESP_ANSWERS_LINK), is(caseData));
+
+        verify(populateDocLink, times(0)).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void runShouldReturnCaseDataAndExecuteTasksWhenServiceApplicationIsGrantedAndIsNotRequestingRespondentAnswers() throws Exception {
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(SERVICE_APPLICATION_TYPE, DEEMED);
+        caseData.put(SERVICE_APPLICATION_GRANTED, YES_VALUE);
+
+        CaseDetails caseDetails = CaseDetails.builder()
+            .caseData(caseData)
+            .build();
+
+        when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
+
+        assertThat(solicitorDnFetchDocWorkflow.run(caseDetails, DOCUMENT_TYPE_PETITION, MINI_PETITION_LINK), is(caseData));
+
+        verify(populateDocLink).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void runShouldReturnCaseDataAndExecuteTasksWhenServiceApplicationIsNotGrantedAndIsRequestingRespondentAnswers() throws Exception {
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(SERVICE_APPLICATION_TYPE, DEEMED);
+        caseData.put(SERVICE_APPLICATION_GRANTED, NO_VALUE);
+        taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
+
+        CaseDetails caseDetails = CaseDetails.builder()
+            .caseData(caseData)
+            .build();
+
+        when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
+
+        assertThat(solicitorDnFetchDocWorkflow.run(caseDetails, DOCUMENT_TYPE_PETITION, RESP_ANSWERS_LINK), is(caseData));
+
+        verify(populateDocLink).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void runShouldReturnCaseDataAndExecuteTasksWhenServiceApplicationTypeIsNotDefinedAndIsRequestingRespondentAnswers() throws Exception {
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(SERVICE_APPLICATION_GRANTED, YES_VALUE);
+        taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
+
+        CaseDetails caseDetails = CaseDetails.builder()
+            .caseData(caseData)
+            .build();
+
+        when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
+
+        assertThat(solicitorDnFetchDocWorkflow.run(caseDetails, DOCUMENT_TYPE_PETITION, RESP_ANSWERS_LINK), is(caseData));
 
         verify(populateDocLink).execute(taskContext, caseData);
     }


### PR DESCRIPTION


# Description

When triggering the event "Draft Decree Nisi Application", a callback is called to query the respondent answers document so that it can be displayed on the first page of the event workflow.
Currently, when this document is not present, an error is raised.
Not query respondent answers document for deemed or dispensed approved

Fixes https://tools.hmcts.net/jira/browse/DIV-6094

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
