### PR TITLE
feature(TA-12): Retry failed API tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
     id 'jacoco'
     id 'org.flywaydb.flyway' version '6.5.5'
+    id 'org.gradle.test-retry' version '1.1.9'
     id 'org.owasp.dependencycheck' version '6.0.2'
     id 'org.sonarqube' version '3.0'
     id 'org.springframework.boot' version '2.3.4.RELEASE'
@@ -399,6 +400,10 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
 
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     forkEvery = 10
+    retry {
+        maxRetries = 2
+        maxFailures = 30
+    }
 
     setTestClassesDirs(sourceSets.integrationTest.output.classesDirs)
     setClasspath(sourceSets.integrationTest.runtimeClasspath)


### PR DESCRIPTION
# Description

This change adds retries to the currently flakey Functional API test-runs in AAT, to help improve build pipeline stability and reduce the impact from other services in the test environment.
The tests will be retried up to a maximum of 2 times, and have a cut-off at 30 retries, so that if a common component like IDAM is down it won't hog build resources retrying unnecessarily.

Fixes # (TA-141)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
