### PR TITLE
DIV-6726: Bringing file generation parameters from CCD config file in…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DocumentGeneratedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/DocumentGeneratedTest.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.divorce.callback;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.functionaltest.PrepareToPrintForPronouncementTest;
+import uk.gov.hmcts.reform.divorce.orchestration.functionaltest.UpdateBulkCaseHearingDetailsTest;
 import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
 import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
 
@@ -20,23 +23,48 @@ public class DocumentGeneratedTest extends IntegrationTest {
     private static final String CCD_CALLBACK_REQUEST = "fixtures/callback/basic-case.json";
     private static final String TEST_CASE_ID = "0123456789012345";
     public static final String MINI_PETITION_TEMPLATE_NAME = "divorceminipetition";
-    
+
+    private CcdCallbackRequest ccdCallbackRequest;
+
     @Autowired
     private CosApiClient cosApiClient;
 
+    @Before
+    public void setUp() {
+        ccdCallbackRequest = ResourceLoader.loadJsonToObject(CCD_CALLBACK_REQUEST, CcdCallbackRequest.class);
+    }
+
     @Test
-    public void givenCase_whenGenerateDocumentForMiniPetition_thenReturnCallbackResponseWithMiniPetitionDocument() {
-        CcdCallbackRequest ccdCallbackRequest = ResourceLoader.loadJsonToObject(CCD_CALLBACK_REQUEST, CcdCallbackRequest.class);
+    public void shouldGenerateAndReturnDocumentForMiniPetition() {
 
         Map<String, Object> response = cosApiClient
-                .generateDocument(createCaseWorkerUser().getAuthToken(), ccdCallbackRequest,
-                        MINI_PETITION_TEMPLATE_NAME, DOCUMENT_TYPE_PETITION, MINI_PETITION_TEMPLATE_NAME);
+            .generateDocument(createCaseWorkerUser().getAuthToken(), ccdCallbackRequest,
+                MINI_PETITION_TEMPLATE_NAME, DOCUMENT_TYPE_PETITION, MINI_PETITION_TEMPLATE_NAME);
 
-        String jsonResponse = objectToJson(response);
-
-        assertThat(
-                jsonResponse,
-                hasJsonPath("$.data.D8DocumentsGenerated[0].value.DocumentFileName", is(MINI_PETITION_TEMPLATE_NAME + TEST_CASE_ID))
-        );
+        assertGeneratedDocumentMatchesFileName(response, MINI_PETITION_TEMPLATE_NAME);
     }
+
+    @Test
+    public void shouldGenerateAndReturnDocumentWhenPreparingToPrintForPronouncement() {
+        Map<String, Object> response = cosApiClient
+            .prepareToPrintForPronouncement(createCaseWorkerUser().getAuthToken(), ccdCallbackRequest);
+
+        assertGeneratedDocumentMatchesFileName(response, PrepareToPrintForPronouncementTest.EXPECTED_FILE_NAME_PREFIX);
+    }
+
+    @Test
+    public void shouldGenerateAndReturnDocumentWhenUpdatingBulkCaseHearingDetails() {
+        Map<String, Object> response = cosApiClient
+            .updateBulkCaseHearingDetails(createCaseWorkerUser().getAuthToken(), ccdCallbackRequest);
+
+        assertGeneratedDocumentMatchesFileName(response, UpdateBulkCaseHearingDetailsTest.EXPECTED_FILE_NAME_PREFIX);
+    }
+
+    private void assertGeneratedDocumentMatchesFileName(Map<String, Object> response, String fileNamePrefix) {
+        String jsonResponse = objectToJson(response);
+        assertThat(jsonResponse, hasJsonPath("$.data.D8DocumentsGenerated[0].value.DocumentFileName",
+            is(fileNamePrefix + TEST_CASE_ID)
+        ));
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -148,12 +148,27 @@ public interface CosApiClient {
 
     @ApiOperation("Handle callback to generate documents with provided parameters")
     @PostMapping(value = "/generate-document")
+    @Deprecated
     Map<String, Object> generateDocument(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestBody CcdCallbackRequest ccdCallbackRequest,
         @RequestParam(name = "templateId") String templateId,
         @RequestParam(name = "documentType") String documentType,
         @RequestParam(name = "filename") String filename
+    );
+
+    @ApiOperation("Prepare case data before printing for pronouncement")
+    @PostMapping(value = "/prepare-to-print-for-pronouncement")
+    Map<String, Object> prepareToPrintForPronouncement(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestBody CcdCallbackRequest ccdCallbackRequest
+    );
+
+    @ApiOperation("Prepare case data before updating bulk case hearing details")
+    @PostMapping(value = "/update-bulk-case-hearing-details")
+    Map<String, Object> updateBulkCaseHearingDetails(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestBody CcdCallbackRequest ccdCallbackRequest
     );
 
     @ApiOperation("Handle callback to generate DN Pronouncement Documents")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -106,7 +106,7 @@ public interface CaseOrchestrationService {
     Map<String, Object> generateBulkCaseForListing() throws WorkflowException;
 
     Map<String, Object> handleDocumentGenerationCallback(CcdCallbackRequest ccdCallbackRequest, String authToken, String templateId,
-                                                         String documentType, String filename) throws WorkflowException;
+                                                         String documentType, String filename) throws CaseOrchestrationServiceException;
 
     Map<String, Object> processAosSolicitorNominated(CcdCallbackRequest ccdCallbackRequest,
                                                      String authToken) throws CaseOrchestrationServiceException;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -695,11 +695,17 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
     }
 
     @Override
-    public Map<String, Object> handleDocumentGenerationCallback(final CcdCallbackRequest ccdCallbackRequest, final String authToken,
-                                                                final String templateId, final String documentType, final String filename)
-        throws WorkflowException {
-
-        return documentGenerationWorkflow.run(ccdCallbackRequest.getCaseDetails(), authToken, templateId, documentType, filename);
+    public Map<String, Object> handleDocumentGenerationCallback(final CcdCallbackRequest ccdCallbackRequest,
+                                                                final String authToken,
+                                                                final String templateId,
+                                                                final String documentType,
+                                                                final String filename) throws CaseOrchestrationServiceException {
+        CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();
+        try {
+            return documentGenerationWorkflow.run(caseDetails, authToken, templateId, documentType, filename);
+        } catch (WorkflowException workflowException) {
+            throw new CaseOrchestrationServiceException(workflowException, caseDetails.getCaseId());
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DocumentGenerationWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DocumentGenerationWorkflow.java
@@ -34,7 +34,6 @@ public class DocumentGenerationWorkflow extends DefaultWorkflow<Map<String, Obje
 
     private final AddNewDocumentsToCaseDataTask addNewDocumentsToCaseDataTask;
 
-
     @Autowired
     public DocumentGenerationWorkflow(final SetFormattedDnCourtDetails setFormattedDnCourtDetails,
                                       final DocumentGenerationTask documentGenerationTask,

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
@@ -744,42 +744,94 @@ public class CallbackControllerTest {
 
     @Test
     public void whenGenerateDocument_thenExecuteService() throws Exception {
-        Map<String, Object> payload = singletonMap("testKey", "testValue");
         CcdCallbackRequest incomingRequest = CcdCallbackRequest.builder()
-            .caseDetails(CaseDetails.builder()
-                .caseData(payload)
-                .build())
+            .caseDetails(TEST_INCOMING_CASE_DETAILS)
             .build();
 
-        when(caseOrchestrationService
-            .handleDocumentGenerationCallback(incomingRequest, AUTH_TOKEN, "a", "b", "c")).thenReturn(payload);
+        when(caseOrchestrationService.handleDocumentGenerationCallback(eq(incomingRequest), eq(AUTH_TOKEN), any(), any(), any()))
+            .thenReturn(TEST_INCOMING_CASE_DETAILS.getCaseData());
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.generateDocument(AUTH_TOKEN, "a", "b", "c",
-            incomingRequest);
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.generateDocument(AUTH_TOKEN, "a", "b", "c", incomingRequest);
 
+        verify(caseOrchestrationService).handleDocumentGenerationCallback(incomingRequest, AUTH_TOKEN, "a", "b", "c");
         assertThat(response.getStatusCode(), is(OK));
+        assertThat(response.getBody().getData(), is(TEST_INCOMING_CASE_DETAILS.getCaseData()));
     }
 
     @Test
-    public void givenWorkflowException_whenGenerateDocuments_thenReturnErrors() throws WorkflowException {
-        Map<String, Object> payload = singletonMap("testKey", "testValue");
+    public void whenGenerateDocument_whenPreparingToPrintForPronouncement() throws Exception {
         CcdCallbackRequest incomingRequest = CcdCallbackRequest.builder()
-            .caseDetails(CaseDetails.builder()
-                .caseData(payload)
-                .build())
+            .caseDetails(TEST_INCOMING_CASE_DETAILS)
             .build();
 
-        String errorString = "foo";
+        when(caseOrchestrationService.handleDocumentGenerationCallback(eq(incomingRequest), eq(AUTH_TOKEN), any(), any(), any()))
+            .thenReturn(TEST_INCOMING_CASE_DETAILS.getCaseData());
 
-        when(caseOrchestrationService
-            .handleDocumentGenerationCallback(incomingRequest, AUTH_TOKEN, "a", "b", "c"))
-            .thenThrow(new WorkflowException(errorString));
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.prepareToPrintForPronouncement(AUTH_TOKEN, incomingRequest);
 
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.generateDocument(AUTH_TOKEN, "a", "b", "c",
-            incomingRequest);
-
+        verify(caseOrchestrationService).handleDocumentGenerationCallback(
+            incomingRequest, AUTH_TOKEN, "FL-DIV-GNO-ENG-00059.docx", "caseListForPronouncement", "caseListForPronouncement");
         assertThat(response.getStatusCode(), is(OK));
-        assertThat(response.getBody().getErrors(), contains(errorString));
+        assertThat(response.getBody().getData(), is(TEST_INCOMING_CASE_DETAILS.getCaseData()));
+    }
+
+    @Test
+    public void whenGenerateDocument_whenUpdateBulkCaseHearingDetails() throws Exception {
+        CcdCallbackRequest incomingRequest = CcdCallbackRequest.builder()
+            .caseDetails(TEST_INCOMING_CASE_DETAILS)
+            .build();
+
+        when(caseOrchestrationService.handleDocumentGenerationCallback(eq(incomingRequest), eq(AUTH_TOKEN), any(), any(), any()))
+            .thenReturn(TEST_INCOMING_CASE_DETAILS.getCaseData());
+
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.updateBulkCaseHearingDetails(AUTH_TOKEN, incomingRequest);
+
+        verify(caseOrchestrationService).handleDocumentGenerationCallback(
+            incomingRequest, AUTH_TOKEN, "FL-DIV-GNO-ENG-00020.docx", "coe", "certificateOfEntitlement");
+        assertThat(response.getStatusCode(), is(OK));
+        assertThat(response.getBody().getData(), is(TEST_INCOMING_CASE_DETAILS.getCaseData()));
+    }
+
+    @Test
+    public void givenWorkflowException_whenGenerateDocuments_thenReturnErrors() throws CaseOrchestrationServiceException {
+        CcdCallbackRequest incomingRequest = CcdCallbackRequest.builder()
+            .caseDetails(TEST_INCOMING_CASE_DETAILS)
+            .build();
+        CaseOrchestrationServiceException expectedException = new CaseOrchestrationServiceException("foo");
+        when(caseOrchestrationService.handleDocumentGenerationCallback(eq(incomingRequest), eq(AUTH_TOKEN), any(), any(), any()))
+            .thenThrow(expectedException);
+
+        CaseOrchestrationServiceException actualException = assertThrows(CaseOrchestrationServiceException.class,
+            () -> classUnderTest.generateDocument(AUTH_TOKEN, "a", "b", "c", incomingRequest));
+        assertThat(actualException, is(expectedException));
+    }
+
+    @Test
+    public void givenWorkflowException_whenPreparingToPrintForPronouncement_thenReturnErrors() throws CaseOrchestrationServiceException {
+        CcdCallbackRequest incomingRequest = CcdCallbackRequest.builder()
+            .caseDetails(TEST_INCOMING_CASE_DETAILS)
+            .build();
+        CaseOrchestrationServiceException expectedException = new CaseOrchestrationServiceException("foo");
+        when(caseOrchestrationService.handleDocumentGenerationCallback(eq(incomingRequest), eq(AUTH_TOKEN), any(), any(), any()))
+            .thenThrow(expectedException);
+
+        CaseOrchestrationServiceException actualException = assertThrows(CaseOrchestrationServiceException.class,
+            () -> classUnderTest.prepareToPrintForPronouncement(AUTH_TOKEN, incomingRequest));
+        assertThat(actualException, is(expectedException));
+    }
+
+    @Test
+    public void givenWorkflowException_whenUpdateBulkCaseHearingDetails_thenReturnErrors() throws CaseOrchestrationServiceException {
+        CcdCallbackRequest incomingRequest = CcdCallbackRequest.builder()
+            .caseDetails(TEST_INCOMING_CASE_DETAILS)
+            .build();
+        CaseOrchestrationServiceException expectedException = new CaseOrchestrationServiceException("foo");
+        when(caseOrchestrationService.handleDocumentGenerationCallback(eq(incomingRequest), eq(AUTH_TOKEN), any(), any(), any()))
+            .thenThrow(expectedException);
+
+        CaseOrchestrationServiceException actualException = assertThrows(CaseOrchestrationServiceException.class,
+            () -> classUnderTest.updateBulkCaseHearingDetails(AUTH_TOKEN, incomingRequest));
+        assertThat(actualException, is(expectedException));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseHearingDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/UpdateBulkCaseHearingDetailsTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
 
-import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -13,8 +12,6 @@ import java.util.Map;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -27,11 +24,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.COURT_NAME_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.COURT_CONTACT_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_CASE_DETAILS_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.functionaltest.DocumentGenerationITest.hasItemMatchingExpectedValues;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
-public class DocumentGenerationITest extends MockedFunctionalTest {
+public class UpdateBulkCaseHearingDetailsTest extends MockedFunctionalTest {
 
-    private static final String API_URL = "/generate-document";
+    private static final String API_URL = "/update-bulk-case-hearing-details";
 
     private static final Map<String, Object> CASE_DATA = new HashMap<>();
 
@@ -44,9 +42,9 @@ public class DocumentGenerationITest extends MockedFunctionalTest {
         .caseDetails(CASE_DETAILS)
         .build();
 
-    private static final String TEST_TEMPLATE_ID = "a";
-    private static final String TEST_DOCUMENT_TYPE = "b";
-    private static final String TEST_FILENAME = "c";
+    private static final String TEMPLATE_NAME = "FL-DIV-GNO-ENG-00020.docx";
+    private static final String EXPECTED_DOCUMENT_TYPE = "coe";
+    public static final String EXPECTED_FILE_NAME_PREFIX = "certificateOfEntitlement";
 
     @Autowired
     private MockMvc webClient;
@@ -70,53 +68,20 @@ public class DocumentGenerationITest extends MockedFunctionalTest {
     }
 
     @Test
-    public void givenTemplateIdIsNull_whenEndpointInvoked_thenReturnBadRequest() throws Exception {
-        webClient.perform(post(API_URL)
-            .content(convertObjectToJsonString(CCD_CALLBACK_REQUEST))
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .param("documentType", TEST_DOCUMENT_TYPE)
-            .param("filename", TEST_FILENAME))
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    public void givenDocumentTypeIsNull_whenEndpointInvoked_thenReturnBadRequest() throws Exception {
-        webClient.perform(post(API_URL)
-            .content(convertObjectToJsonString(CCD_CALLBACK_REQUEST))
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .param("templateId", TEST_TEMPLATE_ID)
-            .param("filename", TEST_FILENAME))
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    public void givenFilenameIsNull_whenEndpointInvoked_thenReturnBadRequest() throws Exception {
-        webClient.perform(post(API_URL)
-            .content(convertObjectToJsonString(CCD_CALLBACK_REQUEST))
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .param("templateId", TEST_TEMPLATE_ID)
-            .param("documentType", TEST_DOCUMENT_TYPE))
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
     public void happyPath() throws Exception {
-        stubDocumentGeneratorService(TEST_TEMPLATE_ID, singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS), TEST_DOCUMENT_TYPE);
+        stubDocumentGeneratorService(TEMPLATE_NAME, singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, CASE_DETAILS), EXPECTED_DOCUMENT_TYPE);
 
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)
             .content(convertObjectToJsonString(CCD_CALLBACK_REQUEST))
-            .param("templateId", TEST_TEMPLATE_ID)
-            .param("documentType", TEST_DOCUMENT_TYPE)
-            .param("filename", TEST_FILENAME)
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(hasJsonPath("$.data.D8DocumentsGenerated", hasSize(1))))
-            .andExpect(content().string(hasJsonPath("$.data.D8DocumentsGenerated", hasItemMatchingExpectedValues(TEST_DOCUMENT_TYPE, TEST_FILENAME))))
+            .andExpect(content().string(hasJsonPath("$.data.D8DocumentsGenerated", hasItemMatchingExpectedValues(
+                EXPECTED_DOCUMENT_TYPE,
+                EXPECTED_FILE_NAME_PREFIX
+            ))))
             .andExpect(content().string(hasJsonPath("$.errors", is(nullValue()))));
     }
 
@@ -132,7 +97,9 @@ public class DocumentGenerationITest extends MockedFunctionalTest {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put(COURT_NAME_CCD_FIELD, "liverpool");
 
-        stubDocumentGeneratorService(TEST_TEMPLATE_ID, singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, expectedDocumentCaseDetails), TEST_DOCUMENT_TYPE);
+        stubDocumentGeneratorService(TEMPLATE_NAME,
+            singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, expectedDocumentCaseDetails),
+            EXPECTED_DOCUMENT_TYPE);
 
         CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(caseData).build();
 
@@ -141,25 +108,16 @@ public class DocumentGenerationITest extends MockedFunctionalTest {
         webClient.perform(post(API_URL)
             .header(AUTHORIZATION, AUTH_TOKEN)
             .content(convertObjectToJsonString(ccdCallbackRequest))
-            .param("templateId", TEST_TEMPLATE_ID)
-            .param("documentType", TEST_DOCUMENT_TYPE)
-            .param("filename", TEST_FILENAME)
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(hasJsonPath("$.data.CourtName", is("liverpool"))))
             .andExpect(content().string(hasJsonPath("$.data.D8DocumentsGenerated", hasSize(1))))
-            .andExpect(content().string(hasJsonPath("$.data.D8DocumentsGenerated", hasItemMatchingExpectedValues(TEST_DOCUMENT_TYPE, TEST_FILENAME))))
+            .andExpect(content().string(hasJsonPath("$.data.D8DocumentsGenerated", hasItemMatchingExpectedValues(
+                EXPECTED_DOCUMENT_TYPE,
+                EXPECTED_FILE_NAME_PREFIX
+            ))))
             .andExpect(content().string(hasJsonPath("$.errors", is(nullValue()))));
-    }
-
-    public static Matcher<Iterable<? super Object>> hasItemMatchingExpectedValues(String expectedDocumentType, String expectedFileNamePrefix) {
-        return hasItem(
-            hasJsonPath("value", allOf(
-                hasJsonPath("DocumentType", is(expectedDocumentType)),
-                hasJsonPath("DocumentLink.document_filename", is(expectedFileNamePrefix + TEST_CASE_ID + ".pdf"))
-            ))
-        );
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -991,12 +991,10 @@ public class CaseOrchestrationServiceImplTest {
     }
 
     @Test
-    public void shouldCallTheRightWorkflow_ForDocumentGeneration() throws WorkflowException {
-        when(documentGenerationWorkflow.run(ccdCallbackRequest.getCaseDetails(), AUTH_TOKEN, "a", "b", "c"))
-            .thenReturn(requestPayload);
+    public void shouldCallTheRightWorkflow_ForDocumentGeneration() throws WorkflowException, CaseOrchestrationServiceException {
+        when(documentGenerationWorkflow.run(ccdCallbackRequest.getCaseDetails(), AUTH_TOKEN, "a", "b", "c")).thenReturn(requestPayload);
 
-        final Map<String, Object> result = classUnderTest
-            .handleDocumentGenerationCallback(ccdCallbackRequest, AUTH_TOKEN, "a", "b", "c");
+        final Map<String, Object> result = classUnderTest.handleDocumentGenerationCallback(ccdCallbackRequest, AUTH_TOKEN, "a", "b", "c");
 
         assertThat(result, is(requestPayload));
     }
@@ -1128,14 +1126,16 @@ public class CaseOrchestrationServiceImplTest {
         verifyNoMoreInteractions(documentGenerationWorkflow);
     }
 
-    @Test(expected = WorkflowException.class)
-    public void shouldThrowException_ForDocumentGeneration_WhenWorkflowExceptionIsCaught()
-        throws WorkflowException {
-
+    @Test
+    public void shouldThrowException_ForDocumentGeneration_WhenWorkflowExceptionIsCaught() throws WorkflowException {
+        WorkflowException workflowException = new WorkflowException("This operation threw an exception");
         when(documentGenerationWorkflow.run(ccdCallbackRequest.getCaseDetails(), AUTH_TOKEN, "a", "b", "c"))
-            .thenThrow(new WorkflowException("This operation threw an exception"));
+            .thenThrow(workflowException);
 
-        classUnderTest.handleDocumentGenerationCallback(ccdCallbackRequest, AUTH_TOKEN, "a", "b", "c");
+        CaseOrchestrationServiceException caseOrchestrationServiceException = assertThrows(CaseOrchestrationServiceException.class,
+            () -> classUnderTest.handleDocumentGenerationCallback(ccdCallbackRequest, AUTH_TOKEN, "a", "b", "c"));
+        assertThat(caseOrchestrationServiceException.getCaseId().get(), is(TEST_CASE_ID));
+        assertThat(caseOrchestrationServiceException.getCause(), is(workflowException));
     }
 
     @Test(expected = WorkflowException.class)


### PR DESCRIPTION
…to COS.

# Description

The idea here is to make sure document re-generation is precise.
Once these endpoints are in prod, I'll change the CCD definitions file to point to them instead. This will give us the assurance we need that the re-generated documents will always use the same parameters as the original documents.

# How Has This Been Tested?

Existing tests, new unit, functional and integration tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
