### PR TITLE
DIV-6545:Bump divCommonLib to 1.2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def versions = [
         commonsIo                    : '2.6',
         commonsLang3                 : '3.9',
         commonsMath3                 : '3.6.1',
-        divCommonLib                 : '1.2.1',
+        divCommonLib                 : '1.2.4',
         dumbster                     : '1.7.1',
         elasticsearch                : '7.9.3',
         feignHttpClient              : '10.3.0',

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ def versions = [
         puppyCrawl                   : '8.29',
         reformHealth                 : '0.0.5',
         reformPropertiesVolume       : '0.0.4',
-        reformsJavaLogging           : '5.1.6',
+        reformsJavaLogging           : '5.1.7',
         sendLetterClient             : '2.2.0',
         serenity                     : '2.1.13',
         serenityCucumber             : '1.9.50',
@@ -74,7 +74,8 @@ def versions = [
         tomcat                       : '9.0.39',
         unirest                      : '1.4.9',
         embeddedPostgres             : '1.5.5',
-        pact_version                 : '4.1.7'
+        pact_version                 : '4.1.7',
+        httpComponents               : '4.5.13'
 
 ]
 
@@ -286,10 +287,14 @@ dependencies {
     implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: versions.idamClient
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformsJavaLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformsJavaLogging
-    implementation group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: versions.reformsJavaLogging
+    implementation (group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: versions.reformsJavaLogging){
+        exclude group: 'org.apache.httpcomponents', 'module': 'httpclient'
+    }
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformsJavaLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: versions.reformHealth
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: versions.reformPropertiesVolume
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: versions.httpComponents
+    implementation group: 'org.apache.httpcomponents', name: 'fluent-hc', version: versions.httpComponents
     implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: versions.serviceTokenGenerator
     implementation group: 'uk.gov.hmcts.reform', name: 'send-letter-client', version: versions.sendLetterClient
     implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: versions.hmctsNotify

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -147,4 +147,11 @@
         <packageUrl regex="true">^pkg:maven/junit/junit@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-15250</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: httpclient-4.5.10.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpclient@.*$</packageUrl>
+        <cpe>cpe:/a:apache:httpclient</cpe>
+    </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -147,11 +147,4 @@
         <packageUrl regex="true">^pkg:maven/junit/junit@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-15250</vulnerabilityName>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: httpclient-4.5.10.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpclient@.*$</packageUrl>
-        <cpe>cpe:/a:apache:httpclient</cpe>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
Previously 1.2.1

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6645

### Change description ###
Add `servedByAlternativeMethod`


| Repo  | Link | Status | Issue
|-----|------|--------|-------|
| Comlib |https://github.com/hmcts/div-common-lib/pull/44      |    🟣Merged       |  |
| COS |https://github.com/hmcts/div-case-orchestration-service/pull/1164      |  🔴 Failed      |  CVE-2020-25638, CVE-2020-13956  |
| CDF |https://github.com/hmcts/div-case-data-formatter/pull/234      | 🔴 Failed       |   |
| CMS  | https://github.com/hmcts/div-case-maintenance-service/pull/379     |   🔴 Failed     |  |



