### PR TITLE
Ignoring unknown fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/Organisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/Organisation.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
@@ -8,6 +9,7 @@ import lombok.ToString;
 @Data
 @Builder
 @ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Organisation {
 
     @JsonProperty("OrganisationID")

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/OrganisationPolicy.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/ccd/OrganisationPolicy.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
@@ -8,6 +9,7 @@ import lombok.ToString;
 @Data
 @Builder
 @ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OrganisationPolicy {
 
     @JsonProperty("Organisation")


### PR DESCRIPTION
# Description

Looking at the logs is seems there is more data returning than the domain model handles and getting errors when solicitorCreate event is triggered especially on Demo env

```
...ERROR [http-nio-4012-exec-4] u.g.h.r.l.f.RequestStatusLoggingFilter - Request POST /solicitor-create failed in 205ms
org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.IllegalArgumentException: Unrecognized field "PreviousOrganisations" (class uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.OrganisationPolicy), not marked as ignorable (3 known properties: "Organisation", "OrgPolicyReference", "OrgPolicyCaseAssignedRole"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.OrganisationPolicy["PreviousOrganisations"])
```

Ignoring fields we dont use. Would also enquire from the CCD team about this `PreviousOrganisations` fields

