### PR TITLE
DIV-6699: we must use values from last element of 'ServiceApplications' collection

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/ServiceApplicationDataExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/ServiceApplicationDataExtractor.java
@@ -1,13 +1,17 @@
 package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.divorce.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DivorceServiceApplication;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.helper.ExtractorHelper.getMandatoryStringValue;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getOptionalPropertyValueAsString;
@@ -22,6 +26,23 @@ public class ServiceApplicationDataExtractor {
         public static final String SERVICE_APPLICATION_GRANTED = CcdFields.SERVICE_APPLICATION_GRANTED;
         public static final String SERVICE_APPLICATION_TYPE = CcdFields.SERVICE_APPLICATION_TYPE;
         public static final String SERVICE_APPLICATION_PAYMENT = CcdFields.SERVICE_APPLICATION_PAYMENT;
+    }
+
+    public static DivorceServiceApplication getLastServiceApplication(Map<String, Object> caseData) {
+        List list = Optional.ofNullable(caseData.get(CcdFields.SERVICE_APPLICATIONS))
+            .map(List.class::cast)
+            .orElse(new ArrayList());
+
+        if (list.isEmpty()) {
+            return DivorceServiceApplication.builder().build();
+        }
+
+        return new ObjectMapper()
+            .convertValue(
+                list.get(list.size() - 1),
+                new TypeReference<CollectionMember<DivorceServiceApplication>>() {
+                })
+            .getValue();
     }
 
     public static String getServiceApplicationRefusalReason(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/common/Conditions.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/common/Conditions.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DivorceServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes;
 
 import java.util.Map;
@@ -18,12 +19,24 @@ public class Conditions {
         return YES_VALUE.equalsIgnoreCase((String) caseData.get(CcdFields.SERVICE_APPLICATION_GRANTED));
     }
 
+    public static boolean isServiceApplicationGranted(DivorceServiceApplication serviceApplication) {
+        return YES_VALUE.equalsIgnoreCase(serviceApplication.getApplicationGranted());
+    }
+
     public static boolean isServiceApplicationDispensed(Map<String, Object> caseData) {
         return ApplicationServiceTypes.DISPENSED.equalsIgnoreCase((String) caseData.get(CcdFields.SERVICE_APPLICATION_TYPE));
     }
 
+    public static boolean isServiceApplicationDispensed(DivorceServiceApplication serviceApplication) {
+        return ApplicationServiceTypes.DISPENSED.equalsIgnoreCase(serviceApplication.getType());
+    }
+
     public static boolean isServiceApplicationDeemed(Map<String, Object> caseData) {
         return ApplicationServiceTypes.DEEMED.equalsIgnoreCase((String) caseData.get(CcdFields.SERVICE_APPLICATION_TYPE));
+    }
+
+    public static boolean isServiceApplicationDeemed(DivorceServiceApplication serviceApplication) {
+        return ApplicationServiceTypes.DEEMED.equalsIgnoreCase(serviceApplication.getType());
     }
 
     public static boolean isServiceApplicationBailiff(Map<String, Object> caseData) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/MakeServiceDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/MakeServiceDecisionTest.java
@@ -68,6 +68,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.S
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.functionaltest.servicejourney.ServiceDecisionMadeTest.buildRefusalRequest;
 import static uk.gov.hmcts.reform.divorce.orchestration.functionaltest.servicejourney.ServiceDecisionMadeTest.buildServiceRefusalOrderCaseData;
@@ -399,6 +400,8 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
         );
 
         caseData.put(SERVICE_APPLICATION_PAYMENT, TEST_SERVICE_APPLICATION_PAYMENT);
+        caseData.put(SERVICE_APPLICATION_TYPE, serviceType);
+        caseData.put(SERVICE_APPLICATION_GRANTED, NO_VALUE);
         caseData.put(SERVICE_APPLICATIONS, new ArrayList<>(Arrays.asList(buildCollectionMember())));
 
         return ccdCallbackRequest;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/MakeServiceDecisionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/MakeServiceDecisionTest.java
@@ -415,6 +415,7 @@ public class MakeServiceDecisionTest extends IdamTestSupport {
         );
         refusalOrderData.put(RECEIVED_SERVICE_ADDED_DATE, TEST_ADDED_DATE);
         refusalOrderData.put(SERVICE_APPLICATION_PAYMENT, TEST_SERVICE_APPLICATION_PAYMENT);
+        refusalOrderData.remove(SERVICE_APPLICATIONS);
 
         CcdCallbackRequest ccdCallbackRequest = buildRefusalRequest(refusalOrderData);
         ccdCallbackRequest.getCaseDetails().setState(SERVICE_APPLICATION_NOT_APPROVED);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/ServiceDecisionMadeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/ServiceDecisionMadeTest.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.bsp.common.model.document.CtscContactDetails;
 import uk.gov.hmcts.reform.divorce.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.model.ccd.Document;
 import uk.gov.hmcts.reform.divorce.model.ccd.DocumentLink;
@@ -24,6 +23,7 @@ import java.util.Map;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.allOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,17 +40,15 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETIT
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FULL_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_LAST_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RECEIVED_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FULL_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RECEIVED_SERVICE_APPLICATION_DATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATIONS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_DOCUMENTS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_GRANTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_REFUSAL_REASON;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_REFUSAL_DRAFT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
@@ -69,6 +67,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.datae
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.CaseDataKeys.RESPONDENT_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getPetitionerFullName;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractorTest.buildCollectionMember;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 import static uk.gov.hmcts.reform.divorce.orchestration.workflows.servicejourney.ServiceDecisionMadeWorkflowTest.petitionerRepresented;
 
@@ -76,17 +75,17 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
 
     private static final String API_URL = "/service-decision-made/final";
 
+    private static final String CITIZEN_DEEMED_APPROVED_EMAIL_ID = "00f27db6-2678-4ccd-8cdd-44971b330ca4";
     private static final String PET_SOL_DEEMED_APPROVED_EMAIL_ID = "b762cdc0-fa4d-4699-b60d-1532e912cc3e";
-    private static final String DEEMED_APPROVED_EMAIL_ID = "00f27db6-2678-4ccd-8cdd-44971b330ca4";
-    private static final String CITIZEN_DEEMED_NOT_APPROVED_EMAIL_ID = "5140a51a-fcda-42e4-adf4-0b469a1b927a";
-    private static final String SOLICITOR_DEEMED_NOT_APPROVED_EMAIL_ID = "919e3780-0776-4219-a30c-72e9d6999414";
-    private static final String DISPENSED_APPROVED_EMAIL_ID = "cf03cea1-a155-4f20-a3a6-3ad8fad7742f";
-    private static final String SOL_DISPENSED_APPROVED_EMAIL_ID = "2cb5e2c4-8090-4f7e-b0ae-574491cd8680";
-    private static final String DISPENSED_NOT_APPROVED_EMAIL_ID = "e40d8623-e801-4de1-834a-7de101c9d857";
-    private static final String SOL_DISPENSED_NOT_APPROVED_EMAIL_ID = "d4de177b-b5b9-409c-95bc-cc8f85afd136";
-    private static final String CITIZEN_DISPENSED_NOT_APPROVED_EMAIL_ID = "e40d8623-e801-4de1-834a-7de101c9d857";
 
-    private CtscContactDetails ctscContactDetails;
+    private static final String CITIZEN_DEEMED_NOT_APPROVED_EMAIL_ID = "5140a51a-fcda-42e4-adf4-0b469a1b927a";
+    private static final String SOL_DEEMED_NOT_APPROVED_EMAIL_ID = "919e3780-0776-4219-a30c-72e9d6999414";
+
+    private static final String CITIZEN_DISPENSED_APPROVED_EMAIL_ID = "cf03cea1-a155-4f20-a3a6-3ad8fad7742f";
+    private static final String SOL_DISPENSED_APPROVED_EMAIL_ID = "2cb5e2c4-8090-4f7e-b0ae-574491cd8680";
+
+    private static final String CITIZEN_DISPENSED_NOT_APPROVED_EMAIL_ID = "e40d8623-e801-4de1-834a-7de101c9d857";
+    private static final String SOL_DISPENSED_NOT_APPROVED_EMAIL_ID = "d4de177b-b5b9-409c-95bc-cc8f85afd136";
 
     @Autowired
     private MockMvc webClient;
@@ -99,7 +98,6 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
 
     @Before
     public void setup() {
-        ctscContactDetails = ctscContactDetailsDataProviderService.getCtscContactDetails();
         documentGeneratorServiceServer.resetAll();
     }
 
@@ -116,7 +114,7 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
             .andExpect(content().string(allOf(isJson(), hasNoJsonPath("$.errors"))));
 
         verify(emailClient).sendEmail(
-            eq(DEEMED_APPROVED_EMAIL_ID),
+            eq(CITIZEN_DEEMED_APPROVED_EMAIL_ID),
             eq(TEST_PETITIONER_EMAIL),
             eq(expectedCitizenEmailVars(caseData)),
             any()
@@ -156,7 +154,7 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
             .andExpect(content().string(allOf(isJson(), hasNoJsonPath("$.errors"))));
 
         verify(emailClient).sendEmail(
-            eq(DISPENSED_APPROVED_EMAIL_ID),
+            eq(CITIZEN_DISPENSED_APPROVED_EMAIL_ID),
             eq(TEST_PETITIONER_EMAIL),
             eq(expectedCitizenEmailVars(caseData)),
             any()
@@ -256,7 +254,7 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
             .andExpect(content().string(allOf(isJson(), hasNoJsonPath("$.errors"))));
 
         verify(emailClient).sendEmail(
-            eq(SOLICITOR_DEEMED_NOT_APPROVED_EMAIL_ID),
+            eq(SOL_DEEMED_NOT_APPROVED_EMAIL_ID),
             eq(TEST_SOLICITOR_EMAIL),
             eq(expectedSolicitorEmailVars()),
             any()
@@ -287,9 +285,7 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
         caseData.put(RESPONDENT_FIRST_NAME, TEST_RESPONDENT_FIRST_NAME);
         caseData.put(RESPONDENT_LAST_NAME, TEST_RESPONDENT_LAST_NAME);
 
-        caseData.put(RECEIVED_SERVICE_APPLICATION_DATE, TEST_RECEIVED_DATE);
-        caseData.put(SERVICE_APPLICATION_GRANTED, isApplicationGranted);
-        caseData.put(SERVICE_APPLICATION_TYPE, applicationType);
+        caseData.put(SERVICE_APPLICATIONS, asList(buildCollectionMember(isApplicationGranted, applicationType)));
 
         return caseData;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/ServiceDecisionMadeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/ServiceDecisionMadeTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.client.EmailClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.functionaltest.IdamTestSupport;
-import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.CtscContactDetailsDataProviderService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,12 +34,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_FAMILY_MAN_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_DECISION_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_MY_REASON;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FULL_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_LAST_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RECEIVED_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_FULL_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
@@ -92,9 +91,6 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
 
     @Autowired
     private MockMvc webClient;
-
-    @Autowired
-    private CtscContactDetailsDataProviderService ctscContactDetailsDataProviderService;
 
     @MockBean
     private EmailClient emailClient;
@@ -287,7 +283,7 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
         caseData.put(PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME);
         caseData.put(RESPONDENT_FIRST_NAME, TEST_RESPONDENT_FIRST_NAME);
         caseData.put(RESPONDENT_LAST_NAME, TEST_RESPONDENT_LAST_NAME);
-        caseData.put(RECEIVED_SERVICE_APPLICATION_DATE, TEST_DECISION_DATE);
+        caseData.put(RECEIVED_SERVICE_APPLICATION_DATE, TEST_RECEIVED_DATE);
 
         caseData.put(SERVICE_APPLICATIONS, asList(buildCollectionMember(isApplicationGranted, applicationType)));
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/ServiceDecisionMadeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/servicejourney/ServiceDecisionMadeTest.java
@@ -35,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_FAMILY_MAN_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_DECISION_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_MY_REASON;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FIRST_NAME;
@@ -45,10 +46,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPO
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RECEIVED_SERVICE_APPLICATION_DATE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATIONS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_DOCUMENTS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_GRANTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_REFUSAL_REASON;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_REFUSAL_DRAFT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
@@ -284,6 +287,7 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
         caseData.put(PETITIONER_LAST_NAME, TEST_PETITIONER_LAST_NAME);
         caseData.put(RESPONDENT_FIRST_NAME, TEST_RESPONDENT_FIRST_NAME);
         caseData.put(RESPONDENT_LAST_NAME, TEST_RESPONDENT_LAST_NAME);
+        caseData.put(RECEIVED_SERVICE_APPLICATION_DATE, TEST_DECISION_DATE);
 
         caseData.put(SERVICE_APPLICATIONS, asList(buildCollectionMember(isApplicationGranted, applicationType)));
 
@@ -312,6 +316,7 @@ public class ServiceDecisionMadeTest extends IdamTestSupport {
 
         Map<String, Object> payload = ImmutableMap.of(
             SERVICE_APPLICATION_GRANTED, NO_VALUE,
+            SERVICE_APPLICATION_TYPE, serviceApplicationType,
             SERVICE_REFUSAL_DRAFT, serviceRefusalDraft,
             SERVICE_APPLICATION_DOCUMENTS, generatedDocumentInfoList,
             SERVICE_APPLICATION_REFUSAL_REASON, TEST_MY_REASON

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/ServiceApplicationDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/ServiceApplicationDataExtractorTest.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor;
 
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.core.Is;
+import org.apache.logging.log4j.util.Strings;
 import org.junit.Test;
 import uk.gov.hmcts.reform.divorce.model.ccd.CollectionMember;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DivorceServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.InvalidDataForTaskException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,17 +19,23 @@ import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertNull;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_MY_REASON;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_GRANTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_REFUSAL_REASON;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DISPENSED;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.CaseDataKeys.REFUSAL_REASON;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.CaseDataKeys.SERVICE_APPLICATION_PAYMENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getLastServiceApplication;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getListOfServiceApplications;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getServiceApplicationGranted;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getServiceApplicationPayment;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getServiceApplicationRefusalReason;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getServiceApplicationRefusalReasonOrEmpty;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getServiceApplicationType;
 
 public class ServiceApplicationDataExtractorTest {
@@ -79,7 +86,7 @@ public class ServiceApplicationDataExtractorTest {
     public void givenNoField_whenGetListOfServiceApplications_shouldReturnAnEmptyArray() {
         List<CollectionMember<DivorceServiceApplication>> result = getListOfServiceApplications(emptyMap());
 
-        assertThat(result, Is.is(empty()));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -89,7 +96,7 @@ public class ServiceApplicationDataExtractorTest {
         List<CollectionMember<DivorceServiceApplication>> result =
             getListOfServiceApplications(ImmutableMap.of(CcdFields.SERVICE_APPLICATIONS, myList));
 
-        assertThat(result, Is.is(empty()));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -99,8 +106,83 @@ public class ServiceApplicationDataExtractorTest {
         List<CollectionMember<DivorceServiceApplication>> result =
             getListOfServiceApplications(ImmutableMap.of(CcdFields.SERVICE_APPLICATIONS, myList));
 
-        assertThat(result.size(), Is.is(1));
-        assertThat(result, Is.is(myList));
+        assertThat(result.size(), is(1));
+        assertThat(result, is(myList));
+    }
+
+    @Test
+    public void givenNoField_whenGetServiceApplicationRefusalReasonOrEmpty_shouldReturnEmptyString() {
+        assertThat(getServiceApplicationRefusalReasonOrEmpty(new HashMap<>()), is(Strings.EMPTY));
+    }
+
+    @Test
+    public void givenFieldPopulated_whenGetServiceApplicationRefusalReasonOrEmpty_shouldReturnValue() {
+        String expectedValue = "value";
+
+        assertThat(
+            getServiceApplicationRefusalReasonOrEmpty(ImmutableMap.of(REFUSAL_REASON, expectedValue)),
+            is(expectedValue)
+        );
+    }
+
+    @Test
+    public void getLastServiceApplicationShouldReturnEmptyWhenNoList() {
+        DivorceServiceApplication result = getLastServiceApplication(new HashMap<>());
+
+        assertNull(result.getType());
+    }
+
+    @Test
+    public void getLastServiceApplicationShouldReturnEmptyWhenEmptyList() {
+        DivorceServiceApplication result = getLastServiceApplication(
+            ImmutableMap.of(CcdFields.SERVICE_APPLICATIONS, new ArrayList<>())
+        );
+
+        assertNull(result.getType());
+    }
+
+    @Test
+    public void getLastServiceApplicationShouldReturnElementWhenOneElementOnList() {
+        final List<CollectionMember<DivorceServiceApplication>> myList = new ArrayList<>();
+
+        myList.add(buildCollectionMember(YES_VALUE, DEEMED));
+
+        DivorceServiceApplication result = getLastServiceApplication(
+            ImmutableMap.of(CcdFields.SERVICE_APPLICATIONS, myList)
+        );
+
+        assertThat(result.getType(), is(DEEMED));
+    }
+
+    @Test
+    public void getLastServiceApplicationShouldReturnLastElementWhenManyElementsOnList() {
+        final List<CollectionMember<DivorceServiceApplication>> myList = asList(
+            buildCollectionMember(YES_VALUE, DEEMED),
+            buildCollectionMember(YES_VALUE, DISPENSED),
+            buildCollectionMember(NO_VALUE, DISPENSED),
+            buildCollectionMember(NO_VALUE, DEEMED)
+        );
+
+        DivorceServiceApplication result = getLastServiceApplication(
+            ImmutableMap.of(CcdFields.SERVICE_APPLICATIONS, myList)
+        );
+
+        assertThat(result.getApplicationGranted(), is(NO_VALUE));
+        assertThat(result.getType(), is(DEEMED));
+    }
+
+    public static CollectionMember<DivorceServiceApplication> buildCollectionMember(String granted, String type) {
+        CollectionMember<DivorceServiceApplication> collectionMember = new CollectionMember<>();
+        collectionMember.setValue(buildServiceApplication(granted, type));
+
+        return collectionMember;
+    }
+
+    private static DivorceServiceApplication buildServiceApplication(String granted, String type) {
+        return DivorceServiceApplication.builder()
+            .applicationGranted(granted)
+            .type(type)
+            .build();
     }
 
     private static Map<String, Object> buildCaseDataWithField(String field, String value) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/common/ConditionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/common/ConditionsTest.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.divorce.orchestration.service.common;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DivorceServiceApplication;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,11 +11,18 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_GRANTED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_DA;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_SERVICE_CONSIDERATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.BAILIFF;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DISPENSED;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isAwaitingServiceConsideration;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationBailiff;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationDeemed;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationDispensed;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationGranted;
 
 public class ConditionsTest {
@@ -28,6 +35,72 @@ public class ConditionsTest {
     @Test
     public void isServiceApplicationGrantedShouldReturnFalse() {
         asList(NO_VALUE, "", "no", "NO", null).forEach(ConditionsTest::assertApplicationIsNotGrantedForValue);
+    }
+
+    @Test
+    public void isServiceApplicationGrantedForElementShouldReturnTrue() {
+        asList(YES_VALUE, "YES", "yes").forEach(ConditionsTest::assertApplicationIsGrantedForElement);
+    }
+
+    @Test
+    public void isServiceApplicationGrantedForElementShouldReturnFalse() {
+        asList(NO_VALUE, "", "no", "NO", null).forEach(ConditionsTest::assertApplicationIsNotGrantedForElement);
+    }
+
+    @Test
+    public void isServiceApplicationDispensedForValueShouldReturnTrue() {
+        assertThat(isServiceApplicationDispensed(buildCaseData(SERVICE_APPLICATION_TYPE, DISPENSED)), is(true));
+    }
+
+    @Test
+    public void isServiceApplicationDispensedForElementShouldReturnFalse() {
+        asList(DEEMED, BAILIFF, "", null).forEach(ConditionsTest::assertApplicationIsNotDispensedForElement);
+    }
+
+    @Test
+    public void isServiceApplicationDispensedForElementShouldReturnTrue() {
+        assertThat(
+            isServiceApplicationDispensed(DivorceServiceApplication.builder().type(DISPENSED).build()),
+            is(true)
+        );
+    }
+
+    @Test
+    public void isServiceApplicationDispensedForValuesShouldReturnFalse() {
+        asList(DEEMED, BAILIFF, "", null).forEach(ConditionsTest::assertApplicationIsNotDispensedForElement);
+    }
+
+    @Test
+    public void isServiceApplicationDeemedForValueShouldReturnTrue() {
+        assertThat(isServiceApplicationDeemed(buildCaseData(SERVICE_APPLICATION_TYPE, DEEMED)), is(true));
+    }
+
+    @Test
+    public void isServiceApplicationDeemedForValuesShouldReturnFalse() {
+        asList(DISPENSED, BAILIFF, "", null).forEach(ConditionsTest::assertApplicationIsNotDeemedForValue);
+    }
+
+    @Test
+    public void isServiceApplicationDeemedForElementShouldReturnTrue() {
+        assertThat(
+            isServiceApplicationDeemed(DivorceServiceApplication.builder().type(DEEMED).build()),
+            is(true)
+        );
+    }
+
+    @Test
+    public void isServiceApplicationDeemedForElementShouldReturnFalse() {
+        asList(DISPENSED, BAILIFF, "", null).forEach(ConditionsTest::assertApplicationIsNotDeemedForElement);
+    }
+
+    @Test
+    public void isServiceApplicationBailiffForValueShouldReturnTrue() {
+        asList(BAILIFF).forEach(ConditionsTest::assertApplicationIsBailiffForValue);
+    }
+
+    @Test
+    public void isServiceApplicationBailiffForValuesShouldReturnFalse() {
+        asList(DEEMED, DISPENSED, "", null).forEach(ConditionsTest::assertApplicationIsNotBailiffForValue);
     }
 
     @Test
@@ -48,24 +121,68 @@ public class ConditionsTest {
         assertThat(isAwaitingServiceConsideration(caseDetails), is(false));
     }
 
-    @Test
-    public void isServiceApplicationGrantedShouldBeTrue() {
-        Map<String, Object> caseData = ImmutableMap.of(SERVICE_APPLICATION_GRANTED, YES_VALUE);
+    private static void assertApplicationIsNotDeemedForValue(String value) {
+        Map<String, Object> caseData = buildCaseData(SERVICE_APPLICATION_TYPE, value);
 
-        assertThat(isServiceApplicationGranted(caseData), is(true));
+        assertThat(isServiceApplicationDeemed(caseData), is(false));
     }
 
-    private static void assertApplicationIsNotGrantedForValue(Object value) {
-        Map<String, Object> caseData = new HashMap<>();
-        caseData.put(SERVICE_APPLICATION_GRANTED, value);
+    private static void assertApplicationIsBailiffForValue(String value) {
+        Map<String, Object> caseData = buildCaseData(SERVICE_APPLICATION_TYPE, value);
+
+        assertThat(isServiceApplicationBailiff(caseData), is(true));
+    }
+
+    private static void assertApplicationIsNotBailiffForValue(String value) {
+        Map<String, Object> caseData = buildCaseData(SERVICE_APPLICATION_TYPE, value);
+
+        assertThat(isServiceApplicationBailiff(caseData), is(false));
+    }
+
+    private static void assertApplicationIsNotGrantedForValue(String value) {
+        Map<String, Object> caseData = buildCaseData(SERVICE_APPLICATION_GRANTED, value);
 
         assertThat(isServiceApplicationGranted(caseData), is(false));
     }
 
-    private static void assertApplicationIsGrantedForValue(Object value) {
+    private static Map<String, Object> buildCaseData(String field, String value) {
         Map<String, Object> caseData = new HashMap<>();
-        caseData.put(SERVICE_APPLICATION_GRANTED, value);
+        caseData.put(field, value);
+
+        return caseData;
+    }
+
+    private static void assertApplicationIsNotGrantedForElement(String value) {
+        assertThat(
+            isServiceApplicationGranted(DivorceServiceApplication.builder().applicationGranted(value).build()),
+            is(false)
+        );
+    }
+
+    private static void assertApplicationIsGrantedForElement(String value) {
+        assertThat(
+            isServiceApplicationGranted(DivorceServiceApplication.builder().applicationGranted(value).build()),
+            is(true)
+        );
+    }
+
+    private static void assertApplicationIsGrantedForValue(String value) {
+        Map<String, Object> caseData = buildCaseData(SERVICE_APPLICATION_GRANTED, value);
 
         assertThat(isServiceApplicationGranted(caseData), is(true));
+    }
+
+    private static void assertApplicationIsNotDispensedForElement(String value) {
+        assertThat(
+            isServiceApplicationDispensed(DivorceServiceApplication.builder().type(value).build()),
+            is(false)
+        );
+    }
+
+    private static void assertApplicationIsNotDeemedForElement(String value) {
+        assertThat(
+            isServiceApplicationDeemed(DivorceServiceApplication.builder().type(value).build()),
+            is(false)
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/ServiceDecisionMadeWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/servicejourney/ServiceDecisionMadeWorkflowTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.servicejourney.emails.Dis
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -27,8 +28,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_GRANTED;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATION_TYPE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATIONS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_DECREE_NISI;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.SERVICE_APPLICATION_NOT_APPROVED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
@@ -37,6 +37,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DISPENSED;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractorTest.buildCollectionMember;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.mockTasksExecution;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.verifyTaskWasCalled;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.verifyTasksCalledInOrder;
@@ -263,8 +264,7 @@ public class ServiceDecisionMadeWorkflowTest {
 
     private Map<String, Object> buildCaseData(String serviceApplicationType, String serviceApplicationGranted) {
         return ImmutableMap.of(
-            SERVICE_APPLICATION_TYPE, serviceApplicationType,
-            SERVICE_APPLICATION_GRANTED, serviceApplicationGranted
+            SERVICE_APPLICATIONS, asList(buildCollectionMember(serviceApplicationGranted, serviceApplicationType))
         );
     }
 


### PR DESCRIPTION
Story:
https://tools.hmcts.net/jira/browse/DIV-6699

We have 2 callbacks:
```
{
  "LiveFrom": "28/07/2020",
  "CaseTypeID": "DIVORCE",
  "ID": "makeServiceDecision",
  "Name": "Make Service Decision",
  "Description": "Make Service Decision",
  "DisplayOrder": 12,
  "PreConditionState(s)": "AwaitingServiceConsideration",
  "PostConditionState": "*",
  "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/make-service-decision",
  "RetriesTimeoutURLAboutToSubmitEvent": "30,30",
  "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/service-decision-made/final",
  "RetriesTimeoutURLSubmittedEvent": "120,120",
  "SecurityClassification": "Public",
  "ShowSummary":  "Y"
},
```

The first one is removing fields:
```
public class ServiceApplicationRemovalTask extends FieldsRemovalTask {

    @Override
    protected List<String> getFieldsToRemove() {
        return asList(
            CcdFields.RECEIVED_SERVICE_APPLICATION_DATE,
            CcdFields.RECEIVED_SERVICE_ADDED_DATE,
            CcdFields.SERVICE_APPLICATION_TYPE,
            CcdFields.SERVICE_APPLICATION_PAYMENT,
            CcdFields.SERVICE_APPLICATION_GRANTED,
            CcdFields.SERVICE_APPLICATION_DECISION_DATE,
            CcdFields.SERVICE_APPLICATION_REFUSAL_REASON
        );
    }
}
```

and the other one was trying to use some of them.

That was a mistake.

We should use values from the last element of collection where all these values are copied over and removed from simple case data fields so that all forms on event pages are not pre-populated.