### PR TITLE
Div-6533: RespSol complete AOS whilst bailiff in progress 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -539,6 +539,22 @@ public class CallbackController {
         return ResponseEntity.ok(callbackResponseBuilder.build());
     }
 
+    @PostMapping(path = "/confirm-sol-dn-review", consumes = APPLICATION_JSON, produces = APPLICATION_JSON)
+    @ApiOperation(value = "Callback to set state after Solicitor reviews DN petition")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Callback processed",
+                    response = CcdCallbackResponse.class),
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 500, message = "Internal Server Error")})
+    public ResponseEntity<CcdCallbackResponse> confirmSolDnReviewPetition(
+            @RequestBody CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
+
+        return ResponseEntity.ok(
+                caseOrchestrationService
+                        .confirmSolDnReviewPetition(ccdCallbackRequest.getCaseDetails())
+        );
+    }
+
     @PostMapping(path = "/sol-dn-resp-answers-doc", consumes = APPLICATION_JSON, produces = APPLICATION_JSON)
     @ApiOperation(value = "Populates Respondent Answers doc for solicitor DN journey")
     @ApiResponses(value = {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/CaseOrchestrationService.java
@@ -104,6 +104,8 @@ public interface CaseOrchestrationService {
     Map<String, Object> processSolDnDoc(CcdCallbackRequest ccdCallbackRequest, String ccdDocumentType, String docLinkFieldName)
         throws CaseOrchestrationServiceException;
 
+    CcdCallbackResponse confirmSolDnReviewPetition(CaseDetails caseDetails) throws CaseOrchestrationServiceException;
+
     Map<String, Object> generateCoRespondentAnswers(CcdCallbackRequest ccdCallbackRequest, String authToken) throws WorkflowException;
 
     Map<String, Object> generateBulkCaseForListing() throws WorkflowException;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/common/Conditions.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/common/Conditions.java
@@ -10,6 +10,8 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.Applicati
 
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING_SOLICITOR;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PREVIOUS_CASE_ID_CCD_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 
@@ -54,6 +56,11 @@ public class Conditions {
 
     public static boolean isAwaitingServiceConsideration(CaseDetails caseDetails) {
         return CcdStates.AWAITING_SERVICE_CONSIDERATION.equalsIgnoreCase(caseDetails.getState());
+    }
+
+    public static boolean isAOSDraftedCandidate(CaseDetails caseDetails) {
+        return caseDetails.getState().equals(AOS_AWAITING_SOLICITOR)
+                || caseDetails.getState().equals(AOS_AWAITING);
     }
 
     public static boolean isPetitionAmended(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -95,6 +95,9 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.JUDGE_COSTS_DECISION;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING_SOLICITOR;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_DRAFTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_PAYMENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.BULK_LISTING_CASE_ID_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_EVENT_DATA_JSON_KEY;
@@ -673,6 +676,20 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
         } catch (WorkflowException e) {
             throw new CaseOrchestrationServiceException(e);
         }
+    }
+
+    @Override
+    public CcdCallbackResponse confirmSolDnReviewPetition(CaseDetails caseDetails) {
+        String currentState = caseDetails.getState();
+
+        CcdCallbackResponse.CcdCallbackResponseBuilder builder = CcdCallbackResponse.builder();
+        builder.data(caseDetails.getCaseData());
+
+        if (currentState.equals(AOS_AWAITING_SOLICITOR) || currentState.equals(AOS_AWAITING)) {
+            builder.state(AOS_DRAFTED);
+        }
+
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -95,8 +95,6 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.JUDGE_COSTS_DECISION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING_SOLICITOR;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_DRAFTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_PAYMENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.BULK_LISTING_CASE_ID_FIELD;
@@ -110,6 +108,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.COSTS_ORDER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.DECREE_NISI;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isAOSDraftedCandidate;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils.isPetitionerClaimingCosts;
 
 @Slf4j
@@ -680,15 +679,13 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
 
     @Override
     public CcdCallbackResponse confirmSolDnReviewPetition(CaseDetails caseDetails) {
-        String currentState = caseDetails.getState();
-
         CcdCallbackResponse.CcdCallbackResponseBuilder builder = CcdCallbackResponse.builder();
         builder.data(caseDetails.getCaseData());
 
-        if (currentState.equals(AOS_AWAITING_SOLICITOR) || currentState.equals(AOS_AWAITING)) {
+        if (isAOSDraftedCandidate(caseDetails)) {
             builder.state(AOS_DRAFTED);
         } else {
-            builder.state(currentState);
+            builder.state(caseDetails.getState());
         }
 
         return builder.build();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImpl.java
@@ -687,6 +687,8 @@ public class CaseOrchestrationServiceImpl implements CaseOrchestrationService {
 
         if (currentState.equals(AOS_AWAITING_SOLICITOR) || currentState.equals(AOS_AWAITING)) {
             builder.state(AOS_DRAFTED);
+        } else {
+            builder.state(currentState);
         }
 
         return builder.build();

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackControllerTest.java
@@ -621,6 +621,23 @@ public class CallbackControllerTest {
             .processSolDnDoc(incomingRequest, OrchestrationConstants.DOCUMENT_TYPE_PETITION, OrchestrationConstants.MINI_PETITION_LINK);
     }
 
+
+    @Test
+    public void confirmSolDnReviewPetition() throws CaseOrchestrationServiceException {
+        final Map<String, Object> caseData = Collections.emptyMap();
+        final CaseDetails caseDetails = CaseDetails.builder().caseData(caseData).build();
+        final CcdCallbackRequest ccdCallbackRequest = CcdCallbackRequest.builder().caseDetails(caseDetails).build();
+        final CcdCallbackResponse expectedResponse = CcdCallbackResponse.builder().data(caseData).build();
+
+        when(caseOrchestrationService.confirmSolDnReviewPetition(caseDetails))
+                .thenReturn(CcdCallbackResponse.builder().data(caseData).build());
+
+        final ResponseEntity<CcdCallbackResponse> response = classUnderTest.confirmSolDnReviewPetition(ccdCallbackRequest);
+
+        assertThat(response.getStatusCode(), is(OK));
+        assertThat(response.getBody(), is(expectedResponse));
+    }
+
     @Test
     public void testSolDnReviewPetitionPopulatesErrorsIfExceptionIsThrown() throws CaseOrchestrationServiceException {
         CcdCallbackRequest incomingRequest = CcdCallbackRequest.builder()

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ConfirmSolDNReview.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ConfirmSolDNReview.java
@@ -1,27 +1,19 @@
 package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
 
-import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
-import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
-import static java.lang.String.format;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -30,12 +22,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AOS_AWAITI
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_DRAFTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.ISSUED_TO_BAILIFF;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
-import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByAlternativeMethodCaseData;
-import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByProcessServerCaseData;
-import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServiceApplicationCaseData;
 
 public class ConfirmSolDNReview extends MockedFunctionalTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ConfirmSolDNReview.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ConfirmSolDNReview.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.reform.divorce.orchestration.functionaltest;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackRequest;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CcdCallbackResponse;
+import uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AOS_AWAITING_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_DRAFTED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.ISSUED_TO_BAILIFF;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByAlternativeMethodCaseData;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByProcessServerCaseData;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServiceApplicationCaseData;
+
+public class ConfirmSolDNReview extends MockedFunctionalTest {
+
+    private static final String API_URL = "/confirm-sol-dn-review";
+
+    @Autowired
+    private MockMvc webClient;
+
+    @Test
+    public void givenAOSDraftedCandidateState_whenEnpointIsCalled_thenShouldChangeState() throws Exception {
+
+        final Map<String, Object> caseData = Collections.emptyMap();
+
+        CaseDetails caseDetails = CaseDetails.builder()
+                .caseData(caseData)
+                .caseId(TEST_CASE_ID)
+                .state(AOS_AWAITING_STATE)
+                .build();
+
+        CcdCallbackRequest request = CcdCallbackRequest.builder()
+                .caseDetails(caseDetails)
+                .build();
+
+        webClient.perform(post(API_URL)
+                .content(convertObjectToJsonString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(allOf(
+                        isJson(),
+                        hasJsonPath("$.state", is(AOS_DRAFTED)),
+                        hasNoJsonPath("$.errors"),
+                        hasNoJsonPath("$.warnings")
+                )));
+    }
+
+    @Test
+    public void givenNotAOSDraftedCandidateState_whenEnpointIsCalled_thenShouldNotChangeState() throws Exception {
+
+        final Map<String, Object> caseData = Collections.emptyMap();
+
+        CaseDetails caseDetails = CaseDetails.builder()
+                .caseData(caseData)
+                .caseId(TEST_CASE_ID)
+                .state(ISSUED_TO_BAILIFF)
+                .build();
+
+        CcdCallbackRequest request = CcdCallbackRequest.builder()
+                .caseDetails(caseDetails)
+                .build();
+
+        webClient.perform(post(API_URL)
+                .content(convertObjectToJsonString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(allOf(
+                        isJson(),
+                        hasJsonPath("$.state", is(ISSUED_TO_BAILIFF)),
+                        hasNoJsonPath("$.errors"),
+                        hasNoJsonPath("$.warnings")
+                )));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -136,7 +136,13 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_TOKEN
 import static uk.gov.hmcts.reform.divorce.orchestration.controller.util.CallbackControllerTestUtils.assertCaseOrchestrationServiceExceptionIsSetProperly;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.JUDGE_COSTS_DECISION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PETITIONER_SOLICITOR_ORGANISATION_POLICY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_AWAITING_SOLICITOR;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AOS_DRAFTED;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_BAILIFF_REFERRAL;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_BAILIFF_SERVICE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.AWAITING_PAYMENT;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdStates.ISSUED_TO_BAILIFF;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.BULK_LISTING_CASE_ID_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.COSTS_ORDER_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DECREE_ABSOLUTE_GRANTED_DATE_CCD_FIELD;
@@ -1765,6 +1771,61 @@ public class CaseOrchestrationServiceImplTest {
             .eventId(TEST_EVENT_ID)
             .token(TEST_TOKEN)
             .build();
+    }
+
+    @Test
+    public void givenDraftAOSEvent_shouldChangeToAosDraftedState_whenAOSAwaitingSolicitor() {
+        CaseDetails caseDetails = CaseDetails.builder()
+                .state(AOS_AWAITING_SOLICITOR)
+                .build();
+
+        CcdCallbackResponse response = classUnderTest.confirmSolDnReviewPetition(caseDetails);
+
+        assertThat(response.getState(), is(AOS_DRAFTED));
+    }
+
+    @Test
+    public void givenDraftAOSEvent_shouldChangeToAosDraftedState_whenAOSAwaiting() {
+        CaseDetails caseDetails = CaseDetails.builder()
+                .state(AOS_AWAITING)
+                .build();
+
+        CcdCallbackResponse response = classUnderTest.confirmSolDnReviewPetition(caseDetails);
+
+        assertThat(response.getState(), is(AOS_DRAFTED));
+    }
+
+    @Test
+    public void givenDraftAOSEvent_shouldNotChangeState_whenAwaitingBailiffService() {
+        CaseDetails caseDetails = CaseDetails.builder()
+                .state(AWAITING_BAILIFF_SERVICE)
+                .build();
+
+        CcdCallbackResponse response = classUnderTest.confirmSolDnReviewPetition(caseDetails);
+
+        assertThat(response.getState(), is(AWAITING_BAILIFF_SERVICE));
+    }
+
+    @Test
+    public void givenDraftAOSEvent_shouldNotChangeState_whenIssuedToBailiff() {
+        CaseDetails caseDetails = CaseDetails.builder()
+                .state(ISSUED_TO_BAILIFF)
+                .build();
+
+        CcdCallbackResponse response = classUnderTest.confirmSolDnReviewPetition(caseDetails);
+
+        assertThat(response.getState(), is(ISSUED_TO_BAILIFF));
+    }
+
+    @Test
+    public void givenDraftAOSEvent_shouldNotChangeState__whenAwaitingBailiffReferral() {
+        CaseDetails caseDetails = CaseDetails.builder()
+                .state(AWAITING_BAILIFF_REFERRAL)
+                .build();
+
+        CcdCallbackResponse response = classUnderTest.confirmSolDnReviewPetition(caseDetails);
+
+        assertThat(response.getState(), is(AWAITING_BAILIFF_REFERRAL));
     }
 
     private Map<String, Object> buildCaseDataWithOrganisationPolicy() {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/impl/CaseOrchestrationServiceImplTest.java
@@ -1818,7 +1818,7 @@ public class CaseOrchestrationServiceImplTest {
     }
 
     @Test
-    public void givenDraftAOSEvent_shouldNotChangeState__whenAwaitingBailiffReferral() {
+    public void givenDraftAOSEvent_shouldNotChangeState_whenAwaitingBailiffReferral() {
         CaseDetails caseDetails = CaseDetails.builder()
                 .state(AWAITING_BAILIFF_REFERRAL)
                 .build();


### PR DESCRIPTION
# Description

Added new callback and logic

https://tools.hmcts.net/jira/browse/DIV-6533


ACs 1-3. (4 was previous implemented and tested)
- Respondent solicitor CAA is able to assign case to respondent solicitor. If a case is in the states 'AwaitingBailiffReferral', 'AwaitingBailifService', 'IssueToBailiff' then the CAA has access to these states and is able to assign the case to a member of their organisation.
- Respondent solicitor is able to draft an AOS response. If a case is in the states 'AwaitingBailiffReferral', 'AwaitingBailifService', 'IssueToBailiff' the respondent solicitor is able to trigger the event 'Draft AOS' (ID: SolicitorDraftAOS), however rather than moving into the state 'AOSdrafted' it stays in the same state.
- Respondent solicitor is able to update an AOS response. If a case is in the states 'AwaitingBailiffReferral', 'AwaitingBailifService', 'IssueToBailiff' the respondent solicitor is able to trigger the event 'Update AOS' (ID: SolicitorUpdatesAOS), however rather than moving into the state 'AOSdrafted' it stays in the same state.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
