### PR TITLE
DIV-6504: clean up before implementation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/GeneralEmailParties.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/GeneralEmailParties.java
@@ -4,12 +4,10 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ListElements {
+public class GeneralEmailParties {
 
-    // GeneralEmailPartiesEnum ListElementCode values
     public static final String RESPONDENT_GENERAL_EMAIL_SELECTION = "respondent";
     public static final String PETITIONER_GENERAL_EMAIL_SELECTION = "petitioner";
     public static final String CO_RESPONDENT_GENERAL_EMAIL_SELECTION = "co-respondent";
     public static final String OTHER_GENERAL_EMAIL_SELECTION = "other";
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/GeneralOrderParty.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/GeneralOrderParty.java
@@ -6,7 +6,7 @@ public enum GeneralOrderParty {
 
     PETITIONER("petitioner"),
     RESPONDENT("respondent"),
-    CO_RESPONDENT("co-respondent");
+    CORESPONDENT("corespondent");
 
     private final String value;
 
@@ -32,8 +32,8 @@ public enum GeneralOrderParty {
             return GeneralOrderParty.RESPONDENT;
         }
 
-        if (party.equals(CO_RESPONDENT.getValue())) {
-            return GeneralOrderParty.CO_RESPONDENT;
+        if (party.equals(CORESPONDENT.getValue())) {
+            return GeneralOrderParty.CORESPONDENT;
         }
 
         return null;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/GeneralOrderDataExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/GeneralOrderDataExtractor.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.GeneralOrderPa
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.helper.ExtractorHelper.getMandatoryListOfStrings;
@@ -50,6 +51,7 @@ public class GeneralOrderDataExtractor {
     public static List<GeneralOrderParty> getGeneralOrderParties(Map<String, Object> caseData) {
         return getMandatoryListOfStrings(caseData, CaseDataKeys.GENERAL_ORDER_PARTIES).stream()
             .map(GeneralOrderParty::from)
+            .filter(Objects::nonNull)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/GeneralEmailWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/GeneralEmailWorkflow.java
@@ -21,10 +21,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.CO_RESPONDENT_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.OTHER_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.PETITIONER_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.RESPONDENT_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.CO_RESPONDENT_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.OTHER_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.PETITIONER_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.RESPONDENT_GENERAL_EMAIL_SELECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.PartyRepresentationChecker.getGeneralEmailParties;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.PartyRepresentationChecker.isCoRespondentDigital;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/generalemail/GeneralEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/generalemail/GeneralEmailTest.java
@@ -49,10 +49,10 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.C
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_EMAIL_DETAILS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_EMAIL_PARTIES;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PETITIONER_EMAIL;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.CO_RESPONDENT_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.OTHER_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.PETITIONER_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.RESPONDENT_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.CO_RESPONDENT_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.OTHER_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.PETITIONER_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.RESPONDENT_GENERAL_EMAIL_SELECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_REPRESENTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITIONER_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_SOL_REPRESENTED;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
@@ -18,10 +18,10 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLIC
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_EMAIL_OTHER_RECIPIENT_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_EMAIL_OTHER_RECIPIENT_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_EMAIL_PARTIES;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.CO_RESPONDENT_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.OTHER_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.PETITIONER_GENERAL_EMAIL_SELECTION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ListElements.RESPONDENT_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.CO_RESPONDENT_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.OTHER_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.PETITIONER_GENERAL_EMAIL_SELECTION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.GeneralEmailParties.RESPONDENT_GENERAL_EMAIL_SELECTION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_IS_USING_DIGITAL_CHANNEL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_REPRESENTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_DERIVED_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_ADDRESS;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/GeneralOrderDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/GeneralOrderDataExtractorTest.java
@@ -80,6 +80,15 @@ public class GeneralOrderDataExtractorTest {
     }
 
     @Test
+    public void getGeneralOrderPartiesShouldReturnEmptyListWhenInvalidValue() {
+        Map<String, Object> caseData = ImmutableMap.of(
+            CcdFields.GENERAL_ORDER_PARTIES, asList("invalid value")
+        );
+
+        assertThat(GeneralOrderDataExtractor.getGeneralOrderParties(caseData).size(), is(0));
+    }
+
+    @Test
     public void getGeneralOrderPartiesShouldReturnListWhenFieldFound() {
         Map<String, Object> caseData = ImmutableMap.of(
             CcdFields.GENERAL_ORDER_PARTIES, asList(GeneralOrderParty.PETITIONER.getValue())
@@ -89,6 +98,28 @@ public class GeneralOrderDataExtractorTest {
         assertThat(
             GeneralOrderDataExtractor.getGeneralOrderParties(caseData).get(0),
             is(GeneralOrderParty.PETITIONER)
+        );
+    }
+
+    @Test
+    public void getGeneralOrderPartiesShouldRemoveNullsReturnListWhenFieldFound() {
+        Map<String, Object> caseData = ImmutableMap.of(
+            CcdFields.GENERAL_ORDER_PARTIES,
+            asList(
+                GeneralOrderParty.CORESPONDENT.getValue(),
+                "this will be not found",
+                GeneralOrderParty.RESPONDENT.getValue()
+            )
+        );
+
+        assertThat(GeneralOrderDataExtractor.getGeneralOrderParties(caseData).size(), is(2));
+        assertThat(
+            GeneralOrderDataExtractor.getGeneralOrderParties(caseData).get(0),
+            is(GeneralOrderParty.CORESPONDENT)
+        );
+        assertThat(
+            GeneralOrderDataExtractor.getGeneralOrderParties(caseData).get(1),
+            is(GeneralOrderParty.RESPONDENT)
         );
     }
 }


### PR DESCRIPTION
"co-respondent" to "corespondent" and renamed class that should be only for one specific fixed list and not another "I-don't-know-where-to-store-this-value" class of random consts.

CCD update:
https://github.com/hmcts/div-ccd-definitions/pull/500