### PR TITLE
RPET-694: Add field to manage legal connections

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -56,12 +56,10 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.GENERATE_AOS_INVITATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.LANGUAGE_PREFERENCE_WELSH;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_LINK;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_LEGAL_CONNECTION_POLICY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ANSWERS_LINK;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_PBA_PAYMENT_ERROR_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.VALIDATION_ERROR_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.CASE_LIST_FOR_PRONOUNCEMENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.COE;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.ControllerUtils.getPbaUpdatedState;
@@ -330,26 +328,6 @@ public class CallbackController {
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         ccdCallbackRequest.getCaseDetails().getCaseData().computeIfAbsent(LANGUAGE_PREFERENCE_WELSH, value -> NO_VALUE);
-
-        return ResponseEntity.ok(CcdCallbackResponse.builder()
-            .data(ccdCallbackRequest.getCaseDetails().getCaseData())
-            .build());
-    }
-
-    @PostMapping(path = "/solicitor-default-values",
-        consumes = MediaType.APPLICATION_JSON,
-        produces = MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Default application state for solicitor")
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Default state set",
-            response = CcdCallbackResponse.class),
-        @ApiResponse(code = 400, message = "Bad Request")})
-    public ResponseEntity<CcdCallbackResponse> solicitorDefaultValue(
-        @RequestHeader(value = "Authorization", required = false) String authorizationToken,
-        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
-
-        ccdCallbackRequest.getCaseDetails().getCaseData().computeIfAbsent(LANGUAGE_PREFERENCE_WELSH, value -> NO_VALUE);
-        ccdCallbackRequest.getCaseDetails().getCaseData().computeIfAbsent(NEW_LEGAL_CONNECTION_POLICY, value -> YES_VALUE);
 
         return ResponseEntity.ok(CcdCallbackResponse.builder()
             .data(ccdCallbackRequest.getCaseDetails().getCaseData())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -56,10 +56,12 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.GENERATE_AOS_INVITATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.LANGUAGE_PREFERENCE_WELSH;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_LINK;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_LEGAL_CONNECTION_POLICY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ANSWERS_LINK;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_PBA_PAYMENT_ERROR_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.VALIDATION_ERROR_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.CASE_LIST_FOR_PRONOUNCEMENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.COE;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.ControllerUtils.getPbaUpdatedState;
@@ -328,6 +330,26 @@ public class CallbackController {
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         ccdCallbackRequest.getCaseDetails().getCaseData().computeIfAbsent(LANGUAGE_PREFERENCE_WELSH, value -> NO_VALUE);
+
+        return ResponseEntity.ok(CcdCallbackResponse.builder()
+            .data(ccdCallbackRequest.getCaseDetails().getCaseData())
+            .build());
+    }
+
+    @PostMapping(path = "/solicitor-default-values",
+        consumes = MediaType.APPLICATION_JSON,
+        produces = MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Default application state for solicitor")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Default state set",
+            response = CcdCallbackResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request")})
+    public ResponseEntity<CcdCallbackResponse> solicitorDefaultValue(
+        @RequestHeader(value = "Authorization", required = false) String authorizationToken,
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
+
+        ccdCallbackRequest.getCaseDetails().getCaseData().computeIfAbsent(LANGUAGE_PREFERENCE_WELSH, value -> NO_VALUE);
+        ccdCallbackRequest.getCaseDetails().getCaseData().computeIfAbsent(NEW_LEGAL_CONNECTION_POLICY, value -> YES_VALUE);
 
         return ResponseEntity.ok(CcdCallbackResponse.builder()
             .data(ccdCallbackRequest.getCaseDetails().getCaseData())

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -410,4 +410,7 @@ public class OrchestrationConstants {
     // Bulk Scan
     public static final String CASE_TYPE_ID = "DIVORCE";
 
+    // New legal connection policy
+    public static final String NEW_LEGAL_CONNECTION_POLICY = "NewLegalConnectionPolicy";
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetNewLegalConnectionPolicyTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetNewLegalConnectionPolicyTask.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_LEGAL_CONNECTION_POLICY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+
+public class SetNewLegalConnectionPolicyTask implements Task<Map<String, Object>> {
+
+    public Map<String, Object> execute(TaskContext context, Map<String, Object> caseData) {
+        caseData.put(NEW_LEGAL_CONNECTION_POLICY, YES_VALUE);
+
+        return caseData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddMiniPetitionDraftTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseDataTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFromTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetNewLegalConnectionPolicyTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetSolicitorCourtDetailsTask;
 
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     private final AddMiniPetitionDraftTask addMiniPetitionDraftTask;
     private final AddNewDocumentsToCaseDataTask addNewDocumentsToCaseDataTask;
     private final SetClaimCostsFromTask setClaimCostsFromTask;
+    private final SetNewLegalConnectionPolicyTask setNewLegalConnectionPolicyTask;
 
     public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
         final List<Task<Map<String, Object>>> tasks = new ArrayList<>();
@@ -40,6 +42,7 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
         tasks.add(setSolicitorCourtDetailsTask);
         tasks.add(addMiniPetitionDraftTask);
         tasks.add(addNewDocumentsToCaseDataTask);
+        tasks.add(setNewLegalConnectionPolicyTask);
 
         return this.execute(tasks.toArray(new Task[0]),
             caseDetails.getCaseData(),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
@@ -81,7 +81,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.EMPTY_STRING;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_PAY_BY_ACCOUNT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.LANGUAGE_PREFERENCE_WELSH;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_LEGAL_CONNECTION_POLICY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_HOW_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
@@ -1829,61 +1828,5 @@ public class CallbackControllerTest {
         assertThat(response.getBody().getErrors(), is(nullValue()));
         assertThat(response.getBody().getData(), is(TEST_PAYLOAD_TO_RETURN));
         verify(courtOrderDocumentsUpdateService).updateExistingCourtOrderDocuments(AUTH_TOKEN, TEST_INCOMING_CASE_DETAILS);
-    }
-
-    @Test
-    public void testSolicitorDefaultValues_WelshLanguage_No() {
-
-        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(new HashMap<>()).build();
-        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
-
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
-
-        assertThat(response.getStatusCode(), equalTo(OK));
-        assertThat(response.getBody().getData().get(LANGUAGE_PREFERENCE_WELSH), is(NO_VALUE));
-        assertThat(response.getBody().getErrors(), is(nullValue()));
-    }
-
-    @Test
-    public void testSolicitorDefaultValues_WelshLanguage_Yes() {
-
-        Map<String, Object> caseData = new HashMap<>();
-        caseData.put(LANGUAGE_PREFERENCE_WELSH, YES_VALUE);
-        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(caseData).build();
-        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
-
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
-
-        assertThat(response.getStatusCode(), equalTo(OK));
-        assertThat(response.getBody().getData().get(LANGUAGE_PREFERENCE_WELSH), is(YES_VALUE));
-        assertThat(response.getBody().getErrors(), is(nullValue()));
-    }
-
-    @Test
-    public void testSolicitorDefaultValues_LegalConnectionPolicy_Yes() {
-
-        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(new HashMap<>()).build();
-        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
-
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
-
-        assertThat(response.getStatusCode(), equalTo(OK));
-        assertThat(response.getBody().getData().get(NEW_LEGAL_CONNECTION_POLICY), is(YES_VALUE));
-        assertThat(response.getBody().getErrors(), is(nullValue()));
-    }
-
-    @Test
-    public void testSolicitorDefaultValues_LegalConnectionPolicy_No() {
-
-        Map<String, Object> caseData = new HashMap<>();
-        caseData.put(NEW_LEGAL_CONNECTION_POLICY, NO_VALUE);
-        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(caseData).build();
-        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
-
-        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
-
-        assertThat(response.getStatusCode(), equalTo(OK));
-        assertThat(response.getBody().getData().get(NEW_LEGAL_CONNECTION_POLICY), is(NO_VALUE));
-        assertThat(response.getBody().getErrors(), is(nullValue()));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
@@ -81,6 +81,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.EMPTY_STRING;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_PAY_BY_ACCOUNT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.LANGUAGE_PREFERENCE_WELSH;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_LEGAL_CONNECTION_POLICY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_HOW_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
@@ -1830,4 +1831,59 @@ public class CallbackControllerTest {
         verify(courtOrderDocumentsUpdateService).updateExistingCourtOrderDocuments(AUTH_TOKEN, TEST_INCOMING_CASE_DETAILS);
     }
 
+    @Test
+    public void testSolicitorDefaultValues_WelshLanguage_No() {
+
+        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(new HashMap<>()).build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
+
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
+
+        assertThat(response.getStatusCode(), equalTo(OK));
+        assertThat(response.getBody().getData().get(LANGUAGE_PREFERENCE_WELSH), is(NO_VALUE));
+        assertThat(response.getBody().getErrors(), is(nullValue()));
+    }
+
+    @Test
+    public void testSolicitorDefaultValues_WelshLanguage_Yes() {
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(LANGUAGE_PREFERENCE_WELSH, YES_VALUE);
+        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(caseData).build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
+
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
+
+        assertThat(response.getStatusCode(), equalTo(OK));
+        assertThat(response.getBody().getData().get(LANGUAGE_PREFERENCE_WELSH), is(YES_VALUE));
+        assertThat(response.getBody().getErrors(), is(nullValue()));
+    }
+
+    @Test
+    public void testSolicitorDefaultValues_LegalConnectionPolicy_Yes() {
+
+        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(new HashMap<>()).build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
+
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
+
+        assertThat(response.getStatusCode(), equalTo(OK));
+        assertThat(response.getBody().getData().get(NEW_LEGAL_CONNECTION_POLICY), is(YES_VALUE));
+        assertThat(response.getBody().getErrors(), is(nullValue()));
+    }
+
+    @Test
+    public void testSolicitorDefaultValues_LegalConnectionPolicy_No() {
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(NEW_LEGAL_CONNECTION_POLICY, NO_VALUE);
+        CaseDetails caseDetails = CaseDetails.builder().caseId(TEST_CASE_ID).caseData(caseData).build();
+        CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
+
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorDefaultValue(TEST_TOKEN, ccdCallbackRequest);
+
+        assertThat(response.getStatusCode(), equalTo(OK));
+        assertThat(response.getBody().getData().get(NEW_LEGAL_CONNECTION_POLICY), is(NO_VALUE));
+        assertThat(response.getBody().getErrors(), is(nullValue()));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetNewLegalConnectionPolicyTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/SetNewLegalConnectionPolicyTaskTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NEW_LEGAL_CONNECTION_POLICY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetNewLegalConnectionPolicyTaskTest {
+
+    @InjectMocks
+    private SetNewLegalConnectionPolicyTask setNewLegalConnectionPolicyTask;
+
+    private Map<String, Object> testData;
+    private TaskContext context;
+
+    @Before
+    public void setup() {
+
+        testData = new HashMap<>();
+        context = new DefaultTaskContext();
+    }
+
+    @Test
+    public void executeShouldSetNewLegalConnectionPolicyToYes() {
+        Map<String, Object> resultData = new HashMap<>();
+        resultData.put(NEW_LEGAL_CONNECTION_POLICY, YES_VALUE);
+
+        assertEquals(resultData, setNewLegalConnectionPolicyTask.execute(context, testData));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflowTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddMiniPetitionDraftTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseDataTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFromTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetNewLegalConnectionPolicyTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetSolicitorCourtDetailsTask;
 
 import java.util.Collections;
@@ -44,6 +45,9 @@ public class SolicitorCreateWorkflowTest {
     @Mock
     SetClaimCostsFromTask setClaimCostsFromTask;
 
+    @Mock
+    SetNewLegalConnectionPolicyTask setNewLegalConnectionPolicyTask;
+
     @InjectMocks
     SolicitorCreateWorkflow solicitorCreateWorkflow;
 
@@ -62,11 +66,13 @@ public class SolicitorCreateWorkflowTest {
 
         assertEquals(payload, solicitorCreateWorkflow.run(caseDetails, AUTH_TOKEN));
 
-        InOrder inOrder = inOrder(setSolicitorCourtDetailsTask, addMiniPetitionDraftTask, addNewDocumentsToCaseDataTask);
+        InOrder inOrder = inOrder(setSolicitorCourtDetailsTask, addMiniPetitionDraftTask, addNewDocumentsToCaseDataTask,
+            setNewLegalConnectionPolicyTask);
 
         inOrder.verify(setSolicitorCourtDetailsTask).execute(context, payload);
         inOrder.verify(addMiniPetitionDraftTask).execute(context, payload);
         inOrder.verify(addNewDocumentsToCaseDataTask).execute(context, payload);
+        inOrder.verify(setNewLegalConnectionPolicyTask).execute(context, payload);
     }
 
     @Test


### PR DESCRIPTION
 + Set new wording on legal connection policy for all new cases

# Description

NewLegalConnectionPolicy is a new field used to manage which wording to show on legal connections. Older cases should still see the old wording while new cases should see the new wording.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
