### PR TITLE
Remove specific solicitor names to be more generic

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -256,8 +256,6 @@ public class OrchestrationConstants {
     public static final String NOTIFICATION_CO_RESPONDENT_NAME = "co-respondent name";
     public static final String NOTIFICATION_OTHER_NAME = "general other recipient name";
     public static final String NOTIFICATION_SOLICITOR_NAME = "solicitor name";
-    public static final String NOTIFICATION_RESPONDENT_SOLICITOR_NAME = "respondent solicitor name";
-    public static final String NOTIFICATION_CO_RESPONDENT_SOLICITOR_NAME = "co-respondent solicitor name";
     public static final String NOTIFICATION_WELSH_FORM_SUBMISSION_DATE_LIMIT_KEY = "welsh form submission date limit";
     public static final String NOTIFICATION_GENERAL_EMAIL_DETAILS = "general email details";
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/helper/GeneralEmailTaskHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/helper/GeneralEmailTaskHelper.java
@@ -12,11 +12,9 @@ import java.util.Map;
 import static java.lang.String.format;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CCD_REFERENCE_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CO_RESPONDENT_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CO_RESPONDENT_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_GENERAL_EMAIL_DETAILS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_OTHER_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_PET_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RESPONDENT_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RESP_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getCoRespondentFullName;
@@ -96,7 +94,7 @@ public class GeneralEmailTaskHelper {
         Map<String, String> templateVars = getDefaultTemplateVars(taskContext, caseData);
         templateVars.put(NOTIFICATION_PET_NAME, getPetitionerFullName(caseData));
         templateVars.put(NOTIFICATION_RESP_NAME, getRespondentFullName(caseData));
-        templateVars.put(NOTIFICATION_RESPONDENT_SOLICITOR_NAME, getRespondentSolicitorFullName(caseData));
+        templateVars.put(NOTIFICATION_SOLICITOR_NAME, getRespondentSolicitorFullName(caseData));
 
         return templateVars;
     }
@@ -112,7 +110,7 @@ public class GeneralEmailTaskHelper {
         Map<String, String> templateVars = getDefaultTemplateVars(taskContext, caseData);
         templateVars.put(NOTIFICATION_PET_NAME, getPetitionerFullName(caseData));
         templateVars.put(NOTIFICATION_RESP_NAME, getRespondentFullName(caseData));
-        templateVars.put(NOTIFICATION_CO_RESPONDENT_SOLICITOR_NAME, getCoRespondentSolicitorFullName(caseData));
+        templateVars.put(NOTIFICATION_SOLICITOR_NAME, getCoRespondentSolicitorFullName(caseData));
 
         return templateVars;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/helper/GeneralEmailTaskHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/helper/GeneralEmailTaskHelperTest.java
@@ -29,11 +29,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.P
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CCD_REFERENCE_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CO_RESPONDENT_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_CO_RESPONDENT_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_GENERAL_EMAIL_DETAILS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_OTHER_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_PET_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RESPONDENT_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_RESP_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOTIFICATION_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.CO_RESPONDENT_FIRST_NAME;
@@ -100,7 +98,7 @@ public class GeneralEmailTaskHelperTest {
 
         assertThat(templateVars.get(NOTIFICATION_PET_NAME), is(TEST_PETITIONER_FULL_NAME));
         assertThat(templateVars.get(NOTIFICATION_RESP_NAME), is(TEST_RESPONDENT_FULL_NAME));
-        assertThat(templateVars.get(NOTIFICATION_RESPONDENT_SOLICITOR_NAME), is(TEST_RESPONDENT_SOLICITOR_NAME));
+        assertThat(templateVars.get(NOTIFICATION_SOLICITOR_NAME), is(TEST_RESPONDENT_SOLICITOR_NAME));
     }
 
     @Test
@@ -125,7 +123,7 @@ public class GeneralEmailTaskHelperTest {
 
         assertThat(templateVars.get(NOTIFICATION_PET_NAME), is(TEST_PETITIONER_FULL_NAME));
         assertThat(templateVars.get(NOTIFICATION_RESP_NAME), is(TEST_RESPONDENT_FULL_NAME));
-        assertThat(templateVars.get(NOTIFICATION_CO_RESPONDENT_SOLICITOR_NAME), is(TEST_CO_RESPONDENT_SOLICITOR_NAME));
+        assertThat(templateVars.get(NOTIFICATION_SOLICITOR_NAME), is(TEST_CO_RESPONDENT_SOLICITOR_NAME));
     }
 
     @Test


### PR DESCRIPTION
# Description
https://tools.hmcts.net/jira/browse/DIV-6502

This PR will make all docmosis template names for solicitors generic.
This moves away from "respondent solicitor name" to a "solicitor name"