### PR TITLE
DIV-6441: Making decision to enable scheduler not a default one

### DIFF
--- a/charts/div-cos/Chart.yaml
+++ b/charts/div-cos/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Divorce - Case Orchestration Service
 name: div-cos
-version: 1.4.7
+version: 1.4.8

--- a/charts/div-cos/values.yaml
+++ b/charts/div-cos/values.yaml
@@ -15,7 +15,6 @@ java:
         SERVICE_AUTH_MICROSERVICE : "divorce_frontend"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
         SCHEDULER_RE_CREATE: true
-        SCHEDULER_ENABLED: true
         FEATURE_DN_REFUSAL: "true"
         FEATURE_RESP_SOLICITOR_DETAILS: true
         DIV_SCHEDULER_DB_HOST : "div-cos-{{ .Values.global.environment }}.postgres.database.azure.com"


### PR DESCRIPTION
# Description

This being on by default means that staging pods are listed as quartz agents. That can be a problem because there's always going to be an old staging pod (as we only use 1 of 2 clusters) and we might be running the scheduler with unintended code.
If we want to test the scheduler before the pipeline, we can always turn it on in the PR environment.
For other environments, the configuration will live in Flux.

This should only be merged when https://github.com/hmcts/cnp-flux-config/pull/5978 is merged.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Will be checked manually in AAT and staging.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
