### PR TITLE
No more skipped unit tests

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.divorce.orchestration.tasks.dataextraction;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/dataextraction/DataExtractionEmailClientTest.java
@@ -36,10 +36,13 @@ public class DataExtractionEmailClientTest {
         Files.write(file.toPath(), content.getBytes());
     }
 
-    @Test
-    @Ignore("See description of this class to find out how to run this test")
+    /**
+     * Please see description of this class to find out how to run this test.
+     * */
     public void sendEmailWithAttachment() throws MessagingException {
-        dataExtractionEmailClient.sendEmailWithAttachment("test@divorce.gov.uk", "myFileName.csv", file);
+        dataExtractionEmailClient.sendEmailWithAttachment(
+            "test@divorce.gov.uk", "myFileName.csv", file
+        );
         //Now go to MailHog and check that your e-mail has been sent as expected
     }
 


### PR DESCRIPTION
This is not a test that we meant to run on Jenkins. If we want to run it locally we should add `@Test` annotation instead of removing `@Ignore`.

If it needs manual steps lets keep it clear.