### PR TITLE
DIV-6869: remove value from 'RespondentOrganisationPolicy' when resp sol not digital

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,8 +140,8 @@ allprojects {
                 entry 'jackson-module-parameter-names'
             }
 
-            // solves CVE-2014-3488, CVE-2015-2156, CVE-2019-16869
-            dependencySet(group: 'io.netty', version: '4.1.60.Final') {
+            // solves CVE-2014-3488, CVE-2015-2156, CVE-2019-16869, CVE-2021-21409
+            dependencySet(group: 'io.netty', version: '4.1.61.Final') {
                 entry 'netty-buffer'
                 entry 'netty-codec'
                 entry 'netty-codec-http'

--- a/src/integrationTest/resources/fixtures/solicitor/solicitor-request-data.json
+++ b/src/integrationTest/resources/fixtures/solicitor/solicitor-request-data.json
@@ -186,6 +186,7 @@
       },
       "respondentSolicitorReference": "RespondentSolicitorReference",
       "respondentSolicitorRepresented": "Yes",
+      "RespSolDigital": "Yes",
       "RespondentOrganisationPolicy": {
         "Organisation": {
           "OrganisationID": null,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/CcdFields.java
@@ -91,4 +91,5 @@ public class CcdFields {
 
     public static final String JUDGE_COSTS_DECISION = "JudgeCostsDecision";
 
+    public static final String RESPONDENT_SOLICITOR_DIGITAL = "RespSolDigital";
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentOrganisationPolicyRemovalTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentOrganisationPolicyRemovalTask.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
+import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.generics.FieldsRemovalTask;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+@Component
+@Slf4j
+public class RespondentOrganisationPolicyRemovalTask extends FieldsRemovalTask {
+
+    @Override
+    protected List<String> getFieldsToRemove() {
+        return asList(
+            CcdFields.RESPONDENT_SOLICITOR_ORGANISATION_POLICY
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflow.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.Features;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.DefaultWorkflow;
@@ -14,6 +15,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.FeatureToggleService;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddMiniPetitionDraftTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseDataTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CopyD8JurisdictionConnectionPolicyTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.RespondentOrganisationPolicyRemovalTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFromTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetNewLegalConnectionPolicyTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetPetitionerSolicitorOrganisationPolicyReferenceTask;
@@ -30,6 +32,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_COSTS_CLAIM_FROM_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getOptionalPropertyValueAsString;
 
 @Component
 @Slf4j
@@ -42,9 +45,11 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     private final SetClaimCostsFromTask setClaimCostsFromTask;
     private final SetPetitionerSolicitorOrganisationPolicyReferenceTask setPetitionerSolicitorOrganisationPolicyReferenceTask;
     private final SetRespondentSolicitorOrganisationPolicyReferenceTask setRespondentSolicitorOrganisationPolicyReferenceTask;
-    private final FeatureToggleService featureToggleService;
+    private final RespondentOrganisationPolicyRemovalTask respondentOrganisationPolicyRemovalTask;
     private final SetNewLegalConnectionPolicyTask setNewLegalConnectionPolicyTask;
     private final CopyD8JurisdictionConnectionPolicyTask copyD8JurisdictionConnectionPolicyTask;
+
+    private final FeatureToggleService featureToggleService;
 
     public Map<String, Object> run(CaseDetails caseDetails, String authToken) throws WorkflowException {
         return this.execute(
@@ -65,9 +70,11 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
     }
 
     private Task<Map<String, Object>>[] getTasks(CaseDetails caseDetails) {
+        final String caseId = caseDetails.getCaseId();
         List<Task<Map<String, Object>>> tasks = new ArrayList<>();
 
         if (isPetitionerClaimingCostsAndClaimCostsFromIsEmptyIn(caseDetails)) {
+            log.info("CaseId: {} petitioner claiming costs", caseId);
             tasks.add(setClaimCostsFromTask);
         }
 
@@ -78,11 +85,31 @@ public class SolicitorCreateWorkflow extends DefaultWorkflow<Map<String, Object>
         tasks.add(addNewDocumentsToCaseDataTask);
 
         if (featureToggleService.isFeatureEnabled(Features.REPRESENTED_RESPONDENT_JOURNEY)) {
-            log.info("Adding OrganisationPolicyReferenceTasks, REPRESENTED_RESPONDENT_JOURNEY feature toggle is set to true.");
+            log.info("CaseId: {} Adding OrganisationPolicyReferenceTasks", caseId);
             tasks.add(setPetitionerSolicitorOrganisationPolicyReferenceTask);
-            tasks.add(setRespondentSolicitorOrganisationPolicyReferenceTask);
+
+            if (isRespondentSolicitorDigital(caseDetails.getCaseData())) {
+                log.info("CaseId: {} respondent solicitor is digital", caseId);
+                tasks.add(setRespondentSolicitorOrganisationPolicyReferenceTask);
+            } else {
+                log.info("CaseId: {} respondent solicitor is NOT digital", caseId);
+                tasks.add(respondentOrganisationPolicyRemovalTask);
+            }
+        } else {
+            log.info("CaseId: {} RRJ is OFF", caseId);
         }
 
         return tasks.toArray(new Task[] {});
+    }
+
+    /**
+     * I know there is re-usable method, but that method can (and should) be used after this step of the process.
+     * Here we have an edge case scenario when somebody may select Yes, populate it and then select No.
+     *
+     * <p>We need to cover this scenario and clean up data properly.
+     * */
+    private boolean isRespondentSolicitorDigital(Map<String, Object> caseData) {
+        return getOptionalPropertyValueAsString(caseData, CcdFields.RESPONDENT_SOLICITOR_DIGITAL, "")
+            .equalsIgnoreCase(YES_VALUE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/SolicitorCreateTest.java
@@ -30,6 +30,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPO
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.BulkCaseConstants.CREATE_EVENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PETITIONER_SOLICITOR_ORGANISATION_POLICY;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RESPONDENT_SOLICITOR_DIGITAL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RESPONDENT_SOLICITOR_ORGANISATION_POLICY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_RESPONDENT_SOLICITOR_REFERENCE;
@@ -80,6 +81,7 @@ public class SolicitorCreateTest extends IdamTestSupport {
         caseData.put(PETITIONER_SOLICITOR_ORGANISATION_POLICY, buildOrganisationPolicy());
         caseData.put(D8_RESPONDENT_SOLICITOR_REFERENCE, TEST_RESPONDENT_SOLICITOR_REFERENCE);
         caseData.put(RESP_SOL_REPRESENTED, YES_VALUE);
+        caseData.put(RESPONDENT_SOLICITOR_DIGITAL, YES_VALUE);
         caseData.put(RESPONDENT_SOLICITOR_ORGANISATION_POLICY, buildOrganisationPolicy());
 
         stubDraftDocumentGeneratorService(
@@ -102,6 +104,40 @@ public class SolicitorCreateTest extends IdamTestSupport {
                 hasJsonPath("$.data.respondentSolicitorReference"),
                 hasJsonPath("$.data.PetitionerOrganisationPolicy.OrgPolicyReference", is(TEST_SOLICITOR_REFERENCE)),
                 hasJsonPath("$.data.RespondentOrganisationPolicy.OrgPolicyReference", is(TEST_RESPONDENT_SOLICITOR_REFERENCE)))
+        );
+    }
+
+    @Test
+    public void givenCaseData_whenSolicitorCreate_thenCheckIfRespSolIsDigital() throws Exception {
+        CcdCallbackRequest ccdCallbackRequest = buildRequest();
+        Map<String, Object> caseData = ccdCallbackRequest.getCaseDetails().getCaseData();
+        caseData.put(SOLICITOR_REFERENCE_JSON_KEY, TEST_SOLICITOR_REFERENCE);
+        caseData.put(PETITIONER_SOLICITOR_ORGANISATION_POLICY, buildOrganisationPolicy());
+        caseData.put(D8_RESPONDENT_SOLICITOR_REFERENCE, TEST_RESPONDENT_SOLICITOR_REFERENCE);
+        caseData.put(RESP_SOL_REPRESENTED, YES_VALUE);
+        caseData.put(RESPONDENT_SOLICITOR_DIGITAL, NO_VALUE);
+        caseData.put(RESPONDENT_SOLICITOR_ORGANISATION_POLICY, buildOrganisationPolicy());
+
+        stubDraftDocumentGeneratorService(
+            DRAFT_MINI_PETITION_TEMPLATE_NAME,
+            singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, ccdCallbackRequest.getCaseDetails()),
+            AddMiniPetitionDraftTask.DOCUMENT_TYPE
+        );
+
+        MvcResult mvcResult = webClient.perform(post(API_URL_CREATE)
+            .header(AUTHORIZATION, AUTH_TOKEN)
+            .content(getBody(ccdCallbackRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        assertThat(mvcResult.getResponse().getContentAsString(),
+            allOf(
+                hasJsonPath("$.data.D8SolicitorReference"),
+                hasJsonPath("$.data.respondentSolicitorReference"),
+                hasJsonPath("$.data.PetitionerOrganisationPolicy.OrgPolicyReference", is(TEST_SOLICITOR_REFERENCE)),
+                hasNoJsonPath("$.data.RespondentOrganisationPolicy"))
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentOrganisationPolicyRemovalTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RespondentOrganisationPolicyRemovalTaskTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.divorce.orchestration.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.hmcts.reform.divorce.orchestration.testutil.TaskContextHelper.contextWithToken;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RespondentOrganisationPolicyRemovalTaskTest {
+
+    @InjectMocks
+    private RespondentOrganisationPolicyRemovalTask classUnderTest;
+
+    @Test
+    public void shouldRemoveFieldsFromCaseData() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("incomingKey", "incomingValue");
+        caseData.put(CcdFields.RESPONDENT_SOLICITOR_ORGANISATION_POLICY, "1");
+
+        Map<String, Object> returnedPayload = classUnderTest.execute(contextWithToken(), caseData);
+
+        assertThat(returnedPayload, hasKey("incomingKey"));
+        classUnderTest.getFieldsToRemove().forEach(field -> assertThat(returnedPayload, not(hasKey(field))));
+    }
+
+    @Test
+    public void getFieldToRemoveIsValid() {
+        assertThat(classUnderTest.getFieldsToRemove().size(), is(1));
+        assertThat(
+            classUnderTest.getFieldsToRemove().get(0),
+            is(CcdFields.RESPONDENT_SOLICITOR_ORGANISATION_POLICY)
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflowTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/workflows/SolicitorCreateWorkflowTest.java
@@ -5,12 +5,14 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.Features;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.service.FeatureToggleService;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddMiniPetitionDraftTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.AddNewDocumentsToCaseDataTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.CopyD8JurisdictionConnectionPolicyTask;
+import uk.gov.hmcts.reform.divorce.orchestration.tasks.RespondentOrganisationPolicyRemovalTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetClaimCostsFromTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetNewLegalConnectionPolicyTask;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.SetPetitionerSolicitorOrganisationPolicyReferenceTask;
@@ -60,6 +62,9 @@ public class SolicitorCreateWorkflowTest {
     @Mock
     CopyD8JurisdictionConnectionPolicyTask copyD8JurisdictionConnectionPolicyTask;
 
+    @Mock
+    RespondentOrganisationPolicyRemovalTask respondentOrganisationPolicyRemovalTask;
+
     @InjectMocks
     SolicitorCreateWorkflow solicitorCreateWorkflow;
 
@@ -67,6 +72,46 @@ public class SolicitorCreateWorkflowTest {
     public void runShouldSetClaimCostsFromWhenClaimCostsIsYesAndClaimCostsFromIsEmpty() throws Exception {
         Map<String, Object> payload = new HashMap<>();
         payload.put(DIVORCE_COSTS_CLAIM_CCD_FIELD, YES_VALUE);
+
+        when(featureToggleService.isFeatureEnabled(Features.REPRESENTED_RESPONDENT_JOURNEY)).thenReturn(true);
+
+        CaseDetails caseDetails = CaseDetails.builder().caseData(payload).build();
+
+        mockTasksExecution(
+            caseDetails.getCaseData(),
+            setClaimCostsFromTask,
+            setSolicitorCourtDetailsTask,
+            setNewLegalConnectionPolicyTask,
+            copyD8JurisdictionConnectionPolicyTask,
+            addMiniPetitionDraftTask,
+            addNewDocumentsToCaseDataTask,
+            setPetitionerSolicitorOrganisationPolicyReferenceTask,
+            respondentOrganisationPolicyRemovalTask
+        );
+
+        assertThat(solicitorCreateWorkflow.run(caseDetails, AUTH_TOKEN), is(caseDetails.getCaseData()));
+
+        verifyTasksCalledInOrder(
+            caseDetails.getCaseData(),
+            setClaimCostsFromTask,
+            setSolicitorCourtDetailsTask,
+            setNewLegalConnectionPolicyTask,
+            copyD8JurisdictionConnectionPolicyTask,
+            addMiniPetitionDraftTask,
+            addNewDocumentsToCaseDataTask,
+            setPetitionerSolicitorOrganisationPolicyReferenceTask,
+            respondentOrganisationPolicyRemovalTask
+        );
+
+        verifyTasksWereNeverCalled(setRespondentSolicitorOrganisationPolicyReferenceTask);
+    }
+
+    @Test
+    public void shouldExecuteSetRespondentSolicitorOrganisationPolicyReferenceTaskWhenFtOnAndRespSolDigital()
+        throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put(DIVORCE_COSTS_CLAIM_CCD_FIELD, YES_VALUE);
+        payload.put(CcdFields.RESPONDENT_SOLICITOR_DIGITAL, YES_VALUE);
 
         when(featureToggleService.isFeatureEnabled(Features.REPRESENTED_RESPONDENT_JOURNEY)).thenReturn(true);
 
@@ -97,6 +142,8 @@ public class SolicitorCreateWorkflowTest {
             setPetitionerSolicitorOrganisationPolicyReferenceTask,
             setRespondentSolicitorOrganisationPolicyReferenceTask
         );
+
+        verifyTasksWereNeverCalled(respondentOrganisationPolicyRemovalTask);
     }
 
     @Test
@@ -130,7 +177,10 @@ public class SolicitorCreateWorkflowTest {
             addNewDocumentsToCaseDataTask
         );
 
-        verifyTasksWereNeverCalled(setPetitionerSolicitorOrganisationPolicyReferenceTask);
-        verifyTasksWereNeverCalled(setRespondentSolicitorOrganisationPolicyReferenceTask);
+        verifyTasksWereNeverCalled(
+            setPetitionerSolicitorOrganisationPolicyReferenceTask,
+            setRespondentSolicitorOrganisationPolicyReferenceTask,
+            respondentOrganisationPolicyRemovalTask
+        );
     }
 }


### PR DESCRIPTION
Story:
https://tools.hmcts.net/jira/browse/DIV-6869

Make sure RespondentOrganisationPolicy is not populated when resp sol is not digital.

It may need this PR:
https://github.com/hmcts/div-ccd-definitions/pull/806
