### PR TITLE
Forcing dependencies to stop Java 11 issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:${versions.lombok}")
     testAnnotationProcessor("org.projectlombok:lombok:${versions.lombok}")
 
-    implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.2.11'
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
     implementation group: 'com.jayway.jsonpath', name: 'json-path-assert', version: versions.jsonPathAssert
     implementation group: 'com.github.kirviq', name: 'dumbster', version: versions.dumbster
     implementation group: 'com.puppycrawl.tools', name: 'checkstyle', version: versions.puppyCrawl

--- a/build.gradle
+++ b/build.gradle
@@ -240,6 +240,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:${versions.lombok}")
     testAnnotationProcessor("org.projectlombok:lombok:${versions.lombok}")
 
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.2.11'
     implementation group: 'com.jayway.jsonpath', name: 'json-path-assert', version: versions.jsonPathAssert
     implementation group: 'com.github.kirviq', name: 'dumbster', version: versions.dumbster
     implementation group: 'com.puppycrawl.tools', name: 'checkstyle', version: versions.puppyCrawl


### PR DESCRIPTION
# Description

Hopefully this will keep our tests working without the Java 11 error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
