### PR TITLE
Fixing class duplication issue that makes integration tests fail

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/AosSolicitorNominatedCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/AosSolicitorNominatedCallbackTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.callback;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/BulkPrintCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/BulkPrintCallbackTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/CaseListedForHearingCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/CaseListedForHearingCallbackTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/GetPetitionIssueFeesTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/GetPetitionIssueFeesTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseLink;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PaymentUpdateCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PaymentUpdateCallbackTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.payment.PaymentUpdate;
 import uk.gov.hmcts.reform.divorce.support.CcdClientSupport;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PetitionIssueCallBackE2ETest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/PetitionIssueCallBackE2ETest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.category.ExtendedTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/RemoveCaseFromListingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/RemoveCaseFromListingTest.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseLink;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/ScheduleBulkCaseForListingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/ScheduleBulkCaseForListingTest.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Ignore;
 import org.junit.Test;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseLink;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorLinkCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorLinkCaseCallbackTest.java
@@ -8,8 +8,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.PinResponse;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.PinResponse;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.RetrieveAosCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorPersonalServiceCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorPersonalServiceCallbackTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.callback;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 import uk.gov.hmcts.reform.divorce.RetryRule;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.IdamUtils;
 
 import java.io.IOException;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/draft/DraftServiceEndToEndTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/draft/DraftServiceEndToEndTest.java
@@ -7,7 +7,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cms.CmsClientSupport;
 import uk.gov.hmcts.reform.divorce.support.cos.DraftsSubmissionSupport;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AmendPetitionForRefusalTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AmendPetitionForRefusalTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.support.CcdClientSupport;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AmendPetitionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AmendPetitionTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.support.CcdClientSupport;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AosOverdueTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/AosOverdueTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.RetrieveCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.ElasticSearchTestHelper;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/CreateBulkCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/CreateBulkCaseTest.java
@@ -7,7 +7,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/LinkRespondentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/LinkRespondentTest.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.category.ExtendedTest;
-import uk.gov.hmcts.reform.divorce.model.PinResponse;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.PinResponse;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.RetrieveAosCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/MakeCaseEligibleForDATest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/MakeCaseEligibleForDATest.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cms.CmsClientSupport;
 import uk.gov.hmcts.reform.divorce.support.cos.RetrieveCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/RetrieveAosTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/RetrieveAosTest.java
@@ -8,7 +8,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.RetrieveAosCaseSupport;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/RetrieveCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/RetrieveCaseTest.java
@@ -8,7 +8,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.RetrieveCaseSupport;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SolicitorAmendPetitionForRefusalTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SolicitorAmendPetitionForRefusalTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitCaseToCCDIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitCaseToCCDIntegrationTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.category.ExtendedTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.cos.RetrieveCaseSupport;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitCoRespondentAosCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitCoRespondentAosCaseTest.java
@@ -10,7 +10,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.category.ExtendedTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.RetrieveAosCaseSupport;
 
 import java.time.LocalDate;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDaCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDaCaseTest.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitDnCaseTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 
 import static org.junit.Assert.assertEquals;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitRespondentAosCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/SubmitRespondentAosCaseTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.category.ExtendedTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 
 import java.time.LocalDate;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/UpdateCaseInCCDIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/maintenance/UpdateCaseInCCDIntegrationTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.CcdClientSupport;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/GeneratePinRequest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/GeneratePinRequest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.divorce.model;
+package uk.gov.hmcts.reform.divorce.model.idam;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/PinResponse.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/PinResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.divorce.model;
+package uk.gov.hmcts.reform.divorce.model.idam;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Builder;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/RegisterUserRequest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/RegisterUserRequest.java
@@ -1,8 +1,9 @@
-package uk.gov.hmcts.reform.divorce.model;
+package uk.gov.hmcts.reform.divorce.model.idam;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
+import uk.gov.hmcts.reform.divorce.model.idam.UserGroup;
 
 @Builder
 @Getter

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/UserDetails.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/UserDetails.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.divorce.model;
+package uk.gov.hmcts.reform.divorce.model.idam;
 
 import lombok.Builder;
 import lombok.Data;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/UserGroup.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/model/idam/UserGroup.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.divorce.model;
+package uk.gov.hmcts.reform.divorce.model.idam;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdClientSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdClientSupport.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 
 public class CcdClientSupport {
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdSubmissionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdSubmissionSupport.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpHeaders;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;
 
 import java.util.Arrays;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamUtils.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamUtils.java
@@ -7,11 +7,11 @@ import org.apache.http.entity.ContentType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import uk.gov.hmcts.reform.divorce.model.GeneratePinRequest;
-import uk.gov.hmcts.reform.divorce.model.PinResponse;
-import uk.gov.hmcts.reform.divorce.model.RegisterUserRequest;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
-import uk.gov.hmcts.reform.divorce.model.UserGroup;
+import uk.gov.hmcts.reform.divorce.model.idam.GeneratePinRequest;
+import uk.gov.hmcts.reform.divorce.model.idam.PinResponse;
+import uk.gov.hmcts.reform.divorce.model.idam.RegisterUserRequest;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserGroup;
 
 import java.util.ArrayList;
 import java.util.Base64;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cms/CmsClientSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cms/CmsClientSupport.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.client.CaseMaintenanceClient;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 import uk.gov.hmcts.reform.divorce.util.RestUtil;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/DraftsSubmissionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/DraftsSubmissionSupport.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.divorce.support.cos;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.model.idam.UserDetails;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 
 import java.util.Map;


### PR DESCRIPTION
# Description

The fact that a different UserDetails class exist in the common-lib in the same package is both confusing and leads to runtime errors in Integration tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
