### PR TITLE
BuildFix: Reorder mavenCentral and Jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,10 +110,10 @@ allprojects {
     }
 
     repositories {
-        maven { url "https://dl.bintray.com/hmcts/hmcts-maven" }
-        maven { url 'https://repo.spring.io/libs-milestone' }
         mavenCentral()
         jcenter()
+        maven { url "https://dl.bintray.com/hmcts/hmcts-maven" }
+        maven { url 'https://repo.spring.io/libs-milestone' }
     }
 
     dependencyManagement {


### PR DESCRIPTION
# Description
On a fresh pull from github, i experienced consistent build failures that prevented COS from building and indexing appropriately. 

Following the approach detailed below:
https://docs.gradle.org/current/userguide/declaring_repositories.html

![import](https://user-images.githubusercontent.com/30896346/105852187-108c3500-5fdc-11eb-9e33-bc8470dec049.png)
