### PR TITLE
DIV-6543: Making AOS Overdue grace period configurable

### DIFF
--- a/charts/div-cos/values.preview.template.yaml
+++ b/charts/div-cos/values.preview.template.yaml
@@ -15,6 +15,9 @@ java:
     FLYWAY_URL: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase}}"
     #This means it will apply, as opposed to check, DB changes in preview (since a new DB is created for every deployment)
     FLYWAY_NOOP_STRATEGY: false
+    #Grace period zero. Job running every minute.
+    AOS_OVERDUE_GRACE_PERIOD: 0
+    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_CRON: "0 * * ? * * *"
 
   keyVaults:
     "div":

--- a/charts/div-cos/values.preview.template.yaml
+++ b/charts/div-cos/values.preview.template.yaml
@@ -15,11 +15,6 @@ java:
     FLYWAY_URL: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase}}"
     #This means it will apply, as opposed to check, DB changes in preview (since a new DB is created for every deployment)
     FLYWAY_NOOP_STRATEGY: false
-    #AosOverdueJob: Grace period zero. Job running every minute.
-    SCHEDULER_ENABLED: true
-    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_ENABLED: true
-    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_CRON: "0 * * ? * * *"
-    AOS_OVERDUE_GRACE_PERIOD: 0
 
   keyVaults:
     "div":

--- a/charts/div-cos/values.preview.template.yaml
+++ b/charts/div-cos/values.preview.template.yaml
@@ -15,9 +15,11 @@ java:
     FLYWAY_URL: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase}}"
     #This means it will apply, as opposed to check, DB changes in preview (since a new DB is created for every deployment)
     FLYWAY_NOOP_STRATEGY: false
-    #Grace period zero. Job running every minute.
-    AOS_OVERDUE_GRACE_PERIOD: 0
+    #AosOverdueJob: Grace period zero. Job running every minute.
+    SCHEDULER_ENABLED: true
+    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_ENABLED: true
     SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_CRON: "0 * * ? * * *"
+    AOS_OVERDUE_GRACE_PERIOD: 0
 
   keyVaults:
     "div":

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AosOverdueTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AosOverdueTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.RetrieveCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.ElasticSearchTestHelper;
 
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
@@ -61,7 +62,7 @@ public class AosOverdueTest extends RetrieveCaseSupport {
         await().atMost(60, SECONDS).untilAsserted(() -> {
             CaseDetails caseDetails = retrieveCase(citizenUser, caseId);
             String state = caseDetails.getState();
-            assertThat(state, is(AOS_OVERDUE));
+            assertThat(format("Case %s should be in \"%s\" state", caseId, AOS_OVERDUE), state, is(AOS_OVERDUE));
         });
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/MarkAosCasesAsOverdueTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/MarkAosCasesAsOverdueTask.java
@@ -37,7 +37,9 @@ public class MarkAosCasesAsOverdueTask extends AsyncTask<Void> {
 
     @PostConstruct
     public void init() {
-        String limitDate = buildDateForTodayMinusGivenPeriod(caseOrchestrationValues.getAosOverdueGracePeriod() + ELASTIC_SEARCH_DAYS_REPRESENTATION);
+        String aosOverdueGracePeriod = caseOrchestrationValues.getAosOverdueGracePeriod();
+        log.info("Initialising {} with {} days of grace period.", MarkAosCasesAsOverdueTask.class.getSimpleName(), aosOverdueGracePeriod);
+        String limitDate = buildDateForTodayMinusGivenPeriod(aosOverdueGracePeriod + ELASTIC_SEARCH_DAYS_REPRESENTATION);
         queryBuilders = new QueryBuilder[] {
             QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AOS_AWAITING),
             QueryBuilders.rangeQuery("data.dueDate").lt(limitDate)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CMSElasticSearchSupport.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CMSElasticSearchSupport.java
@@ -18,6 +18,8 @@ import java.util.stream.Stream;
 @Component
 public class CMSElasticSearchSupport {
 
+    public static final String ELASTIC_SEARCH_DAYS_REPRESENTATION = "d";
+
     private final CaseMaintenanceClient caseMaintenanceClient;
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CaseOrchestrationValues.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/util/CaseOrchestrationValues.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.divorce.orchestration.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CaseOrchestrationValues {
+
+    @Value("${aos-overdue.grace-period}")
+    private String aosOverdueGracePeriod;
+
+    public String getAosOverdueGracePeriod() {
+        return aosOverdueGracePeriod;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,9 @@ scheduler:
       jobClass: 'uk.gov.hmcts.reform.divorce.orchestration.job.AosOverdueJob'
       cron: ${SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_CRON:0 0 3 ? * * *} #Every day at 3:00
 
+aos-overdue:
+  grace-period: ${AOS_OVERDUE_GRACE_PERIOD:29}
+
 server:
   port: ${CASE_ORCHESTRATION_SERVICE_URL:4012}
 

--- a/src/main/resources/example-application-aat.yml
+++ b/src/main/resources/example-application-aat.yml
@@ -89,6 +89,9 @@ scheduler:
       jobClass: 'uk.gov.hmcts.reform.divorce.orchestration.job.AosOverdueJob'
       cron: ${SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_CRON:0 0 3 ? * * *} #Every day at 3:00
 
+aos-overdue:
+  grace-period: ${AOS_OVERDUE_GRACE_PERIOD:29}
+
 server:
   port: ${CASE_ORCHESTRATION_SERVICE_URL:4012}
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aos/AosOverdueTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aos/AosOverdueTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.functionaltest.MockedFunctionalTest;
@@ -31,9 +32,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOT_RECEIVED_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.CMSElasticSearchSupport.buildDateForTodayMinusGivenPeriod;
 
+@TestPropertySource(properties = {
+    "AOS_OVERDUE_GRACE_PERIOD=0"
+})
 public class AosOverdueTest extends MockedFunctionalTest {
 
-    private static final String TIME_LIMIT_FOR_AOS = "30d";
+    private static final String TEST_CONFIGURED_AOS_OVERDUE_GRACE_PERIOD = "0d";
 
     @MockBean
     private AuthUtil authUtil;
@@ -54,7 +58,7 @@ public class AosOverdueTest extends MockedFunctionalTest {
     @Test
     public void shouldMoveEligibleCasesToAosOverdue() throws Exception {
         QueryBuilder stateQuery = QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AOS_AWAITING);
-        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data." + CCD_DUE_DATE).lte(buildDateForTodayMinusGivenPeriod(TIME_LIMIT_FOR_AOS));
+        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data." + CCD_DUE_DATE).lt(buildDateForTodayMinusGivenPeriod(TEST_CONFIGURED_AOS_OVERDUE_GRACE_PERIOD));
         stubCaseMaintenanceSearchEndpoint(asList(
             CaseDetails.builder().caseId("123").build(),
             CaseDetails.builder().caseId("456").build()

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aos/AosOverdueTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aos/AosOverdueTest.java
@@ -58,7 +58,8 @@ public class AosOverdueTest extends MockedFunctionalTest {
     @Test
     public void shouldMoveEligibleCasesToAosOverdue() throws Exception {
         QueryBuilder stateQuery = QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AOS_AWAITING);
-        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data." + CCD_DUE_DATE).lt(buildDateForTodayMinusGivenPeriod(TEST_CONFIGURED_AOS_OVERDUE_GRACE_PERIOD));
+        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data." + CCD_DUE_DATE)
+            .lt(buildDateForTodayMinusGivenPeriod(TEST_CONFIGURED_AOS_OVERDUE_GRACE_PERIOD));
         stubCaseMaintenanceSearchEndpoint(asList(
             CaseDetails.builder().caseId("123").build(),
             CaseDetails.builder().caseId("456").build()

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/MarkAosCasesAsOverdueTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/MarkAosCasesAsOverdueTaskTest.java
@@ -34,12 +34,11 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.util.CMSElasticSearchSupport.buildDateForTodayMinusGivenPeriod;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MarkAosCasesAsOverdueTaskTest {
 
-    private static final String AOS_TIME_LIMIT = "30d";
+    private static final String DEFAULT_GRACE_PERIOD = "29";
 
     @Mock
     private CMSElasticSearchSupport cmsElasticSearchSupport;
@@ -64,7 +63,7 @@ public class MarkAosCasesAsOverdueTaskTest {
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
 
         QueryBuilder stateQuery = QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AOS_AWAITING);
-        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data.dueDate").lte(buildDateForTodayMinusGivenPeriod(AOS_TIME_LIMIT));
+        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data.dueDate").lt("now/d-" + DEFAULT_GRACE_PERIOD + "d");
         queryBuilders = new QueryBuilder[] {stateQuery, dateFilter};
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/MarkAosCasesAsOverdueTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/MarkAosCasesAsOverdueTaskTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.event.domain.AosOverdueRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CMSElasticSearchSupport;
+import uk.gov.hmcts.reform.divorce.orchestration.util.CaseOrchestrationValues;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -38,13 +39,16 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RunWith(MockitoJUnitRunner.class)
 public class MarkAosCasesAsOverdueTaskTest {
 
-    private static final String DEFAULT_GRACE_PERIOD = "29";
+    private static final String TEST_GRACE_PERIOD = "12";
 
     @Mock
     private CMSElasticSearchSupport cmsElasticSearchSupport;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private CaseOrchestrationValues caseOrchestrationValues;
 
     @InjectMocks
     private MarkAosCasesAsOverdueTask classUnderTest;
@@ -57,13 +61,15 @@ public class MarkAosCasesAsOverdueTaskTest {
 
     @Before
     public void setUp() {
+        when(caseOrchestrationValues.getAosOverdueGracePeriod()).thenReturn(TEST_GRACE_PERIOD);
+
         classUnderTest.init();
 
         context = new DefaultTaskContext();
         context.setTransientObject(AUTH_TOKEN_JSON_KEY, AUTH_TOKEN);
 
         QueryBuilder stateQuery = QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AOS_AWAITING);
-        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data.dueDate").lt("now/d-" + DEFAULT_GRACE_PERIOD + "d");
+        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data.dueDate").lt("now/d-" + TEST_GRACE_PERIOD + "d");
         queryBuilders = new QueryBuilder[] {stateQuery, dateFilter};
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CaseOrchestrationValuesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/util/CaseOrchestrationValuesTest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.divorce.orchestration.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class CaseOrchestrationValuesTest {
+
+    @Autowired
+    private CaseOrchestrationValues caseOrchestrationValues;
+
+    @Test
+    public void shouldLoadDefaultValues() {
+        assertThat(caseOrchestrationValues.getAosOverdueGracePeriod(), is("29"));
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -71,6 +71,8 @@ scheduler:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types
             non_contextual_creation: true
 
+aos-overdue:
+  grace-period: ${AOS_OVERDUE_GRACE_PERIOD:29}
 
 jackson:
   deserialization:


### PR DESCRIPTION
# Description

This fix keeps the behaviour exactly as it is in prod until we lower the grace period to zero by the business' request through an environment variable.
I'm also making the preview environment work with zero-days grace period and have the job running every minute to make demoing this easier.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit, functional and integration tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
