### PR TITLE
DIV-6531: Allow to trigger link-respondent from ServiceApplicationNotApproved

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdEvents.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdEvents.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.divorce.orchestration.domain.model;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CcdEvents {
+
+    public static final String AOS_START_FROM_SERVICE_APPLICATION_NOT_APPROVED = "startAosFromServiceAppRejected";
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/UpdateRespondentDetails.java
@@ -16,9 +16,11 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import java.util.HashMap;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdEvents.AOS_START_FROM_SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_OVERDUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_REISSUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_START_FROM_OVERDUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AOS_START_FROM_REISSUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
@@ -96,6 +98,8 @@ public class UpdateRespondentDetails implements Task<UserDetails> {
                 return AOS_START_FROM_OVERDUE;
             case AWAITING_REISSUE:
                 return AOS_START_FROM_REISSUE;
+            case SERVICE_APPLICATION_NOT_APPROVED:
+                return AOS_START_FROM_SERVICE_APPLICATION_NOT_APPROVED;
             default:
                 return LINK_RESPONDENT_GENERIC_EVENT_ID;
         }


### PR DESCRIPTION

# Description

Allow to trigger link-respondent  (startAos event) from ServiceApplicationNotApproved

Fixes https://tools.hmcts.net/jira/browse/DIV-6531

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
