### PR TITLE
DIV-6089: Allow to proceed without respondent answers when bailiff successful

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflow.java
@@ -18,6 +18,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_ANSWERS_LINK;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.ServiceApplicationDataExtractor.getLastServiceApplication;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isBailiffServiceSuccessful;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationDeemedOrDispensed;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.common.Conditions.isServiceApplicationGranted;
 import static uk.gov.hmcts.reform.divorce.orchestration.workflows.alternativeservice.AlternativeServiceHelper.isServedByAlternativeMethod;
@@ -62,7 +63,7 @@ public class SolicitorDnFetchDocWorkflow extends DefaultWorkflow<Map<String, Obj
     }
 
     private boolean isRespondentAnswersNotRequired(Map<String, Object> caseData) {
-        return isValidServiceApplicationGranted(caseData) || isAlternativeService(caseData);
+        return isValidServiceApplicationGranted(caseData) || isAlternativeService(caseData) || isBailiffServiceSuccessful(caseData);
     }
 
     private boolean isValidServiceApplicationGranted(Map<String, Object> caseData) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorDnFetchDocTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorDnFetchDocTest.java
@@ -30,6 +30,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.ApplicationServiceTypes.DEEMED;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
+import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildBailiffServiceSuccessfulCaseData;
 import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByAlternativeMethodCaseData;
 import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServedByProcessServerCaseData;
 import static uk.gov.hmcts.reform.divorce.orchestration.workflows.SolicitorDnFetchDocWorkflowTest.buildServiceApplicationCaseData;
@@ -116,6 +117,25 @@ public class SolicitorDnFetchDocTest extends MockedFunctionalTest {
             .andExpect(content().string(allOf(
                 isJson(),
                 hasJsonPath("$.data.ServedByAlternativeMethod", is("Yes")),
+                hasNoJsonPath("$.errors")
+            )));
+    }
+
+    @Test
+    public void givenIsBailiffServiceSuccessful_thenResponseIsWithoutRespondentAnswersDocumentLink() throws Exception {
+        CcdCallbackRequest request = buildRequest(
+            buildBailiffServiceSuccessfulCaseData()
+        );
+
+        webClient.perform(post(API_URL_RESP_ANSWERS)
+            .content(convertObjectToJsonString(request))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(allOf(
+                isJson(),
+                hasJsonPath("$.data.SuccessfulServedByBailiff", is("Yes")),
+                hasNoJsonPath("$.data.respondentanswerslink"),
                 hasNoJsonPath("$.errors")
             )));
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorDnFetchDocWorkflowTest.java
@@ -153,6 +153,16 @@ public class SolicitorDnFetchDocWorkflowTest {
     }
 
     @Test
+    public void shouldNotExecuteTasksWhenIsBailiffServiceSuccessfulAndRespondentAnswersIsRequested() throws WorkflowException {
+        Map<String, Object> caseData = buildBailiffServiceSuccessfulCaseData();
+        taskContext.setTransientObject(DOCUMENT_DRAFT_LINK_FIELD, RESP_ANSWERS_LINK);
+
+        executeWorkflow(caseData, RESP_ANSWERS_LINK);
+
+        verify(populateDocLinkTask, never()).execute(taskContext, caseData);
+    }
+
+    @Test
     public void shouldExecuteTasksWhenIsServedByAlternativeMethodAndRespondentAnswersIsNotRequested() throws WorkflowException {
         Map<String, Object> caseData = buildServedByAlternativeMethodCaseData();
         when(populateDocLinkTask.execute(taskContext, caseData)).thenReturn(caseData);
@@ -202,6 +212,10 @@ public class SolicitorDnFetchDocWorkflowTest {
             CcdFields.SERVED_BY_ALTERNATIVE_METHOD, YES_VALUE,
             CcdFields.SERVED_BY_PROCESS_SERVER, NO_VALUE
         );
+    }
+
+    public static Map<String, Object> buildBailiffServiceSuccessfulCaseData() {
+        return ImmutableMap.of(CcdFields.BAILIFF_SERVICE_SUCCESSFUL, YES_VALUE);
     }
 
     private void executeWorkflow(Map<String, Object> caseData, String respAnswersLink)


### PR DESCRIPTION
# Description

Allow to proceed without respondent answers when bailiff is served successfully.

Fixes https://tools.hmcts.net/jira/browse/DIV-6089

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit and functional tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
