### PR TITLE
Release RPET-559, RPET-567, RPET-269

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorPersonalServiceCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorPersonalServiceCallbackTest.java
@@ -11,7 +11,9 @@ import uk.gov.hmcts.reform.divorce.support.CcdSubmissionSupport;
 import uk.gov.hmcts.reform.divorce.support.cos.CosApiClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 @Slf4j
@@ -20,15 +22,13 @@ public class SolicitorPersonalServiceCallbackTest extends CcdSubmissionSupport {
     private static final String ISSUED_SOLICITOR_PETITION_JSON = "solicitor-petition.json";
     private static final String SOLICITOR_SUBMIT_PERSONAL_SERVICE = "solicitor-submit-personal-service.json";
     private static final String ISSUE_EVENT_ID = "issueFromSubmitted";
-    private static final String DOC_TYPE_PERSONAL_SERVICE = "personalService";
-    private static final String PERSONAL_SERVICE_FILE_NAME_FORMAT = "solicitor-personal-service-%s.pdf";
     private static final String SOLICITOR_STATEMENT_OF_TRUTH_PAY_SUBMIT = "solicitorStatementOfTruthPaySubmit";
 
     @Autowired
     private CosApiClient cosApiClient;
 
     @Test
-    public void testSolicitorPersonalServiceCallbackGeneratesPersonalServicePack() {
+    public void testSolicitorPersonalServiceCallbackGeneratesPersonalServiceResponse() {
         //given
         final UserDetails solicitorUser = createSolicitorUser();
         CaseDetails caseDetails = submitSolicitorCase(ISSUED_SOLICITOR_PETITION_JSON, solicitorUser);
@@ -52,10 +52,6 @@ public class SolicitorPersonalServiceCallbackTest extends CcdSubmissionSupport {
 
         //then
         assertThat(callbackResponse.getErrors(), is(nullValue()));
-        CaseDetails responseCaseDetails = CaseDetails.builder()
-            .id(Long.valueOf(caseId))
-            .data(callbackResponse.getData())
-            .build();
-        assertGeneratedDocumentsExists(responseCaseDetails, DOC_TYPE_PERSONAL_SERVICE, PERSONAL_SERVICE_FILE_NAME_FORMAT);
+        assertThat(callbackResponse.getData().toString(), is(not(emptyOrNullString())));
     }
 }

--- a/src/integrationTest/resources/fixtures/issue-petition/solicitor-petition.json
+++ b/src/integrationTest/resources/fixtures/issue-petition/solicitor-petition.json
@@ -12,9 +12,6 @@
   "D8DivorceCostsClaim": "No",
   "D8DivorceUnit": "eastMidlands",
   "D8DivorceWho": "wife",
-  "D8DocumentsGenerated": [
-  ],
-  "D8DocumentsUploaded": [],
   "D8FinancialOrder": "No",
   "D8InferredPetitionerGender": "male",
   "D8InferredRespondentGender": "female",

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackController.java
@@ -40,9 +40,9 @@ public class SolicitorCallbackController {
 
     @PostMapping(path = "/personal-service-pack",
         consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Generates the petitioner's solicitor personal service pack to be served to the respondent")
+    @ApiOperation(value = "Validates case to be issued with personal service")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Document generated and emailed to the petitioner's solicitor",
+        @ApiResponse(code = 200, message = "Case validation successful",
             response = CaseResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> issuePersonalServicePack(
@@ -52,7 +52,7 @@ public class SolicitorCallbackController {
         Map<String, Object> response;
 
         try {
-            response = solicitorService.issuePersonalServicePack(ccdCallbackRequest, authorizationToken);
+            response = solicitorService.validateForPersonalServicePack(ccdCallbackRequest, authorizationToken);
         } catch (Exception e) {
             return ResponseEntity.ok(
                 CcdCallbackResponse.builder()

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackController.java
@@ -67,6 +67,34 @@ public class SolicitorCallbackController {
                 .build());
     }
 
+    @PostMapping(path = "/solicitor-confirm-service",
+        consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Validates the case for solicitor confirm service")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Case successfully validated",
+            response = CaseResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request")})
+    public ResponseEntity<CcdCallbackResponse> solicitorConfirmPersonalService(
+        @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
+
+        Map<String, Object> response;
+        try {
+            response = solicitorService.solicitorConfirmPersonalService(ccdCallbackRequest);
+        } catch (Exception e) {
+            return ResponseEntity.ok(
+                CcdCallbackResponse.builder()
+                    .data(ImmutableMap.of())
+                    .warnings(ImmutableList.of())
+                    .errors(singletonList("Failed to validate for solicitor confirm personal service - " + e.getMessage()))
+                    .build());
+        }
+        return ResponseEntity.ok(
+            CcdCallbackResponse.builder()
+                .data(response)
+                .build());
+    }
+
+
     @PostMapping(path = "/handle-post-personal-service-pack")
     @ApiOperation(value = "Callback to notify solicitor that personal service pack has been issued")
     @ApiResponses(value = {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -263,8 +263,6 @@ public class OrchestrationConstants {
     public static final String DECREE_ABSOLUTE_GRANTED_CITIZEN_LETTER_DOCUMENT_TYPE = "daGrantedLetter";
     public static final String DECREE_ABSOLUTE_GRANTED_SOLICITOR_LETTER_DOCUMENT_TYPE = "daGrantedLetterSol";
     public static final String DECREE_ABSOLUTE_FILENAME = "decreeAbsolute";
-    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_FILENAME = "solicitor-personal-service-";
-    public static final String SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE = "personalService";
     public static final String FEE_TO_PAY_JSON_KEY = "FeeToPay";
     public static final String AOS_OVERDUE_COVER_LETTER_DOCUMENT_TYPE = "aosOverdueCoverLetter";
     public static final String CERTIFICATE_OF_ENTITLEMENT_FILENAME_PREFIX = "certificateOfEntitlement";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/SolicitorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/SolicitorService.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import java.util.Map;
 
 public interface SolicitorService {
-    Map<String, Object> issuePersonalServicePack(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException;
+    Map<String, Object> validateForPersonalServicePack(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException;
 
     Map<String, Object> sendSolicitorPersonalServiceEmail(CcdCallbackRequest callbackRequest) throws WorkflowException;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/SolicitorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/SolicitorService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 public interface SolicitorService {
     Map<String, Object> validateForPersonalServicePack(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException;
 
+    Map<String, Object> solicitorConfirmPersonalService(CcdCallbackRequest callbackRequest) throws WorkflowException;
+
     Map<String, Object> sendSolicitorPersonalServiceEmail(CcdCallbackRequest callbackRequest) throws WorkflowException;
 
     Map<String, Object> retrievePbaNumbers(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImpl.java
@@ -6,8 +6,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.SolicitorService;
-import uk.gov.hmcts.reform.divorce.orchestration.workflows.IssuePersonalServicePackWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.RetrievePbaNumbersWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.ValidateForPersonalServicePackWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.notification.SendSolicitorPersonalServiceEmailWorkflow;
 
 import java.util.Map;
@@ -16,13 +16,13 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SolicitorServiceImpl implements SolicitorService {
 
-    private final IssuePersonalServicePackWorkflow issuePersonalServicePackWorkflow;
+    private final ValidateForPersonalServicePackWorkflow validateForPersonalServicePackWorkflow;
     private final SendSolicitorPersonalServiceEmailWorkflow sendSolicitorPersonalServiceEmailWorkflow;
     private final RetrievePbaNumbersWorkflow retrievePbaNumbersWorkflow;
 
     @Override
-    public Map<String, Object> issuePersonalServicePack(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException {
-        return issuePersonalServicePackWorkflow.run(callbackRequest, authToken);
+    public Map<String, Object> validateForPersonalServicePack(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException {
+        return validateForPersonalServicePackWorkflow.run(callbackRequest, authToken);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImpl.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackReq
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.SolicitorService;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.RetrievePbaNumbersWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SolConfirmServiceWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.ValidateForPersonalServicePackWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.notification.SendSolicitorPersonalServiceEmailWorkflow;
 
@@ -16,6 +17,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SolicitorServiceImpl implements SolicitorService {
 
+    private final SolConfirmServiceWorkflow solConfirmServiceWorkflow;
     private final ValidateForPersonalServicePackWorkflow validateForPersonalServicePackWorkflow;
     private final SendSolicitorPersonalServiceEmailWorkflow sendSolicitorPersonalServiceEmailWorkflow;
     private final RetrievePbaNumbersWorkflow retrievePbaNumbersWorkflow;
@@ -23,6 +25,11 @@ public class SolicitorServiceImpl implements SolicitorService {
     @Override
     public Map<String, Object> validateForPersonalServicePack(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException {
         return validateForPersonalServicePackWorkflow.run(callbackRequest, authToken);
+    }
+
+    @Override
+    public Map<String, Object> solicitorConfirmPersonalService(CcdCallbackRequest callbackRequest) throws WorkflowException {
+        return solConfirmServiceWorkflow.run(callbackRequest);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/BulkPrintWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/BulkPrintWorkflow.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AosPackDueDateSetterTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FetchPrintDocsFromDmStoreTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.ServiceMethodValidationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.CoRespondentAosPackPrinterTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.RespondentAosPackPrinterTask;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils;
@@ -29,7 +28,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @Slf4j
 public class BulkPrintWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
-    private final ServiceMethodValidationTask serviceMethodValidationTask;
     private final FetchPrintDocsFromDmStoreTask fetchPrintDocsFromDmStoreTask;
     private final RespondentAosPackPrinterTask respondentAosPackPrinterTask;
     private final CoRespondentAosPackPrinterTask coRespondentAosPackPrinterTask;
@@ -40,7 +38,6 @@ public class BulkPrintWorkflow extends DefaultWorkflow<Map<String, Object>> {
     public Map<String, Object> run(final String authToken, CaseDetails caseDetails) throws WorkflowException {
         final List<Task<Map<String, Object>>> tasks = new ArrayList<>();
 
-        tasks.add(serviceMethodValidationTask);
         tasks.add(fetchPrintDocsFromDmStoreTask);
         tasks.add(respondentAosPackPrinterTask);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssuePersonalServicePackWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssuePersonalServicePackWorkflow.java
@@ -3,27 +3,16 @@ package uk.gov.hmcts.reform.divorce.orchestration.workflows;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentTypeHelper;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseDataTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.DocumentGenerationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.PersonalServiceValidationTask;
 
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TEMPLATE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_PERSONAL_SERVICE_LETTER_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.SOLICITOR_PERSONAL_SERVICE_LETTER;
 
 
 @Component
@@ -31,27 +20,16 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.te
 public class IssuePersonalServicePackWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     private final PersonalServiceValidationTask personalServiceValidationTask;
-    private final DocumentGenerationTask documentGenerationTask;
-    private final AddNewDocumentsToCaseDataTask addNewDocumentsToCaseDataTask;
 
     public Map<String, Object> run(CcdCallbackRequest callbackRequest, String authToken) throws WorkflowException {
-        CaseDetails caseDetails = callbackRequest.getCaseDetails();
-
-        String templateId = DocumentTypeHelper.getLanguageAppropriateTemplate(caseDetails.getCaseData(), SOLICITOR_PERSONAL_SERVICE_LETTER);
 
         return this.execute(
             new Task[] {
                 personalServiceValidationTask,
-                documentGenerationTask,
-                addNewDocumentsToCaseDataTask
             },
             callbackRequest.getCaseDetails().getCaseData(),
             ImmutablePair.of(AUTH_TOKEN_JSON_KEY, authToken),
-            ImmutablePair.of(CASE_ID_JSON_KEY, callbackRequest.getCaseDetails().getCaseId()),
-            ImmutablePair.of(CASE_DETAILS_JSON_KEY, callbackRequest.getCaseDetails()),
-            ImmutablePair.of(DOCUMENT_TYPE, SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE),
-            ImmutablePair.of(DOCUMENT_TEMPLATE_ID, templateId),
-            ImmutablePair.of(DOCUMENT_FILENAME, SOLICITOR_PERSONAL_SERVICE_LETTER_FILENAME)
+            ImmutablePair.of(CASE_ID_JSON_KEY, callbackRequest.getCaseDetails().getCaseId())
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolConfirmServiceWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolConfirmServiceWorkflow.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PersonalServiceValidationTask;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SolConfirmServiceWorkflow extends DefaultWorkflow<Map<String, Object>> {
+
+    private final PersonalServiceValidationTask personalServiceValidationTask;
+
+    public Map<String, Object> run(final CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
+        final CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();
+
+        return this.execute(
+            new Task[]{personalServiceValidationTask},
+            caseDetails.getCaseData(),
+            ImmutablePair.of(CASE_ID_JSON_KEY, caseDetails.getCaseId()),
+            ImmutablePair.of(CASE_STATE_JSON_KEY, caseDetails.getState())
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ValidateForPersonalServicePackWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ValidateForPersonalServicePackWorkflow.java
@@ -17,7 +17,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 
 @Component
 @RequiredArgsConstructor
-public class IssuePersonalServicePackWorkflow extends DefaultWorkflow<Map<String, Object>> {
+public class ValidateForPersonalServicePackWorkflow extends DefaultWorkflow<Map<String, Object>> {
 
     private final PersonalServiceValidationTask personalServiceValidationTask;
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackControllerTest.java
@@ -55,7 +55,7 @@ public class SolicitorCallbackControllerTest {
                 .caseDetails(CaseDetails.builder().caseData(divorceSession).build())
                 .build();
 
-        when(solicitorService.issuePersonalServicePack(request, AUTH_TOKEN))
+        when(solicitorService.validateForPersonalServicePack(request, AUTH_TOKEN))
                 .thenReturn(divorceSession);
 
         ResponseEntity<CcdCallbackResponse> response = classUnderTest.issuePersonalServicePack(AUTH_TOKEN, request);
@@ -64,7 +64,7 @@ public class SolicitorCallbackControllerTest {
         assertThat(response.getBody().getData(), is(divorceSession));
         assertThat(response.getBody().getErrors(), is(nullValue()));
 
-        verify(solicitorService).issuePersonalServicePack(request, AUTH_TOKEN);
+        verify(solicitorService).validateForPersonalServicePack(request, AUTH_TOKEN);
     }
 
     @Test
@@ -74,7 +74,7 @@ public class SolicitorCallbackControllerTest {
                 .caseDetails(CaseDetails.builder().caseData(divorceSession).build())
                 .build();
 
-        when(solicitorService.issuePersonalServicePack(request, AUTH_TOKEN))
+        when(solicitorService.validateForPersonalServicePack(request, AUTH_TOKEN))
                 .thenThrow(new RuntimeException("test"));
 
         ResponseEntity<CcdCallbackResponse> response = classUnderTest.issuePersonalServicePack(AUTH_TOKEN, request);
@@ -83,7 +83,7 @@ public class SolicitorCallbackControllerTest {
         assertThat(response.getBody().getErrors().size(), is(1));
         assertThat(response.getBody().getErrors(), contains("Failed to issue solicitor personal service - test"));
 
-        verify(solicitorService).issuePersonalServicePack(request, AUTH_TOKEN);
+        verify(solicitorService).validateForPersonalServicePack(request, AUTH_TOKEN);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackControllerTest.java
@@ -142,6 +142,20 @@ public class SolicitorCallbackControllerTest {
         whenRetrievePbaNumbersExpect(expectedResponse, caseDataReturnedFromService);
     }
 
+    @Test
+    public void testServiceMethodIsCalled_WhenSolicitorConfirmPersonalService() throws WorkflowException {
+        when(solicitorService.solicitorConfirmPersonalService(any())).thenReturn(singletonMap("testKey", "testValue"));
+
+        CcdCallbackRequest callbackRequest = CcdCallbackRequest.builder()
+            .caseDetails(CaseDetails.builder().caseData(singletonMap("testKey", "testValue")).build())
+            .build();
+        ResponseEntity<CcdCallbackResponse> response = classUnderTest.solicitorConfirmPersonalService(callbackRequest);
+
+        assertThat(response.getStatusCode(), CoreMatchers.is(OK));
+        assertThat(response.getBody().getData(), hasEntry("testKey", "testValue"));
+        verify(solicitorService).solicitorConfirmPersonalService(callbackRequest);
+    }
+
     private void whenRetrievePbaNumbersExpect(CcdCallbackResponse expectedResponse, Map<String, Object> caseData) throws WorkflowException {
         final CaseDetails caseDetails = CaseDetails.builder()
             .caseData(caseData)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/BulkPrintTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/BulkPrintTest.java
@@ -23,12 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static java.util.Collections.emptyMap;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -36,8 +31,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.PERSONAL_SERVICE_VALUE;
-import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.SOL_SERVICE_METHOD_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_ORGANISATION_POLICY_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SERVICE_AUTH_TOKEN;
@@ -180,37 +173,6 @@ public class BulkPrintTest extends IdamTestSupport {
             createCollectionMemberDocument("http://localhost:4020/documents/" + testDocumentId, DOCUMENT_TYPE_CO_RESPONDENT_INVITATION, "coRespondentletter")
         ));
         return caseData;
-    }
-
-    @Test
-    public void givenServiceMethodIsPersonalServiceAndStateIsNotAwaitingService_thenResponseContainsErrors() throws Exception {
-        final Map<String, Object> caseData = Collections.singletonMap(
-            SOL_SERVICE_METHOD_CCD_FIELD, PERSONAL_SERVICE_VALUE
-        );
-
-        final CaseDetails caseDetails = CaseDetails.builder()
-            .state("Issued")
-            .caseData(caseData)
-            .build();
-
-        CcdCallbackRequest request = CcdCallbackRequest.builder()
-            .caseDetails(caseDetails)
-            .build();
-
-        webClient.perform(post(API_URL)
-            .content(convertObjectToJsonString(request))
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .header(AUTHORIZATION, AUTH_TOKEN))
-            .andExpect(status().isOk())
-            .andExpect(content().string(allOf(
-                isJson(),
-                hasJsonPath("$.data", is(Collections.emptyMap())),
-                hasJsonPath("$.errors",
-                    hasItem("Failed to bulk print documents - This event cannot be used when "
-                        + "service method is Personal Service and the case is not in Awaiting Service.")
-                )
-            )));
     }
 
     private void setRespondentJourneyFeatureToggleOn() {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorConfirmPersonalServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorConfirmPersonalServiceTest.java
@@ -1,0 +1,104 @@
+package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.divorce.orchestration.OrchestrationServiceApplication;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.core.Is.is;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.SOL_SERVICE_METHOD_CCD_FIELD;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = OrchestrationServiceApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@PropertySource(value = "classpath:application.yml")
+@AutoConfigureMockMvc
+public class SolicitorConfirmPersonalServiceTest {
+
+    private static final String API_URL = "/solicitor-confirm-service";
+
+    @Autowired
+    private MockMvc webClient;
+
+    @Test
+    public void givenNoSolicitorServiceMethod_thenResponseContainsErrors() throws Exception {
+
+        final Map<String, Object> caseData = Collections.emptyMap();
+
+        final CaseDetails caseDetails = CaseDetails.builder()
+            .caseData(caseData)
+            .build();
+
+        CcdCallbackRequest request = CcdCallbackRequest.builder()
+            .caseDetails(caseDetails)
+            .build();
+
+        webClient.perform(post(API_URL)
+            .content(convertObjectToJsonString(request))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .header(AUTHORIZATION, AUTH_TOKEN))
+            .andExpect(status().isOk())
+            .andExpect(content().string(allOf(
+                isJson(),
+                hasJsonPath("$.data", is(Collections.emptyMap())),
+                hasJsonPath("$.errors",
+                    hasItem("Failed to validate for solicitor confirm personal service - "
+                        + "Could not evaluate value of mandatory property \"SolServiceMethod\"")
+                )
+            )));
+    }
+
+    @Test
+    public void givenServiceMethodIsNotPersonalService_thenResponseContainsErrors() throws Exception {
+
+        final Map<String, Object> caseData = Collections.singletonMap(
+            SOL_SERVICE_METHOD_CCD_FIELD, "test"
+        );
+
+        final CaseDetails caseDetails = CaseDetails.builder()
+            .caseData(caseData)
+            .build();
+
+        CcdCallbackRequest request = CcdCallbackRequest.builder()
+            .caseDetails(caseDetails)
+            .build();
+
+        webClient.perform(post(API_URL)
+            .content(convertObjectToJsonString(request))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .header(AUTHORIZATION, AUTH_TOKEN))
+            .andExpect(status().isOk())
+            .andExpect(content().string(allOf(
+                isJson(),
+                hasJsonPath("$.data", is(Collections.emptyMap())),
+                hasJsonPath("$.errors",
+                    hasItem("Failed to validate for solicitor confirm personal service - This event can only be used "
+                        + "with for a case with Personal Service as the service method")
+                )
+            )));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImplTest.java
@@ -8,8 +8,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
-import uk.gov.hmcts.reform.divorce.orchestration.workflows.IssuePersonalServicePackWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.RetrievePbaNumbersWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.ValidateForPersonalServicePackWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.notification.SendSolicitorPersonalServiceEmailWorkflow;
 
 import java.util.Collections;
@@ -24,7 +24,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_TOKEN
 public class SolicitorServiceImplTest {
 
     @Mock
-    IssuePersonalServicePackWorkflow issuePersonalServicePack;
+    ValidateForPersonalServicePackWorkflow issuePersonalServicePack;
 
     @Mock
     SendSolicitorPersonalServiceEmailWorkflow sendSolicitorPersonalServiceEmailWorkflow;
@@ -41,7 +41,7 @@ public class SolicitorServiceImplTest {
                 .caseDetails(CaseDetails.builder().build())
                 .build();
 
-        solicitorService.issuePersonalServicePack(request, TEST_TOKEN);
+        solicitorService.validateForPersonalServicePack(request, TEST_TOKEN);
 
         verify(issuePersonalServicePack).run(request, TEST_TOKEN);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/SolicitorServiceImplTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.RetrievePbaNumbersWorkflow;
+import uk.gov.hmcts.reform.divorce.orchestration.workflows.SolConfirmServiceWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.ValidateForPersonalServicePackWorkflow;
 import uk.gov.hmcts.reform.divorce.orchestration.workflows.notification.SendSolicitorPersonalServiceEmailWorkflow;
 
@@ -28,6 +29,9 @@ public class SolicitorServiceImplTest {
 
     @Mock
     SendSolicitorPersonalServiceEmailWorkflow sendSolicitorPersonalServiceEmailWorkflow;
+
+    @Mock
+    SolConfirmServiceWorkflow solConfirmServiceWorkflow;
 
     @Mock
     RetrievePbaNumbersWorkflow retrievePbaNumbersWorkflow;
@@ -72,5 +76,19 @@ public class SolicitorServiceImplTest {
         solicitorService.retrievePbaNumbers(request, TEST_TOKEN);
 
         verify(retrievePbaNumbersWorkflow).run(request, TEST_TOKEN);
+    }
+
+    @Test
+    public void shouldCallTheRightWorkflow_forSolConfirmPersonalService() throws WorkflowException {
+        Map<String, Object> caseData = Collections.emptyMap();
+        CcdCallbackRequest request = CcdCallbackRequest.builder()
+            .caseDetails(CaseDetails.builder().caseId(TEST_CASE_ID).caseData(caseData).build())
+            .build();
+
+        when(solConfirmServiceWorkflow.run(request)).thenReturn(caseData);
+
+        solicitorService.solicitorConfirmPersonalService(request);
+
+        verify(solConfirmServiceWorkflow).run(request);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/BulkPrintWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/BulkPrintWorkflowTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowExce
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AosPackDueDateSetterTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.FetchPrintDocsFromDmStoreTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.ServiceMethodValidationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.CoRespondentAosPackPrinterTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.RespondentAosPackPrinterTask;
 import uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils;
@@ -29,9 +28,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.testutil.Verificators.ve
 
 @RunWith(MockitoJUnitRunner.class)
 public class BulkPrintWorkflowTest {
-
-    @Mock
-    private ServiceMethodValidationTask serviceMethodValidationTask;
 
     @Mock
     private FetchPrintDocsFromDmStoreTask fetchPrintDocsFromDmStoreTask;
@@ -59,7 +55,6 @@ public class BulkPrintWorkflowTest {
 
         mockTasksExecution(
             caseDetails.getCaseData(),
-            serviceMethodValidationTask,
             fetchPrintDocsFromDmStoreTask,
             aosPackDueDateSetterTask,
             respondentAosPackPrinterTask,
@@ -77,7 +72,6 @@ public class BulkPrintWorkflowTest {
 
         verifyTasksCalledInOrder(
             payload,
-            serviceMethodValidationTask,
             fetchPrintDocsFromDmStoreTask,
             respondentAosPackPrinterTask,
             coRespondentAosPackPrinterTask,
@@ -95,7 +89,6 @@ public class BulkPrintWorkflowTest {
 
         verifyTasksCalledInOrder(
             payload,
-            serviceMethodValidationTask,
             fetchPrintDocsFromDmStoreTask,
             respondentAosPackPrinterTask,
             aosPackDueDateSetterTask

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssuePersonalServicePackWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/IssuePersonalServicePackWorkflowTest.java
@@ -11,8 +11,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackReq
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseDataTask;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.DocumentGenerationTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.PersonalServiceValidationTask;
 
 import java.util.Collections;
@@ -26,13 +24,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTH_TOKEN_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_FILENAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TEMPLATE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_PERSONAL_SERVICE_LETTER_FILENAME;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IssuePersonalServicePackWorkflowTest {
@@ -40,16 +32,8 @@ public class IssuePersonalServicePackWorkflowTest {
     @Mock
     PersonalServiceValidationTask personalServiceValidationTask;
 
-    @Mock
-    DocumentGenerationTask documentGenerationTask;
-
-    @Mock
-    AddNewDocumentsToCaseDataTask addNewDocumentsToCaseDataTask;
-
     @InjectMocks
     IssuePersonalServicePackWorkflow issuePersonalServicePackWorkflow;
-
-    private static final String SOLICITOR_PERSONAL_SERVICE_LETTER_TEMPLATE_ID = "FL-DIV-GNO-ENG-00073.docx";
 
     @Test
     public void testRunExecutesExpectedTasksInOrder() throws WorkflowException, TaskException {
@@ -65,10 +49,6 @@ public class IssuePersonalServicePackWorkflowTest {
             {
                 put(AUTH_TOKEN_JSON_KEY, TEST_TOKEN);
                 put(CASE_ID_JSON_KEY, TEST_CASE_ID);
-                put(CASE_DETAILS_JSON_KEY, caseDetails);
-                put(DOCUMENT_TYPE, SOLICITOR_PERSONAL_SERVICE_LETTER_DOCUMENT_TYPE);
-                put(DOCUMENT_TEMPLATE_ID, SOLICITOR_PERSONAL_SERVICE_LETTER_TEMPLATE_ID);
-                put(DOCUMENT_FILENAME, SOLICITOR_PERSONAL_SERVICE_LETTER_FILENAME);
             }
         });
 
@@ -78,19 +58,14 @@ public class IssuePersonalServicePackWorkflowTest {
 
         //when
         when(personalServiceValidationTask.execute(context, caseData)).thenReturn(caseData);
-        when(documentGenerationTask.execute(context, caseData)).thenReturn(caseData);
-        when(addNewDocumentsToCaseDataTask.execute(context, caseData)).thenReturn(caseData);
+
         Map<String, Object> response = issuePersonalServicePackWorkflow.run(request, TEST_TOKEN);
 
         //then
         assertThat(response, is(caseData));
         InOrder inOrder = inOrder(
-            personalServiceValidationTask,
-            documentGenerationTask,
-            addNewDocumentsToCaseDataTask
+            personalServiceValidationTask
         );
         inOrder.verify(personalServiceValidationTask).execute(context, caseData);
-        inOrder.verify(documentGenerationTask).execute(context, caseData);
-        inOrder.verify(addNewDocumentsToCaseDataTask).execute(context, caseData);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolConfirmServiceWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolConfirmServiceWorkflowTest.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.reform.divorce.orchestration.workflows;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.PersonalServiceValidationTask;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_EVENT_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_TOKEN;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_STATE_JSON_KEY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SolConfirmServiceWorkflowTest {
+
+    @Mock
+    private PersonalServiceValidationTask personalServiceValidationTask;
+
+    @InjectMocks
+    private SolConfirmServiceWorkflow solConfirmServiceWorkflow;
+
+    private CcdCallbackRequest ccdCallbackRequestRequest;
+
+    private Map<String, Object> payload;
+
+    private TaskContext context;
+
+    @Before
+    public void setUp() {
+        payload = new HashMap<>();
+
+        CaseDetails caseDetails = CaseDetails.builder()
+            .caseId(TEST_CASE_ID)
+            .state(TEST_STATE)
+            .caseData(payload)
+            .build();
+
+        ccdCallbackRequestRequest =
+            CcdCallbackRequest.builder()
+                .eventId(TEST_EVENT_ID)
+                .token(TEST_TOKEN)
+                .caseDetails(caseDetails)
+                .build();
+
+        context = new DefaultTaskContext();
+        context.setTransientObject(CASE_ID_JSON_KEY, TEST_CASE_ID);
+        context.setTransientObject(CASE_STATE_JSON_KEY, TEST_STATE);
+    }
+
+    @Test
+    public void whenWorkflowRunsForAdulteryCase_WithNamedCoRespondent_allTasksRun_payloadReturned() throws WorkflowException, TaskException {
+        when(personalServiceValidationTask.execute(context, payload)).thenReturn(payload);
+
+        Map<String, Object> response = solConfirmServiceWorkflow.run(ccdCallbackRequestRequest);
+        assertThat(response, is(payload));
+
+        verify(personalServiceValidationTask).execute(context, payload);
+    }
+
+    @Test
+    public void whenWorkflowRunsForNonAdulteryCase_allTasksRunExceptForCoRespondent_payloadReturned() throws WorkflowException, TaskException {
+        when(personalServiceValidationTask.execute(context, payload)).thenReturn(payload);
+
+        Map<String, Object> response = solConfirmServiceWorkflow.run(ccdCallbackRequestRequest);
+        assertThat(response, is(payload));
+
+        verify(personalServiceValidationTask).execute(context, payload);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ValidateForPersonalServicePackWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/ValidateForPersonalServicePackWorkflowTest.java
@@ -27,13 +27,13 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 
 @RunWith(MockitoJUnitRunner.class)
-public class IssuePersonalServicePackWorkflowTest {
+public class ValidateForPersonalServicePackWorkflowTest {
 
     @Mock
     PersonalServiceValidationTask personalServiceValidationTask;
 
     @InjectMocks
-    IssuePersonalServicePackWorkflow issuePersonalServicePackWorkflow;
+    ValidateForPersonalServicePackWorkflow validateForPersonalServicePackWorkflow;
 
     @Test
     public void testRunExecutesExpectedTasksInOrder() throws WorkflowException, TaskException {
@@ -59,7 +59,7 @@ public class IssuePersonalServicePackWorkflowTest {
         //when
         when(personalServiceValidationTask.execute(context, caseData)).thenReturn(caseData);
 
-        Map<String, Object> response = issuePersonalServicePackWorkflow.run(request, TEST_TOKEN);
+        Map<String, Object> response = validateForPersonalServicePackWorkflow.run(request, TEST_TOKEN);
 
         //then
         assertThat(response, is(caseData));


### PR DESCRIPTION
[Corresponding ccd-definitions PR](https://github.com/hmcts/div-ccd-definitions/pull/775)

- RPET-599 no div-cos changes required 

- RPET-567 update solConfirmPersonalService callback endpoint (#1158)

- RPET-269 remove generation of solicitor personal service letter (#1154)

### JIRA link (if applicable) ###
[RPET-269](https://tools.hmcts.net/jira/browse/RPET-269)
[RPET-567](https://tools.hmcts.net/jira/browse/RPET-567)
[RPET-559](https://tools.hmcts.net/jira/browse/RPET-559)

### Change description ###
Combined release PR for RPET-269, RPET-567, and RPET-559