### PR TITLE
 CVE-2021-21409

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,8 +140,8 @@ allprojects {
                 entry 'jackson-module-parameter-names'
             }
 
-            // solves CVE-2014-3488, CVE-2015-2156, CVE-2019-16869
-            dependencySet(group: 'io.netty', version: '4.1.60.Final') {
+            // solves CVE-2014-3488, CVE-2015-2156, CVE-2019-16869, CVE-2021-21409
+            dependencySet(group: 'io.netty', version: '4.1.61.Final') {
                 entry 'netty-buffer'
                 entry 'netty-codec'
                 entry 'netty-codec-http'


### PR DESCRIPTION
# Description

Fixing CVE-2021-21409 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21409

