### PR TITLE
DIV-6564 Update current naming convention for service refusal documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
@@ -10,11 +10,15 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentG
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.LocalDate;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateFromLocalDate;
 
 /*
  * It should be used as a base class to prepare data models with set of data needed to generate PDFs.
@@ -67,6 +71,10 @@ public abstract class BasePayloadSpecificDocumentGenerationTask implements Task<
             getTemplateId(),
             context.getTransientObject(AUTH_TOKEN_JSON_KEY)
         );
+    }
+
+    protected String getFilenameWithCurrentDate() {
+        return format(DOCUMENT_FILENAME_FMT, getDocumentType(), formatDateFromLocalDate(LocalDate.now()));
     }
 
     protected GeneratedDocumentInfo populateMetadataForGeneratedDocument(GeneratedDocumentInfo documentInfo) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/bulk/printing/BasePayloadSpecificDocumentGenerationTask.java
@@ -10,15 +10,11 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentG
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
-import java.time.LocalDate;
 import java.util.Map;
 
-import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
-import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateFromLocalDate;
 
 /*
  * It should be used as a base class to prepare data models with set of data needed to generate PDFs.
@@ -73,14 +69,13 @@ public abstract class BasePayloadSpecificDocumentGenerationTask implements Task<
         );
     }
 
-    protected String getFilenameWithCurrentDate() {
-        return format(DOCUMENT_FILENAME_FMT, getDocumentType(), formatDateFromLocalDate(LocalDate.now()));
+    protected String getFileName() {
+        return getDocumentType();
     }
 
     protected GeneratedDocumentInfo populateMetadataForGeneratedDocument(GeneratedDocumentInfo documentInfo) {
         documentInfo.setDocumentType(getDocumentType());
-        documentInfo.setFileName(getDocumentType());
-
+        documentInfo.setFileName(getFileName());
         return documentInfo;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderDraftGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderDraftGenerationTask.java
@@ -39,7 +39,7 @@ public class GeneralOrderDraftGenerationTask extends GeneralOrderGenerationTask 
     }
 
     private DocumentLink toDocumentLink(GeneratedDocumentInfo documentInfo) {
-        documentInfo.setFileName(nameWithCurrentDate());
+        documentInfo.setFileName(getFilenameWithCurrentDate());
 
         return CcdMappers.mapDocumentInfoToCcdDocument(documentInfo)
             .getValue()

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderDraftGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderDraftGenerationTask.java
@@ -39,7 +39,7 @@ public class GeneralOrderDraftGenerationTask extends GeneralOrderGenerationTask 
     }
 
     private DocumentLink toDocumentLink(GeneratedDocumentInfo documentInfo) {
-        documentInfo.setFileName(getFilenameWithCurrentDate());
+        documentInfo.setFileName(getFileName());
 
         return CcdMappers.mapDocumentInfoToCcdDocument(documentInfo)
             .getValue()

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTask.java
@@ -22,16 +22,12 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BasePayload
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 import uk.gov.hmcts.reform.divorce.orchestration.util.PartyRepresentationChecker;
 import uk.gov.hmcts.reform.divorce.orchestration.util.mapper.CcdMappers;
-import uk.gov.hmcts.reform.divorce.utils.DateUtils;
 
-import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.lang.String.format;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_ORDERS;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
 
 @Component
@@ -71,8 +67,7 @@ public class GeneralOrderGenerationTask extends BasePayloadSpecificDocumentGener
     @Override
     protected GeneratedDocumentInfo populateMetadataForGeneratedDocument(GeneratedDocumentInfo documentInfo) {
         documentInfo.setDocumentType(getDocumentType());
-        documentInfo.setFileName(nameWithCurrentDate());
-
+        documentInfo.setFileName(getFilenameWithCurrentDate());
         return documentInfo;
     }
 
@@ -101,14 +96,6 @@ public class GeneralOrderGenerationTask extends BasePayloadSpecificDocumentGener
     @Override
     public String getDocumentType() {
         return FileMetadata.DOCUMENT_TYPE;
-    }
-
-    protected String nameWithCurrentDate() {
-        return format(DOCUMENT_FILENAME_FMT, getDocumentType(), getFormattedNow());
-    }
-
-    private String getFormattedNow() {
-        return DateUtils.formatDateFromLocalDate(LocalDate.now());
     }
 
     private String getJudgeType(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTask.java
@@ -23,12 +23,16 @@ import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 import uk.gov.hmcts.reform.divorce.orchestration.util.PartyRepresentationChecker;
 import uk.gov.hmcts.reform.divorce.orchestration.util.mapper.CcdMappers;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_ORDERS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateFromLocalDate;
 
 @Component
 @Slf4j
@@ -65,13 +69,6 @@ public class GeneralOrderGenerationTask extends BasePayloadSpecificDocumentGener
     }
 
     @Override
-    protected GeneratedDocumentInfo populateMetadataForGeneratedDocument(GeneratedDocumentInfo documentInfo) {
-        documentInfo.setDocumentType(getDocumentType());
-        documentInfo.setFileName(getFilenameWithCurrentDate());
-        return documentInfo;
-    }
-
-    @Override
     protected DocmosisTemplateVars prepareDataForPdf(TaskContext context, Map<String, Object> caseData) {
         return GeneralOrder.generalOrderBuilder()
             .caseReference(getCaseId(context))
@@ -96,6 +93,11 @@ public class GeneralOrderGenerationTask extends BasePayloadSpecificDocumentGener
     @Override
     public String getDocumentType() {
         return FileMetadata.DOCUMENT_TYPE;
+    }
+
+    @Override
+    protected String getFileName() {
+        return format(DOCUMENT_FILENAME_FMT, getDocumentType(), formatDateFromLocalDate(LocalDate.now()));
     }
 
     private String getJudgeType(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/ServiceRefusalOrderGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/ServiceRefusalOrderGenerationTask.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ServiceApplicationRefusalOrder;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.docmosis.DocmosisTemplateVars;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
@@ -12,10 +11,14 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextracto
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BasePayloadSpecificDocumentGenerationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CcdUtil;
 
+import java.time.LocalDate;
 import java.util.Map;
 
+import static java.lang.String.format;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getCaseId;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.ServiceApplicationRefusalHelper.getServiceApplicationRefusalReason;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateFromLocalDate;
 
 @Component
 public abstract class ServiceRefusalOrderGenerationTask extends BasePayloadSpecificDocumentGenerationTask {
@@ -41,9 +44,7 @@ public abstract class ServiceRefusalOrderGenerationTask extends BasePayloadSpeci
     }
 
     @Override
-    protected GeneratedDocumentInfo populateMetadataForGeneratedDocument(GeneratedDocumentInfo documentInfo) {
-        documentInfo.setDocumentType(getDocumentType());
-        documentInfo.setFileName(getFilenameWithCurrentDate());
-        return documentInfo;
+    protected String getFileName() {
+        return format(DOCUMENT_FILENAME_FMT, getDocumentType(), formatDateFromLocalDate(LocalDate.now()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/ServiceRefusalOrderGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/servicejourney/ServiceRefusalOrderGenerationTask.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ServiceApplicationRefusalOrder;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.docmosis.DocmosisTemplateVars;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GeneratedDocumentInfo;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.PdfDocumentGenerationService;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
@@ -37,5 +38,12 @@ public abstract class ServiceRefusalOrderGenerationTask extends BasePayloadSpeci
             .serviceApplicationRefusalReason(getServiceApplicationRefusalReason(caseData))
             .documentIssuedOn(DatesDataExtractor.getLetterDate())
             .build();
+    }
+
+    @Override
+    protected GeneratedDocumentInfo populateMetadataForGeneratedDocument(GeneratedDocumentInfo documentInfo) {
+        documentInfo.setDocumentType(getDocumentType());
+        documentInfo.setFileName(getFilenameWithCurrentDate());
+        return documentInfo;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/MakeServiceDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/MakeServiceDecisionTest.java
@@ -44,7 +44,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
@@ -180,7 +179,7 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
         webClient.perform(post(API_URL)
             .contentType(MediaType.APPLICATION_JSON)
             .header(AUTHORIZATION, AUTH_TOKEN)
-            .content(convertObjectToJsonString(ccdCallbackRequest))).andDo(print())
+            .content(convertObjectToJsonString(ccdCallbackRequest)))
             .andExpect(status().isOk())
             .andExpect(commonExpectationsForServiceRefusalOrder(documentType, expectedDocumentFilename));
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/generalorders/GeneralOrderGenerationTaskTest.java
@@ -12,13 +12,17 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.
 import uk.gov.hmcts.reform.divorce.orchestration.exception.JudgeTypeNotFoundException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_ORDERS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME_FMT;
+import static uk.gov.hmcts.reform.divorce.utils.DateUtils.formatDateFromLocalDate;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GeneralOrderGenerationTaskTest extends AbstractGeneralOrderGenerationTaskTest {
@@ -55,11 +59,14 @@ public class GeneralOrderGenerationTaskTest extends AbstractGeneralOrderGenerati
 
     private void verifyNewDocumentWasAddedToCaseData(
         Map<String, Object> returnedCaseData, String expectedDocumentType) {
+        String expectedGeneralOrderFileName = format(DOCUMENT_FILENAME_FMT, expectedDocumentType, formatDateFromLocalDate(LocalDate.now()));
+
         List<CollectionMember<DivorceGeneralOrder>> generalOrdersCollection = (List) returnedCaseData.get(GENERAL_ORDERS);
         assertThat(generalOrdersCollection.size(), is(1));
+
         DivorceGeneralOrder item = generalOrdersCollection.get(0).getValue();
         assertThat(item.getDocument().getDocumentType(), is(expectedDocumentType));
-        assertThat(item.getDocument().getDocumentFileName(), is(generalOrderGenerationTask.nameWithCurrentDate()));
+        assertThat(item.getDocument().getDocumentFileName(), is(expectedGeneralOrderFileName));
 
         assertThat(item.getGeneralOrderParties().size(), is(1));
         assertThat(item.getGeneralOrderParties().get(0), is(GeneralOrderParty.PETITIONER));


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-6564 which is a subtask of https://tools.hmcts.net/jira/browse/DIV-6532

Updating naming convention for refusal file names to end with the current date it was created. This is following the model for general orders and also allows us to differentiate multiple deemed or dispensed documents in a service application collection.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
