### PR TITLE
DIV-6142: generalOrder -> GeneralOrder

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTask.java
@@ -32,7 +32,7 @@ public class GeneralOrderGenerationTask extends BasePayloadSpecificDocumentGener
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class FileMetadata {
         public static final String TEMPLATE_ID = "FL-DIV-GOR-ENG-00572.docx";
-        public static final String DOCUMENT_TYPE = "generalOrder";
+        public static final String DOCUMENT_TYPE = "GeneralOrder";
     }
 
     public GeneralOrderGenerationTask(


### PR DESCRIPTION
document type in CCD is:

```
{
  "LiveFrom": "27/08/2020",
  "ID": "d8documentsReceivedEnum",
  "ListElementCode": "GeneralOrder",
  "ListElement": "General Order"
}
```