### PR TITLE
DIV-6746: Updating existing workflow to cater for alternative service types

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDocLinkTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDocLinkTask.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @Component
 @RequiredArgsConstructor
-public class PopulateDocLink implements Task<Map<String, Object>> {
+public class PopulateDocLinkTask implements Task<Map<String, Object>> {
 
     private final ObjectMapper objectMapper;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflow.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseData
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DecreeNisiRefusalDocumentGeneratorTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DefineWhoPaysCostsOrderTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetAmendPetitionFeeTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLink;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLinkTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetDNDecisionStateTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateDNDecisionTask;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils;
@@ -52,7 +52,7 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
 
     private final FeatureToggleService featureToggleService;
 
-    private final PopulateDocLink populateDocLink;
+    private final PopulateDocLinkTask populateDocLinkTask;
 
     public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
         List<Task<Map<String, Object>>> tasksToRun = new ArrayList<>();
@@ -80,7 +80,7 @@ public class DecreeNisiAboutToBeGrantedWorkflow extends DefaultWorkflow<Map<Stri
             tasksToRun.add(getAmendPetitionFeeTask);
             tasksToRun.add(decreeNisiRefusalDocumentGeneratorTask);
             tasksToRun.add(addNewDocumentsToCaseDataTask);
-            tasksToRun.add(populateDocLink);
+            tasksToRun.add(populateDocLinkTask);
         }
 
         Map<String, Object> payloadToReturn = this.execute(

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
@@ -38,11 +38,11 @@ public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Obj
 
         if (isRespondentAnswersRequested(docLinkFieldName)) {
 
-            if (isValidServiceApplicationGranted(caseData) || isAlternativeService(caseData)) {
+            if (isRespondentAnswersNotRequired(caseData)) {
                 log.info("CaseID: {} Respondent answers requested, but not required.", caseId);
                 return caseData;
             } else {
-                log.info("CaseID: {} Proceeding to populateDocLink", caseId);
+                log.info("CaseID: {} Respondent answers required, proceeding to populateDocLink", caseId);
             }
         }
 
@@ -57,6 +57,10 @@ public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Obj
 
     private boolean isRespondentAnswersRequested(String docLinkFieldName) {
         return RESP_ANSWERS_LINK.equals(docLinkFieldName);
+    }
+
+    private boolean isRespondentAnswersNotRequired(Map<String, Object> caseData) {
+        return isValidServiceApplicationGranted(caseData) || isAlternativeService(caseData);
     }
 
     private boolean isValidServiceApplicationGranted(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
@@ -36,15 +36,14 @@ public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Obj
 
         log.info("CaseID: {} Solicitor DN Fetch Document Workflow is going to be executed.", caseId);
 
-        if (isRespondentAnswersRequestedNotRequired(docLinkFieldName)) {
+        if (isRespondentAnswersRequested(docLinkFieldName)) {
 
             if (isValidServiceApplicationGranted(caseData) || isAlternativeService(caseData)) {
                 log.info("CaseID: {} Respondent answers requested, but not required.", caseId);
                 return caseData;
+            } else {
+                log.info("CaseID: {} Proceeding to populateDocLink", caseId);
             }
-
-        } else {
-            log.info("CaseID: {} Respondent answers not requested. Proceeding to populateDocLink", caseId);
         }
 
         log.info("CaseID: {} populateDocLink task is going to be executed.", caseId);
@@ -56,7 +55,7 @@ public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Obj
             ImmutablePair.of(DOCUMENT_DRAFT_LINK_FIELD, docLinkFieldName));
     }
 
-    private boolean isRespondentAnswersRequestedNotRequired(String docLinkFieldName) {
+    private boolean isRespondentAnswersRequested(String docLinkFieldName) {
         return RESP_ANSWERS_LINK.equals(docLinkFieldName);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DivorceService
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLink;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLinkTask;
 
 import java.util.Map;
 
@@ -19,42 +19,66 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getLastServiceApplication;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationDeemedOrDispensed;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationGranted;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.alternativeservice.AlternativeServiceHelper.isServedByAlternativeMethod;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.alternativeservice.AlternativeServiceHelper.isServedByProcessServer;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
-    private final PopulateDocLink populateDocLink;
+    private final PopulateDocLinkTask populateDocLinkTask;
 
     public Map<String, Object> run(CaseDetails caseDetails, final String ccdDocumentType, final String docLinkFieldName) throws WorkflowException {
 
         final String caseId = caseDetails.getCaseId();
+        Map<String, Object> caseData = caseDetails.getCaseData();
 
         log.info("CaseID: {} Solicitor DN Fetch Document Workflow is going to be executed.", caseId);
 
-        if (isRespondentAnswersRequestedButNotRequired(caseDetails.getCaseData(), docLinkFieldName)) {
-            log.info("CaseID: {} respondent answers requested, but not required.", caseId);
-            return caseDetails.getCaseData();
+        if (isRespondentAnswersRequestedNotRequired(docLinkFieldName)) {
+
+            if (isValidServiceApplicationGranted(caseData) || isAlternativeService(caseData)) {
+                log.info("CaseID: {} Respondent answers requested, but not required.", caseId);
+                return caseData;
+            }
+
+        } else {
+            log.info("CaseID: {} Respondent answers not requested. Proceeding to populateDocLink", caseId);
         }
 
         log.info("CaseID: {} populateDocLink task is going to be executed.", caseId);
 
         return this.execute(
-            new Task[] {populateDocLink},
-            caseDetails.getCaseData(),
+            new Task[] {populateDocLinkTask},
+            caseData,
             ImmutablePair.of(DOCUMENT_TYPE, ccdDocumentType),
             ImmutablePair.of(DOCUMENT_DRAFT_LINK_FIELD, docLinkFieldName));
     }
 
-    private boolean isRespondentAnswersRequestedButNotRequired(Map<String, Object> caseData, String docLinkFieldName) {
+    private boolean isRespondentAnswersRequestedNotRequired(String docLinkFieldName) {
+        return RESP_ANSWERS_LINK.equals(docLinkFieldName);
+    }
+
+    private boolean isValidServiceApplicationGranted(Map<String, Object> caseData) {
         DivorceServiceApplication serviceApplication = getLastServiceApplication(caseData);
 
-        boolean isRespondentAnswersRequested = RESP_ANSWERS_LINK.equals(docLinkFieldName);
-
-        boolean isValidServiceApplicationGranted = isServiceApplicationGranted(serviceApplication)
+        return isServiceApplicationGranted(serviceApplication)
             && isServiceApplicationDeemedOrDispensed(serviceApplication);
+    }
 
-        return isRespondentAnswersRequested && isValidServiceApplicationGranted;
+    private boolean isAlternativeService(Map<String, Object> caseData) {
+        return isValidServedByProcessServer(caseData)
+            || isValidServedByAlternativeMethod(caseData);
+    }
+
+    private boolean isValidServedByProcessServer(Map<String, Object> caseData) {
+        return isServedByProcessServer(caseData)
+            && !isServedByAlternativeMethod(caseData);
+    }
+
+    private boolean isValidServedByAlternativeMethod(Map<String, Object> caseData) {
+        return isServedByAlternativeMethod(caseData)
+            && !isServedByProcessServer(caseData);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorDnFetchDocTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorDnFetchDocTest.java
@@ -29,7 +29,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
-import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildCaseData;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByAlternativeMethodCaseData;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByProcessServerCaseData;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServiceApplicationCaseData;
 
 public class SolicitorDnFetchDocTest extends MockedFunctionalTest {
 
@@ -64,7 +66,7 @@ public class SolicitorDnFetchDocTest extends MockedFunctionalTest {
     @Test
     public void givenValidServiceApplicationGranted_whenRequestingRespondentAnswers_thenResponseDoesNotSetRespondentAnswersDocumentLinkAndContainsNoErrors() throws Exception {
 
-        final Map<String, Object> caseData = buildCaseData(DEEMED, YES_VALUE);
+        final Map<String, Object> caseData = buildServiceApplicationCaseData(DEEMED, YES_VALUE);
 
         CcdCallbackRequest request = buildRequest(caseData);
 
@@ -77,6 +79,42 @@ public class SolicitorDnFetchDocTest extends MockedFunctionalTest {
                 isJson(),
                 hasJsonPath("$.data.ServiceApplications", hasSize(1)),
                 assertServiceApplicationElement(DEEMED, YES_VALUE),
+                hasNoJsonPath("$.errors")
+            )));
+    }
+
+    @Test
+    public void givenValidServedByProcessServer_thenResponseIsWithoutRespondentAnswersDocumentLink() throws Exception {
+        CcdCallbackRequest request = buildRequest(
+            buildServedByProcessServerCaseData()
+        );
+
+        webClient.perform(post(API_URL_RESP_ANSWERS)
+            .content(convertObjectToJsonString(request))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(allOf(
+                isJson(),
+                hasJsonPath("$.data.ServedByProcessServer", is("Yes")),
+                hasNoJsonPath("$.errors")
+            )));
+    }
+
+    @Test
+    public void givenValidServedByAlternativeMethod_thenResponseIsWithoutRespondentAnswersDocumentLink() throws Exception {
+        CcdCallbackRequest request = buildRequest(
+            buildServedByAlternativeMethodCaseData()
+        );
+
+        webClient.perform(post(API_URL_RESP_ANSWERS)
+            .content(convertObjectToJsonString(request))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(allOf(
+                isJson(),
+                hasJsonPath("$.data.ServedByAlternativeMethod", is("Yes")),
                 hasNoJsonPath("$.errors")
             )));
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDocLinkTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/PopulateDocLinkTaskTest.java
@@ -20,15 +20,15 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.MINI_PETITION_LINK;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.getObjectMapperInstance;
 
-public class PopulateDocLinkTest {
+public class PopulateDocLinkTaskTest {
 
-    private PopulateDocLink populateDocLink;
+    private PopulateDocLinkTask populateDocLinkTask;
 
     private TaskContext taskContext;
 
     @Before
     public void setup() {
-        populateDocLink = new PopulateDocLink(getObjectMapperInstance());
+        populateDocLinkTask = new PopulateDocLinkTask(getObjectMapperInstance());
 
         taskContext = new DefaultTaskContext();
         taskContext.setTransientObject(DOCUMENT_TYPE, DOCUMENT_TYPE_PETITION);
@@ -39,7 +39,7 @@ public class PopulateDocLinkTest {
     public void throwsTaskExceptionIfMiniPetitionIsNotPresent() throws TaskException {
         Map<String, Object> payload =  Collections.singletonMap("D8DocumentsGenerated", new ArrayList<>());
 
-        populateDocLink.execute(taskContext, payload);
+        populateDocLinkTask.execute(taskContext, payload);
     }
 
     @SuppressWarnings("unchecked")
@@ -47,7 +47,7 @@ public class PopulateDocLinkTest {
     public void testExecuteSetsMiniPetitionUrl() throws Exception {
         Map<String, Object> payload = ObjectMapperTestUtil.getJsonFromResourceFile("/jsonExamples/payloads/sol-dn-review-petition.json", Map.class);
 
-        Map<String, Object> result = populateDocLink.execute(taskContext, payload);
+        Map<String, Object> result = populateDocLinkTask.execute(taskContext, payload);
 
         assertThat(result, is(payload));
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/DecreeNisiAboutToBeGrantedWorkflowTest.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseData
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DecreeNisiRefusalDocumentGeneratorTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.DefineWhoPaysCostsOrderTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.GetAmendPetitionFeeTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLink;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLinkTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetDNDecisionStateTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.ValidateDNDecisionTask;
 
@@ -82,7 +82,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
     private FeatureToggleService featureToggleService;
 
     @Mock
-    private PopulateDocLink populateDocLink;
+    private PopulateDocLinkTask populateDocLinkTask;
 
     @InjectMocks
     private DecreeNisiAboutToBeGrantedWorkflow workflow;
@@ -245,7 +245,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         when(getAmendPetitionFeeTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
         when(decreeNisiRefusalDocumentGeneratorTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
         when(addNewDocumentsToCaseDataTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
-        when(populateDocLink.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
+        when(populateDocLinkTask.execute(isNotNull(), eq(payloadReturnedByTask))).thenReturn(payloadReturnedByTask);
 
         Map<String, Object> returnedPayload = workflow.run(CaseDetails.builder().caseData(inputPayload).build(), AUTH_TOKEN);
 
@@ -262,7 +262,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
             getAmendPetitionFeeTask,
             decreeNisiRefusalDocumentGeneratorTask,
             addNewDocumentsToCaseDataTask,
-            populateDocLink
+            populateDocLinkTask
         );
 
         inOrder.verify(featureToggleService).isFeatureEnabled(eq(Features.DN_REFUSAL));
@@ -273,7 +273,7 @@ public class DecreeNisiAboutToBeGrantedWorkflowTest {
         inOrder.verify(getAmendPetitionFeeTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
         inOrder.verify(decreeNisiRefusalDocumentGeneratorTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
         inOrder.verify(addNewDocumentsToCaseDataTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
-        inOrder.verify(populateDocLink).execute(any(TaskContext.class), eq(payloadReturnedByTask));
+        inOrder.verify(populateDocLinkTask).execute(any(TaskContext.class), eq(payloadReturnedByTask));
 
 
         verify(defineWhoPaysCostsOrderTask, never()).execute(any(), any());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLinkTask;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -162,10 +161,10 @@ public class SolicitorDnFetchDocWorkflowTest {
 
     @Test
     public void shouldExecuteTasksWhenNotValidAlternativeServiceAndRespondentAnswersIsRequested() throws WorkflowException {
-        Map<String, Object> caseData = new HashMap<>() {{
-            put(CcdFields.SERVED_BY_PROCESS_SERVER, NO_VALUE);
-            put(CcdFields.SERVED_BY_ALTERNATIVE_METHOD, NO_VALUE);
-        }};
+        Map<String, Object> caseData = ImmutableMap.of(
+            CcdFields.SERVED_BY_PROCESS_SERVER, NO_VALUE,
+            CcdFields.SERVED_BY_ALTERNATIVE_METHOD, NO_VALUE
+        );
         taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
 
         when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
@@ -189,18 +188,17 @@ public class SolicitorDnFetchDocWorkflowTest {
     }
 
     public static Map<String, Object> buildServedByProcessServerCaseData() {
-        return new HashMap<>() {{
-            put(CcdFields.SERVED_BY_PROCESS_SERVER, YES_VALUE);
-            put(CcdFields.SERVED_BY_ALTERNATIVE_METHOD, NO_VALUE);
-        }};
-
+        return ImmutableMap.of(
+            CcdFields.SERVED_BY_PROCESS_SERVER, YES_VALUE,
+            CcdFields.SERVED_BY_ALTERNATIVE_METHOD, NO_VALUE
+        );
     }
 
     public static Map<String, Object> buildServedByAlternativeMethodCaseData() {
-        return new HashMap<>() {{
-            put(CcdFields.SERVED_BY_ALTERNATIVE_METHOD, YES_VALUE);
-            put(CcdFields.SERVED_BY_PROCESS_SERVER, NO_VALUE);
-        }};
+        return ImmutableMap.of(
+            CcdFields.SERVED_BY_ALTERNATIVE_METHOD, YES_VALUE,
+            CcdFields.SERVED_BY_PROCESS_SERVER, NO_VALUE
+        );
     }
 
     private void executeWorkflow(Map<String, Object> caseData, String respAnswersLink)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -8,14 +8,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.model.ccd.CollectionMember;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DivorceServiceApplication;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLink;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLinkTask;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -39,7 +41,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.Ap
 public class SolicitorDnFetchDocWorkflowTest {
 
     @Mock
-    PopulateDocLink populateDocLink;
+    PopulateDocLinkTask populateDocLinkTask;
 
     @InjectMocks
     SolicitorDnFetchDocWorkflow solicitorDnFetchDocWorkflow;
@@ -58,67 +60,122 @@ public class SolicitorDnFetchDocWorkflowTest {
 
         Map<String, Object> caseData = Collections.emptyMap();
 
-        when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
+        when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
 
         executeWorkflow(caseData, MINI_PETITION_LINK);
 
-        verify(populateDocLink).execute(taskContext, caseData);
+        verify(populateDocLinkTask).execute(taskContext, caseData);
     }
 
     @Test
     public void runShouldReturnCaseDataAndNotExecuteTasksWhenServiceApplicationIsGrantedAndIsRequestingRespondentAnswers()
         throws Exception {
 
-        Map<String, Object> caseData = buildCaseData(DEEMED, YES_VALUE);
+        Map<String, Object> caseData = buildServiceApplicationCaseData(DEEMED, YES_VALUE);
         taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLink, times(0)).execute(taskContext, caseData);
+        verify(populateDocLinkTask, times(0)).execute(taskContext, caseData);
     }
 
     @Test
     public void runShouldReturnCaseDataAndExecuteTasksWhenServiceApplicationIsGrantedAndIsNotRequestingRespondentAnswers()
         throws Exception {
 
-        Map<String, Object> caseData = buildCaseData(DEEMED, YES_VALUE);
+        Map<String, Object> caseData = buildServiceApplicationCaseData(DEEMED, YES_VALUE);
 
-        when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
+        when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
 
         executeWorkflow(caseData, MINI_PETITION_LINK);
 
-        verify(populateDocLink).execute(taskContext, caseData);
+        verify(populateDocLinkTask).execute(taskContext, caseData);
     }
 
     @Test
     public void runShouldReturnCaseDataAndExecuteTasksWhenServiceApplicationIsNotGrantedAndIsRequestingRespondentAnswers()
         throws Exception {
 
-        Map<String, Object> caseData = buildCaseData(DEEMED, NO_VALUE);
+        Map<String, Object> caseData = buildServiceApplicationCaseData(DEEMED, NO_VALUE);
         taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
 
-        when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
+        when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLink).execute(taskContext, caseData);
+        verify(populateDocLinkTask).execute(taskContext, caseData);
     }
 
     @Test
     public void runShouldReturnCaseDataAndExecuteTasksWhenServiceApplicationTypeIsNotDefinedAndIsRequestingRespondentAnswers()
         throws Exception {
 
-        Map<String, Object> caseData = buildCaseData(null, YES_VALUE);
+        Map<String, Object> caseData = buildServiceApplicationCaseData(null, YES_VALUE);
         taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
 
-        when(populateDocLink.execute(taskContext, caseData)).thenReturn(caseData);
+        when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLink).execute(taskContext, caseData);
+        verify(populateDocLinkTask).execute(taskContext, caseData);
     }
 
-    public static Map<String, Object> buildCaseData(String type, String granted) {
+    @Test
+    public void shouldNotExecuteTasksWhenIsServedByProcessServerAndRespondentAnswersIsRequested() throws WorkflowException {
+        Map<String, Object> caseData = buildServedByProcessServerCaseData();
+        taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
+
+        executeWorkflow(caseData, RESP_ANSWERS_LINK);
+
+        verify(populateDocLinkTask, times(0)).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void shouldExecuteTasksWhenIsServedByProcessServerAndRespondentAnswersIsNotRequested() throws WorkflowException {
+        Map<String, Object> caseData = buildServedByProcessServerCaseData();
+        when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
+
+        executeWorkflow(caseData, MINI_PETITION_LINK);
+
+        verify(populateDocLinkTask).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void shouldNotExecuteTasksWhenIsServedByAlternativeMethodAndRespondentAnswersIsRequested() throws WorkflowException {
+        Map<String, Object> caseData = buildServedByAlternativeMethodCaseData();
+        taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
+
+        executeWorkflow(caseData, RESP_ANSWERS_LINK);
+
+        verify(populateDocLinkTask, times(0)).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void shouldExecuteTasksWhenIsServedByAlternativeMethodAndRespondentAnswersIsNotRequested() throws WorkflowException {
+        Map<String, Object> caseData = buildServedByAlternativeMethodCaseData();
+        when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
+
+        executeWorkflow(caseData, MINI_PETITION_LINK);
+
+        verify(populateDocLinkTask).execute(taskContext, caseData);
+    }
+
+    @Test
+    public void shouldExecuteTasksWhenNotValidAlternativeServiceAndRespondentAnswersIsRequested() throws WorkflowException {
+        Map<String, Object> caseData = new HashMap<>() {{
+            put(CcdFields.SERVED_BY_PROCESS_SERVER, NO_VALUE);
+            put(CcdFields.SERVED_BY_ALTERNATIVE_METHOD, NO_VALUE);
+        }};
+        taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
+
+        when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
+
+        executeWorkflow(caseData, RESP_ANSWERS_LINK);
+
+        verify(populateDocLinkTask).execute(taskContext, caseData);
+    }
+
+    public static Map<String, Object> buildServiceApplicationCaseData(String type, String granted) {
 
         CollectionMember<DivorceServiceApplication> application = new CollectionMember<>();
         DivorceServiceApplication.DivorceServiceApplicationBuilder applicationBuilder = DivorceServiceApplication.builder();
@@ -129,6 +186,21 @@ public class SolicitorDnFetchDocWorkflowTest {
         return ImmutableMap.of(
             SERVICE_APPLICATIONS, asList(application)
         );
+    }
+
+    public static Map<String, Object> buildServedByProcessServerCaseData() {
+        return new HashMap<>() {{
+            put(CcdFields.SERVED_BY_PROCESS_SERVER, YES_VALUE);
+            put(CcdFields.SERVED_BY_ALTERNATIVE_METHOD, NO_VALUE);
+        }};
+
+    }
+
+    public static Map<String, Object> buildServedByAlternativeMethodCaseData() {
+        return new HashMap<>() {{
+            put(CcdFields.SERVED_BY_ALTERNATIVE_METHOD, YES_VALUE);
+            put(CcdFields.SERVED_BY_PROCESS_SERVER, NO_VALUE);
+        }};
     }
 
     private void executeWorkflow(Map<String, Object> caseData, String respAnswersLink)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -75,7 +75,7 @@ public class SolicitorDnFetchDocWorkflowTest {
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLinkTask, times(0)).execute(taskContext, caseData);
+        verify(populateDocLinkTask).execute(taskContext, caseData);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class SolicitorDnFetchDocWorkflowTest {
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLinkTask, times(0)).execute(taskContext, caseData);
+        verify(populateDocLinkTask).execute(taskContext, caseData);
     }
 
     @Test
@@ -146,7 +146,7 @@ public class SolicitorDnFetchDocWorkflowTest {
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLinkTask, times(0)).execute(taskContext, caseData);
+        verify(populateDocLinkTask).execute(taskContext, caseData);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -17,12 +17,15 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLinkTask;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATIONS;
@@ -74,7 +77,7 @@ public class SolicitorDnFetchDocWorkflowTest {
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLinkTask).execute(taskContext, caseData);
+        verify(populateDocLinkTask, never()).execute(taskContext, caseData);
     }
 
     @Test
@@ -125,7 +128,7 @@ public class SolicitorDnFetchDocWorkflowTest {
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLinkTask).execute(taskContext, caseData);
+        verify(populateDocLinkTask, never()).execute(taskContext, caseData);
     }
 
     @Test
@@ -145,7 +148,7 @@ public class SolicitorDnFetchDocWorkflowTest {
 
         executeWorkflow(caseData, RESP_ANSWERS_LINK);
 
-        verify(populateDocLinkTask).execute(taskContext, caseData);
+        verify(populateDocLinkTask, never()).execute(taskContext, caseData);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.PopulateDocLinkTask;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -25,7 +24,6 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATIONS;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.SERVICE_APPLICATIONS;


### PR DESCRIPTION
# Description
https://tools.hmcts.net/jira/browse/DIV-6746

When a case has been `serviced by process server` or `alternative service method` there isn't a respondent answer document as part of the case data. When the Solicitor is drafting a DN the current flow presents the user with a screen with a link to this document for review. This change is to display a default message in these scenarios and also allows the flow to continue and not error out.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
