### PR TITLE
dataExtraction.emailFrom=noreply@mail-divorce.platform.hmcts.net

### DIFF
--- a/src/contractTest/resources/application.yml
+++ b/src/contractTest/resources/application.yml
@@ -551,7 +551,7 @@ documentation:
     enabled: true
 
 dataExtraction:
-  emailFrom: noreply@reform.hmcts.net
+  emailFrom: noreply@mail-divorce.platform.hmcts.net
   status:
     DA:
       emailTo: da-extraction@divorce.gov.uk

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -549,7 +549,7 @@ documentation:
     enabled: true
 
 dataExtraction:
-  emailFrom: noreply@reform.hmcts.net
+  emailFrom: noreply@mail-divorce.platform.hmcts.net
   status:
     DA:
       emailTo:

--- a/src/main/resources/example-application-aat.yml
+++ b/src/main/resources/example-application-aat.yml
@@ -550,7 +550,7 @@ documentation:
     enabled: true
 
 dataExtraction:
-  emailFrom: noreply@reform.hmcts.net
+  emailFrom: noreply@mail-divorce.platform.hmcts.net
   status:
     DA:
       emailTo:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -555,7 +555,7 @@ documentation:
     enabled: true
 
 dataExtraction:
-  emailFrom: noreply@reform.hmcts.net
+  emailFrom: noreply@mail-divorce.platform.hmcts.net
   status:
     DA:
       emailTo: da-extraction@divorce.gov.uk


### PR DESCRIPTION
We are in the process of migrating PROD env to use Sendgrid email service. 

As part of this “DATAEXTRACTION_EMAILFROM”  will be pointing to “noreply@mail-divorce.platform.hmcts.net”. 