### PR TITLE
DIV-6178: Changing the structure of existing AOS Overdue job to make it extensible for new events.

### DIFF
--- a/charts/div-cos/values.preview.template.yaml
+++ b/charts/div-cos/values.preview.template.yaml
@@ -15,9 +15,9 @@ java:
     DIV_SCHEDULER_DB_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     FLYWAY_URL: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase}}"
     #Scheduler parameters
-    SCHEDULER_ENABLED: false
-    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_ENABLED: false
-    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_CRON: "0 * * ? * * *"#Runs every minute (if enabled)
+    SCHEDULER_ENABLED: true
+    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_ENABLED: true
+    SCHEDULER_MAKE_ELIGIBLE_CASES_AOS_OVERDUE_CRON: "0 0/10 * ? * * *"#Runs every 10 minutes (if enabled)
 
   keyVaults:
     "div":

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/util/ElasticSearchTestHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/util/ElasticSearchTestHelper.java
@@ -34,10 +34,10 @@ public class ElasticSearchTestHelper {
     }
 
     private List<CaseDetails> searchCasesWithElasticSearch(final String caseId, final String authToken, String expectedState) {
-        QueryBuilder caseIdFilter = QueryBuilders.matchQuery(ES_CASE_ID_KEY, caseId);
-        QueryBuilder stateFilter = QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, expectedState);
-
-        String searchSourceBuilder = buildCMSBooleanSearchSource(0, 10, caseIdFilter, stateFilter);
+        QueryBuilder queryBuilder = QueryBuilders.boolQuery()
+            .filter(QueryBuilders.matchQuery(ES_CASE_ID_KEY, caseId))
+            .filter(QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, expectedState));
+        String searchSourceBuilder = buildCMSBooleanSearchSource(0, 10, queryBuilder);
 
         return cmsClientSupport.searchCases(searchSourceBuilder, authToken);
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/internal/AosInternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/internal/AosInternalController.java
@@ -30,7 +30,7 @@ public class AosInternalController {
         throws CaseOrchestrationServiceException {
 
         log.info("Will look for cases that are eligible to be moved to 'AOSOverdue' state");
-        aosService.markCasesToBeMovedToAosOverdue(authorizationToken);
+        aosService.findCasesForWhichAosIsOverdue(authorizationToken);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
@@ -67,4 +67,5 @@ public class CcdFields {
     public static final String GENERAL_REFERRAL_WITHOUT_NOTICE_FEE_SUMMARY = "generalReferralWithoutNoticeFeeSummary";
 
     public static final String SERVED_BY_PROCESS_SERVER = "ServedByProcessServer";
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/job/AosOverdueJob.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/job/AosOverdueJob.java
@@ -23,7 +23,7 @@ public class AosOverdueJob implements Job {
         log.info("Running {} job", this.getClass().getSimpleName());
 
         try {
-            aosService.markCasesToBeMovedToAosOverdue(authUtil.getCaseworkerToken());
+            aosService.findCasesForWhichAosIsOverdue(authUtil.getCaseworkerToken());
         } catch (CaseOrchestrationServiceException e) {
             JobExecutionException jobExecutionException = new JobExecutionException(e);
             log.error("Error when trying to run {}", this.getClass().getName(), jobExecutionException);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/AosService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/AosService.java
@@ -13,7 +13,7 @@ public interface AosService {
     Map<String, Object> processAosPackOfflineAnswers(String authToken, CaseDetails caseDetails, DivorceParty divorceParty)
         throws CaseOrchestrationServiceException;
 
-    void markCasesToBeMovedToAosOverdue(String authToken) throws CaseOrchestrationServiceException;
+    void findCasesForWhichAosIsOverdue(String authToken) throws CaseOrchestrationServiceException;
 
     void makeCaseAosOverdue(String authToken, String caseId) throws CaseOrchestrationServiceException;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/AosServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/AosServiceImpl.java
@@ -63,14 +63,14 @@ public class AosServiceImpl implements AosService {
     }
 
     @Override
-    public void markCasesToBeMovedToAosOverdue(String authToken) throws CaseOrchestrationServiceException {
-        log.info("Searching for cases that are eligible to be moved to AosOverdue");
+    public void findCasesForWhichAosIsOverdue(String authToken) throws CaseOrchestrationServiceException {
+        log.info("Searching for cases for which AOS are overdue");
 
         try {
             aosOverdueEligibilityWorkflow.run(authToken);
         } catch (WorkflowException e) {
             CaseOrchestrationServiceException caseOrchestrationServiceException = new CaseOrchestrationServiceException(e);
-            log.error("Error trying to find cases to move to AOSOverdue", caseOrchestrationServiceException);
+            log.error("Error trying to find cases for which AOS are overdue", caseOrchestrationServiceException);
             throw caseOrchestrationServiceException;
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aos/AosOverdueEligibilityWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aos/AosOverdueEligibilityWorkflow.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.aos.MarkAosCasesAsOverdueTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.aos.MarkCasesAsAosOverdueTask;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
 
@@ -14,7 +14,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RequiredArgsConstructor
 public class AosOverdueEligibilityWorkflow extends DefaultWorkflow<Void> {
 
-    private final MarkAosCasesAsOverdueTask markCasesToBeMovedToAosOverdue;
+    private final MarkCasesAsAosOverdueTask markCasesToBeMovedToAosOverdue;
 
     public void run(String authToken) throws WorkflowException {
         execute(new Task[] {markCasesToBeMovedToAosOverdue}, null, ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/TestConstants.java
@@ -122,4 +122,5 @@ public class TestConstants {
     public static final Map<String, Object> TEST_INCOMING_PAYLOAD = singletonMap("incomingKey", "incomingValue");
     public static final CaseDetails TEST_INCOMING_CASE_DETAILS = CaseDetails.builder().caseData(TEST_INCOMING_PAYLOAD).build();
     public static final Map<String, Object> TEST_PAYLOAD_TO_RETURN = singletonMap("returnedKey", "returnedValue");
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/internal/AosInternalControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/internal/AosInternalControllerTest.java
@@ -28,7 +28,7 @@ public class AosInternalControllerTest {
     public void shouldCallRightServiceMethod() throws CaseOrchestrationServiceException {
         ResponseEntity<String> response = controller.markCasesForBeingMovedToAosOverdue(AUTH_TOKEN);
 
-        verify(aosService).markCasesToBeMovedToAosOverdue(AUTH_TOKEN);
+        verify(aosService).findCasesForWhichAosIsOverdue(AUTH_TOKEN);
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeCasesDAOverdueITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MakeCasesDAOverdueITest.java
@@ -51,7 +51,7 @@ public class MakeCasesDAOverdueITest extends MockedFunctionalTest {
     private static final String DN_GRANTED_DATE = "2019-03-31";
     private static final String DN_GRANTED_DATA_REFERENCE = "data.DecreeNisiGrantedDate";
     private final List<CaseDetails> cases = new ArrayList<>();
-    private QueryBuilder[] queryBuilders;
+    private QueryBuilder query;
 
     @Autowired
     private MockMvc webClient;
@@ -85,17 +85,16 @@ public class MakeCasesDAOverdueITest extends MockedFunctionalTest {
         cases.add(caseDetails1);
         cases.add(caseDetails2);
 
-        queryBuilders = new QueryBuilder[] {
-            QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AWAITING_DA),
-            QueryBuilders.rangeQuery(DN_GRANTED_DATA_REFERENCE).lte(buildDateForTodayMinusGivenPeriod("1y"))
-        };
+        query = QueryBuilders.boolQuery()
+            .filter(QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AWAITING_DA))
+            .filter(QueryBuilders.rangeQuery(DN_GRANTED_DATA_REFERENCE).lte(buildDateForTodayMinusGivenPeriod("1y")));
     }
 
     @Test
     public void givenCaseIsInAwaitingDA_WhenMakeCaseOverdueForDAIsCalled_CaseMaintenanceServiceIsCalled() throws Exception {
         Map<String, Object> responseData = Collections.singletonMap(ID, TEST_CASE_ID);
         stubCaseMaintenanceUpdateEndpoint(responseData);
-        stubCaseMaintenanceSearchEndpoint(cases, queryBuilders);
+        stubCaseMaintenanceSearchEndpoint(cases, query);
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)
@@ -110,7 +109,7 @@ public class MakeCasesDAOverdueITest extends MockedFunctionalTest {
     @Test
     public void givenNoCasesInAwaitingDA_WhenMakeCaseOverdueForDAIsCalled_UpdateInCcdIsNotCalled() throws Exception {
         stubCaseMaintenanceUpdateEndpoint(emptyMap());
-        stubCaseMaintenanceSearchEndpoint(emptyList(), queryBuilders);
+        stubCaseMaintenanceSearchEndpoint(emptyList(), query);
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MockedFunctionalTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MockedFunctionalTest.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.SearchResult;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.documentgeneration.GenerateDocumentRequest;
-import uk.gov.hmcts.reform.divorce.orchestration.util.CMSElasticSearchSupport;
 import uk.gov.hmcts.reform.sendletter.api.SendLetterResponse;
 
 import java.util.List;
@@ -38,6 +37,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SERVICE_AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+import static uk.gov.hmcts.reform.divorce.orchestration.util.CMSElasticSearchSupport.buildCMSBooleanSearchSource;
 
 @ContextConfiguration(classes = OrchestrationServiceApplication.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -200,7 +200,7 @@ public abstract class MockedFunctionalTest {
                 .withBody(response)));
     }
 
-    protected void stubCaseMaintenanceSearchEndpoint(List<CaseDetails> casesToReturn, QueryBuilder... expectedQueryBuilders) {
+    protected void stubCaseMaintenanceSearchEndpoint(List<CaseDetails> casesToReturn, QueryBuilder query) {
         SearchResult searchResult = SearchResult.builder()
             .total(casesToReturn.size())
             .cases(casesToReturn)
@@ -208,8 +208,8 @@ public abstract class MockedFunctionalTest {
 
         MappingBuilder mappingBuilder = WireMock.post(CASE_MAINTENANCE_CLIENT_SEARCH_URL);
 
-        if (expectedQueryBuilders.length > 0) {
-            String expectedElasticSearchQuery = CMSElasticSearchSupport.buildCMSBooleanSearchSource(0, 50, expectedQueryBuilders);
+        if (query != null) {
+            String expectedElasticSearchQuery = buildCMSBooleanSearchSource(0, 50, query);
             mappingBuilder = mappingBuilder.withRequestBody(equalTo(expectedElasticSearchQuery));
         }
 
@@ -221,6 +221,10 @@ public abstract class MockedFunctionalTest {
         );
 
         maintenanceServiceServer.stubFor(mappingBuilder);
+    }
+
+    protected void stubCaseMaintenanceSearchEndpoint(List<CaseDetails> casesToReturn) {
+        stubCaseMaintenanceSearchEndpoint(casesToReturn, null);
     }
 
     public String stubDocumentGeneratorService(String templateName, Map<String, Object> templateValues, String documentTypeToReturn) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aos/AosOverdueTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/aos/AosOverdueTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.divorce.orchestration.functionaltest.aos;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.Before;
@@ -10,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.functionaltest.MockedFunctionalTest;
 import uk.gov.hmcts.reform.divorce.orchestration.util.AuthUtil;
@@ -21,13 +21,16 @@ import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.DUE_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_STARTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NOT_RECEIVED_AOS_EVENT_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.CMSElasticSearchSupport.buildDateForTodayMinusGivenPeriod;
@@ -57,25 +60,35 @@ public class AosOverdueTest extends MockedFunctionalTest {
 
     @Test
     public void shouldMoveEligibleCasesToAosOverdue() throws Exception {
-        QueryBuilder stateQuery = QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, AOS_AWAITING);
-        QueryBuilder dateFilter = QueryBuilders.rangeQuery("data." + CcdFields.DUE_DATE)
-            .lt(buildDateForTodayMinusGivenPeriod(TEST_CONFIGURED_AOS_OVERDUE_GRACE_PERIOD));
+        QueryBuilder expectedQuery = QueryBuilders.boolQuery()
+            .filter(QueryBuilders.matchQuery(CASE_STATE_JSON_KEY, String.join(SPACE, AOS_AWAITING, AOS_STARTED)).operator(Operator.OR))
+            .filter(QueryBuilders.rangeQuery("data." + DUE_DATE).lt(buildDateForTodayMinusGivenPeriod(TEST_CONFIGURED_AOS_OVERDUE_GRACE_PERIOD)));
         stubCaseMaintenanceSearchEndpoint(asList(
-            CaseDetails.builder().caseId("123").build(),
-            CaseDetails.builder().caseId("456").build()
-        ), stateQuery, dateFilter);
+            CaseDetails.builder().state(AOS_STARTED).caseId("123").build(),
+            CaseDetails.builder().state(AOS_AWAITING).caseId("456").build(),
+            CaseDetails.builder().state(AOS_AWAITING).caseId("789").build()
+        ), expectedQuery);
 
         mockMvc.perform(post("/cases/aos/make-overdue").header(AUTHORIZATION, AUTH_TOKEN))
             .andExpect(status().isOk());
 
         await().untilAsserted(() -> {
-            verifyCaseWasUpdated("123");
             verifyCaseWasUpdated("456");
+            verifyCaseWasUpdated("789");
         });
+        verifyCaseWasNotUpdated("123");
     }
 
     private void verifyCaseWasUpdated(String caseId) {
-        maintenanceServiceServer.verify(RequestPatternBuilder.newRequestPattern()
+        verifyCaseWasMovedGivenNumberOfTimes(caseId, 1);
+    }
+
+    private void verifyCaseWasNotUpdated(String caseId) {
+        verifyCaseWasMovedGivenNumberOfTimes(caseId, 0);
+    }
+
+    private void verifyCaseWasMovedGivenNumberOfTimes(String caseId, int expectedRequestCount) {
+        maintenanceServiceServer.verify(expectedRequestCount, RequestPatternBuilder.newRequestPattern()
             .withUrl(format("/casemaintenance/version/1/updateCase/%s/%s", caseId, NOT_RECEIVED_AOS_EVENT_ID))
             .withHeader(AUTHORIZATION, equalTo(AUTH_TOKEN))
             .withRequestBody(equalToJson("{}"))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/job/AosOverdueJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/job/AosOverdueJobTest.java
@@ -41,12 +41,12 @@ public class AosOverdueJobTest {
     public void shouldCallService() throws CaseOrchestrationServiceException, JobExecutionException {
         classUnderTest.execute(null);
 
-        verify(aosService).markCasesToBeMovedToAosOverdue(AUTH_TOKEN);
+        verify(aosService).findCasesForWhichAosIsOverdue(AUTH_TOKEN);
     }
 
     @Test
     public void shouldThrowJobExecutionException_WhenServiceFails() throws CaseOrchestrationServiceException {
-        doThrow(CaseOrchestrationServiceException.class).when(aosService).markCasesToBeMovedToAosOverdue(AUTH_TOKEN);
+        doThrow(CaseOrchestrationServiceException.class).when(aosService).findCasesForWhichAosIsOverdue(AUTH_TOKEN);
 
         JobExecutionException jobExecutionException = assertThrows(
             JobExecutionException.class,

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/job/quartz/AosOverdueJobQuartzTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/job/quartz/AosOverdueJobQuartzTest.java
@@ -29,7 +29,7 @@ public class AosOverdueJobQuartzTest extends QuartzTest {
 
     @Override
     protected ThrowingRunnable getBasicAssertion() {
-        return () -> verify(aosService).markCasesToBeMovedToAosOverdue(AUTH_TOKEN);
+        return () -> verify(aosService).findCasesForWhichAosIsOverdue(AUTH_TOKEN);
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/AosServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/AosServiceImplTest.java
@@ -154,7 +154,7 @@ public class AosServiceImplTest {
 
     @Test
     public void shouldCallAppropriateWorkflowWhenMarkingCasesToBeMovedToAosOverdue() throws WorkflowException, CaseOrchestrationServiceException {
-        classUnderTest.markCasesToBeMovedToAosOverdue(AUTH_TOKEN);
+        classUnderTest.findCasesForWhichAosIsOverdue(AUTH_TOKEN);
 
         verify(aosOverdueEligibilityWorkflow).run(AUTH_TOKEN);
     }
@@ -165,7 +165,7 @@ public class AosServiceImplTest {
 
         CaseOrchestrationServiceException exception = assertThrows(
             CaseOrchestrationServiceException.class,
-            () -> classUnderTest.markCasesToBeMovedToAosOverdue(AUTH_TOKEN)
+            () -> classUnderTest.findCasesForWhichAosIsOverdue(AUTH_TOKEN)
         );
         assertThat(exception.getCause(), is(instanceOf(WorkflowException.class)));
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/alternativeservice/AlternativeServiceDueDateSetterTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/alternativeservice/AlternativeServiceDueDateSetterTaskTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks.alternativeservice;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DueDateSetterTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DueDateSetterTaskTest;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.alternativeservice.AlternativeServiceDueDateSetterTask;
 
 public class AlternativeServiceDueDateSetterTaskTest extends DueDateSetterTaskTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aos/AosOverdueEligibilityWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/aos/AosOverdueEligibilityWorkflowTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.aos.MarkAosCasesAsOverdueTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.aos.MarkCasesAsAosOverdueTask;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 public class AosOverdueEligibilityWorkflowTest {
 
     @Mock
-    private MarkAosCasesAsOverdueTask markCasesToBeMovedToAosOverdue;
+    private MarkCasesAsAosOverdueTask markCasesToBeMovedToAosOverdue;
 
     @InjectMocks
     private AosOverdueEligibilityWorkflow aosOverdueEligibilityWorkflow;


### PR DESCRIPTION
# Description

This should not change the behaviour of the AOS Overdue job. The job is now searching for cases in states AOSAwaiting and AOSStarted, but it's ignoring (not moving to AOSOverdue) the AOSStarted cases.
There's a story in our backlog to move those as well in the future, but we're not doing it just yet.

# How Has This Been Tested?

Unit, functional and integration tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
