### PR TITLE
RPET-984: Clean up headers const

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/bulk/scan/BulkScanIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/bulk/scan/BulkScanIntegrationTest.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.reform.divorce.context.IntegrationTest;
 import uk.gov.hmcts.reform.divorce.support.IdamUtils;
 
 import static org.junit.Assert.assertEquals;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.scan.BulkScanForms.D8_FORM;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ResourceLoader.loadResourceAsString;
 
@@ -104,7 +104,7 @@ public class BulkScanIntegrationTest extends IntegrationTest {
 
         return SerenityRest.given()
             .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-            .header(SERVICE_AUTHORIZATION_HEADER, token)
+            .header(SERVICE_AUTHORIZATION, token)
             .relaxedHTTPSValidation()
             .body(validBody)
             .post(cosBaseURL + endpointName, formType);
@@ -114,7 +114,7 @@ public class BulkScanIntegrationTest extends IntegrationTest {
 
         return SerenityRest.given()
             .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-            .header(SERVICE_AUTHORIZATION_HEADER, token)
+            .header(SERVICE_AUTHORIZATION, token)
             .relaxedHTTPSValidation()
             .body(validBody)
             .post(cosBaseURL + endpointName);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/GetPetitionIssueFeesTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/GetPetitionIssueFeesTest.java
@@ -29,10 +29,10 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdEvents.SOLICITOR_SUBMIT;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITION_ISSUE_ORDER_SUMMARY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PREVIOUS_CASE_ID_CCD_KEY;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOL_APPLICATION_FEE_IN_POUNDS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.getJsonFromResourceFile;
 
@@ -130,7 +130,7 @@ public class GetPetitionIssueFeesTest extends IntegrationTest {
         Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         requestHeaders.put(HttpHeaders.AUTHORIZATION, solicitorUser.getAuthToken());
-        requestHeaders.put(SERVICE_AUTHORIZATION_HEADER, getS2sAuth());
+        requestHeaders.put(SERVICE_AUTHORIZATION, getS2sAuth());
 
         return requestHeaders;
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorCreateAndUpdateTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/callback/SolicitorCreateAndUpdateTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PETITIONER_SOLICITOR_ORGANISATION_POLICY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RESPONDENT_SOLICITOR_ORGANISATION_POLICY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CREATED_DATE_JSON_KEY;
@@ -32,7 +33,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DIVORCE_UNIT_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_SOL_REPRESENTED;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_REFERENCE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.getJsonFromResourceFile;
@@ -133,7 +133,7 @@ public class SolicitorCreateAndUpdateTest extends IntegrationTest {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         headers.put(HttpHeaders.AUTHORIZATION, retrieveSolicitorUserDetails().getAuthToken());
-        headers.put(SERVICE_AUTHORIZATION_HEADER, getS2sAuth());
+        headers.put(SERVICE_AUTHORIZATION, getS2sAuth());
 
         return headers;
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/cos/CosApiClient.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 
 @FeignClient(name = "case-orchestration-api", url = "${case.orchestration.service.base.uri}",
     configuration = ServiceContextConfiguration.class)
@@ -255,7 +255,7 @@ public interface CosApiClient {
     @ApiOperation("Validate bulk scanned fields")
     @PostMapping(value = "/forms/{form-type}/validate-ocr")
     SuccessfulUpdateResponse validateBulkScannedFields(
-        @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sAuthToken,
         @PathVariable("form-type") String formType,
         @RequestBody OcrDataValidationRequest request
     );
@@ -263,14 +263,14 @@ public interface CosApiClient {
     @ApiOperation("Transform bulk scanned fields to CCD format")
     @PostMapping(value = "/transform-exception-record")
     SuccessfulTransformationResponse transformBulkScannedFields(
-        @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sAuthToken,
         @RequestBody ExceptionRecord exceptionRecord
     );
 
     @ApiOperation("Transform bulk scanned fields to CCD format for updating case")
     @PostMapping(value = "/update-case")
     SuccessfulUpdateResponse transformBulkScannedFieldsForUpdatingCase(
-        @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sAuthToken,
         @RequestBody BulkScanCaseUpdateRequest request
     );
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/OrganisationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/OrganisationClient.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.prd.OrganisationsResponse;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 
 @FeignClient(name = "organisation-client", url = "${prd.api.url}")
 public interface OrganisationClient {
@@ -19,6 +19,6 @@ public interface OrganisationClient {
     )
     OrganisationsResponse getMyOrganisation(
         @RequestHeader(AUTHORIZATION) String authorisation,
-        @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String s2sToken
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/PaymentClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/PaymentClient.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.domain.model.pay.CreditAccountP
 
 import java.util.Map;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 
 @FeignClient(name = "payment-client", url = "${payment.service.api.baseurl}")
 public interface PaymentClient {
@@ -22,13 +22,13 @@ public interface PaymentClient {
     @PostMapping(value = "/credit-account-payments")
     ResponseEntity<CreditAccountPaymentResponse> creditAccountPayment(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
-            @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String serviceAuthorisation,
+            @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
             CreditAccountPaymentRequest creditAccountPaymentRequest);
 
     @ApiOperation("Returns payment information for given payment reference")
     @GetMapping(value = "/card-payments/{paymentRef}")
     Map<String, Object> checkPayment(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
-            @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String serviceAuthorisation,
+            @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
             @PathVariable("paymentRef") String paymentRef);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/PbaValidationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/PbaValidationClient.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.pay.validation.PBAOrganisationResponse;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 
 @FeignClient(name = "pba-validation-client", url = "${pba.validation.service.api.baseurl}")
 public interface PbaValidationClient {
@@ -18,6 +18,6 @@ public interface PbaValidationClient {
     @GetMapping(value = "/refdata/external/v1/organisations/pbas")
     ResponseEntity<PBAOrganisationResponse> retrievePbaNumbers(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
-        @RequestHeader(SERVICE_AUTHORIZATION_HEADER) String serviceAuthorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
         @RequestParam(name = "email") String email);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/config/SpecificHttpHeaders.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/config/SpecificHttpHeaders.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.divorce.orchestration.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SpecificHttpHeaders {
+
+    public static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkCaseController.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.CaseOrchestrationServic
 import java.util.Map;
 
 import static java.util.Arrays.asList;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_LIST_FOR_PRONOUNCEMENT_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_LIST_FOR_PRONOUNCEMENT_FILE_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.CASE_LIST_FOR_PRONOUNCEMENT;
@@ -52,7 +52,7 @@ public class BulkCaseController {
         @ApiResponse(code = 200, message = "Bulk case processing has been initiated"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> scheduleBulkCaseForHearing(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -101,7 +101,7 @@ public class BulkCaseController {
         @ApiResponse(code = 200, message = "Bulk case processing has been initiated"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> editBulkCaseListingData(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
         @RequestParam(value = "templateId") @ApiParam("templateId") String templateId,
         @RequestParam(value = "documentType") @ApiParam("documentType") String documentType,
@@ -133,7 +133,7 @@ public class BulkCaseController {
         @ApiResponse(code = 200, message = "Bulk case processing has been initiated"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> aboutToEditBulkCase(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -160,7 +160,7 @@ public class BulkCaseController {
         @ApiResponse(code = 200, message = "Required pronouncement data has been set successfully"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> updateCaseDnPronounce(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -182,7 +182,7 @@ public class BulkCaseController {
         @ApiResponse(code = 200, message = "Cases have been removed successfully"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> removeCasesFromBulk(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -204,7 +204,7 @@ public class BulkCaseController {
         @ApiResponse(code = 200, message = "Cases have been removed from listed bulk case successfully"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> removeCasesFromBulkListed(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -225,7 +225,7 @@ public class BulkCaseController {
         @ApiResponse(code = 200, message = "Cases to cancel pronouncement"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> cancelBulkPronouncement(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM") final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkScanController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/BulkScanController.java
@@ -34,8 +34,8 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.ResponseEntity.ok;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_TYPE_ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 
 @Slf4j
 @Controller
@@ -56,7 +56,7 @@ public class BulkScanController {
         @ApiResponse(code = 404, message = "Form type not found")
     })
     public ResponseEntity<OcrValidationResponse> validateOcrData(
-        @RequestHeader(name = SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
+        @RequestHeader(name = SERVICE_AUTHORIZATION) String s2sAuthToken,
         @PathVariable(name = "form-type") String formType,
         @Valid @RequestBody OcrDataValidationRequest request
     ) {
@@ -86,7 +86,7 @@ public class BulkScanController {
         @ApiResponse(code = 422, message = "Exception Record is well-formed, but contains invalid data.")
     })
     public ResponseEntity<SuccessfulTransformationResponse> transformExceptionRecordIntoCase(
-        @RequestHeader(name = SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
+        @RequestHeader(name = SERVICE_AUTHORIZATION) String s2sAuthToken,
         @Valid @RequestBody ExceptionRecord exceptionRecord) {
         String exceptionRecordId = exceptionRecord.getId();
         log.info("Transforming Exception Record to case with Case ID: {}", exceptionRecordId);
@@ -126,7 +126,7 @@ public class BulkScanController {
         @ApiResponse(code = 422, message = "Exception record is well-formed, but contains invalid data")
     })
     public ResponseEntity<SuccessfulUpdateResponse> updateCase(
-        @RequestHeader(name = SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
+        @RequestHeader(name = SERVICE_AUTHORIZATION) String s2sAuthToken,
         @Valid @RequestBody BulkScanCaseUpdateRequest request) {
         authService.assertIsServiceAllowedToUpdate(s2sAuthToken);
         ResponseEntity<SuccessfulUpdateResponse> updateControllerResponse;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/CallbackController.java
@@ -48,7 +48,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.BULK_PRINT_ERROR_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_LIST_FOR_PRONOUNCEMENT_DOCUMENT_TYPE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_LIST_FOR_PRONOUNCEMENT_FILE_NAME;
@@ -111,7 +111,7 @@ public class CallbackController {
         @ApiResponse(code = 401, message = "User Not Authenticated"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> dnSubmitted(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(caseOrchestrationService.dnSubmitted(ccdCallbackRequest, authorizationToken));
@@ -136,7 +136,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> dnPronounced(
-        @RequestHeader(value = AUTHORIZATION_HEADER)
+        @RequestHeader(value = AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
@@ -175,7 +175,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> getPetitionIssueFees(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(caseOrchestrationService.setOrderSummaryAssignRole(ccdCallbackRequest, authorizationToken));
     }
@@ -188,7 +188,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> processPbaPayment(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
         log.info("About to process PBA payment for case id {}", ccdCallbackRequest.getCaseDetails().getCaseId());
@@ -218,7 +218,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> solicitorCreate(
-        @RequestHeader(value = AUTHORIZATION_HEADER, required = false) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION, required = false) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
         return ResponseEntity.ok(CcdCallbackResponse.builder()
             .data(caseOrchestrationService.solicitorCreate(ccdCallbackRequest, authorizationToken))
@@ -232,7 +232,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> solicitorUpdate(
-        @RequestHeader(value = AUTHORIZATION_HEADER, required = false) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION, required = false) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
         return ResponseEntity.ok(CcdCallbackResponse.builder()
             .data(caseOrchestrationService.solicitorUpdate(ccdCallbackRequest, authorizationToken))
@@ -246,7 +246,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> solicitorAmendPetitionForRefusal(
-        @RequestHeader(value = AUTHORIZATION_HEADER, required = false) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION, required = false) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(CcdCallbackResponse.builder()
             .data(caseOrchestrationService.solicitorAmendPetitionForRefusal(ccdCallbackRequest, authorizationToken))
@@ -260,7 +260,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> respondentAOSSubmitted(
-        @RequestHeader(value = AUTHORIZATION_HEADER, required = false) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION, required = false) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
         log.info("/aos-submitted endpoint called for caseId {}", caseId);
@@ -340,7 +340,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> confirmPersonalService(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
         String eventId = ccdCallbackRequest.getEventId();
@@ -372,7 +372,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> bulkPrint(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         try {
@@ -412,7 +412,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> petitionIssuedCallback(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestParam(value = GENERATE_AOS_INVITATION, required = false)
         @ApiParam(GENERATE_AOS_INVITATION) boolean generateAosInvitation,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
@@ -443,7 +443,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> caseLinkedForHearing(
-        @RequestHeader(value = AUTHORIZATION_HEADER)
+        @RequestHeader(value = AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -604,7 +604,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> generateCoRespondentAnswers(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
@@ -639,7 +639,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> generateDocument(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestParam(value = "templateId") @ApiParam("templateId") String templateId,
         @RequestParam(value = "documentType") @ApiParam("documentType") String documentType,
         @RequestParam(value = "filename") @ApiParam("filename") String filename,
@@ -660,7 +660,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> prepareToPrintForPronouncement(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
         return generateNewDocumentAndAddToCaseData(authorizationToken,
@@ -677,7 +677,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> updateBulkCaseHearingDetails(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
         String ccdDocumentType = "coe";
@@ -693,7 +693,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> generateDnDocuments(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
@@ -719,7 +719,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> daAboutToBeGranted(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
@@ -741,7 +741,7 @@ public class CallbackController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "DA Granted callback processed")})
     public ResponseEntity<CcdCallbackResponse> handleDaGranted(
-        @RequestHeader(value = AUTHORIZATION_HEADER)
+        @RequestHeader(value = AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -766,7 +766,7 @@ public class CallbackController {
         @ApiResponse(code = 401, message = "User Not Authenticated"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> aosReceived(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(caseOrchestrationService.aosReceived(ccdCallbackRequest, authorizationToken));
@@ -790,7 +790,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> aosSolicitorNominated(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authToken,
+        @RequestHeader(value = AUTHORIZATION) String authToken,
         @RequestBody @ApiParam("CaseData")
             CcdCallbackRequest ccdCallbackRequest) {
 
@@ -846,7 +846,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> dnAboutToBeGranted(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authToken,
+        @RequestHeader(value = AUTHORIZATION) String authToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
@@ -901,7 +901,7 @@ public class CallbackController {
         @ApiResponse(code = 401, message = "Not authorised"),
         @ApiResponse(code = 404, message = "Case not found")})
     public ResponseEntity<CcdCallbackResponse> solicitorLinkCase(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
@@ -932,7 +932,7 @@ public class CallbackController {
         @ApiResponse(code = 401, message = "Not authorised"),
         @ApiResponse(code = 404, message = "Case not found")})
     public ResponseEntity<CcdCallbackResponse> clearStateCallback(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         CcdCallbackResponse.CcdCallbackResponseBuilder callbackResponseBuilder = CcdCallbackResponse.builder();
@@ -952,7 +952,7 @@ public class CallbackController {
         @ApiResponse(code = 401, message = "Not authorised"),
         @ApiResponse(code = 404, message = "Case not found")})
     public ResponseEntity<CcdCallbackResponse> dnDecisionMadeCallback(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         CcdCallbackResponse.CcdCallbackResponseBuilder callbackResponseBuilder = CcdCallbackResponse.builder();
@@ -1027,7 +1027,7 @@ public class CallbackController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Callback processed")})
     public ResponseEntity<CcdCallbackResponse> issueAosPackOffline(
-        @RequestHeader(name = AUTHORIZATION_HEADER)
+        @RequestHeader(name = AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) String authToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest,
         @PathVariable("party")
@@ -1056,7 +1056,7 @@ public class CallbackController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Successfully processed offline AOS Answers")})
     public ResponseEntity<CcdCallbackResponse> processAosPackOfflineAnswers(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "Authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest,
         @PathVariable("party")
@@ -1182,7 +1182,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> welshContinueIntercept(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
         return ResponseEntity.ok(caseOrchestrationService.welshContinueIntercept(ccdCallbackRequest, authorizationToken));
@@ -1210,7 +1210,7 @@ public class CallbackController {
             response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> makeServiceDecision(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws ServiceJourneyServiceException {
 
@@ -1226,7 +1226,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> draftDocumentsForServiceDecision(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1242,7 +1242,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> serviceDecisionMade(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1257,7 +1257,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> generateDraftOfGeneralOrder(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1276,7 +1276,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> generateGeneralOrder(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1307,7 +1307,7 @@ public class CallbackController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Service payment confirmation callback")})
     public ResponseEntity<CcdCallbackResponse> confirmServicePaymentEvent(
-            @RequestHeader(AUTHORIZATION_HEADER)
+            @RequestHeader(AUTHORIZATION)
             @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1322,7 +1322,7 @@ public class CallbackController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Setup Add Bailiff Return event")})
     public ResponseEntity<CcdCallbackResponse> setupAddBailiffReturnEvent(
-            @RequestHeader(AUTHORIZATION_HEADER)
+            @RequestHeader(AUTHORIZATION)
             @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
             @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1365,7 +1365,7 @@ public class CallbackController {
         @ApiResponse(code = 400, message = "Bad Request")
     })
     public ResponseEntity<CcdCallbackResponse> prepareAosNotReceivedForSubmission(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1499,7 +1499,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> updateCourtOrderDocuments(
-        @RequestHeader(value = AUTHORIZATION_HEADER)
+        @RequestHeader(value = AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1521,7 +1521,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> issueBailiffPack(
-        @RequestHeader(value = AUTHORIZATION_HEADER)
+        @RequestHeader(value = AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
 
@@ -1543,7 +1543,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> judgeCostsDecision(
-        @RequestHeader(value = AUTHORIZATION_HEADER)
+        @RequestHeader(value = AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws JudgeServiceException {
 
@@ -1558,7 +1558,7 @@ public class CallbackController {
         @ApiResponse(code = 200, message = "Callback processed.", response = CcdCallbackResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> aosPackIssued(
-        @RequestHeader(value = AUTHORIZATION_HEADER)
+        @RequestHeader(value = AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws CaseOrchestrationServiceException {
         CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/DecreeAbsoluteController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/DecreeAbsoluteController.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.reform.divorce.orchestration.service.DecreeAbsoluteService;
 
 import static java.util.Collections.singletonList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @RestController
 @Slf4j
@@ -34,7 +34,7 @@ public class DecreeAbsoluteController {
         @ApiResponse(code = 400, message = "Bad Request"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CcdCallbackResponse> notifyRespondentOfDARequested(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
         String caseId = ccdCallbackRequest.getCaseDetails().getCaseId();
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/OrchestrationController.java
@@ -36,10 +36,10 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Features.FEE_PAY_S2S_TOKEN;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SUCCESS_STATUS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.VALIDATION_ERROR_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.courts.CourtConstants.ALLOCATED_COURT_KEY;
@@ -63,7 +63,7 @@ public class OrchestrationController {
         @ApiResponse(code = 403, message = "Calling service is not authorised to use the endpoint"),
         @ApiResponse(code = 500, message = "Internal Server Error")})
     public ResponseEntity<CaseResponse> paymentUpdate(
-        @RequestHeader(value = SERVICE_AUTHORIZATION_HEADER) String s2sAuthToken,
+        @RequestHeader(value = SERVICE_AUTHORIZATION) String s2sAuthToken,
         @RequestBody PaymentUpdate paymentUpdate) throws WorkflowException, AuthenticationError {
 
         if (featureToggleService.isFeatureEnabled(FEE_PAY_S2S_TOKEN)) {
@@ -81,7 +81,7 @@ public class OrchestrationController {
             response = CaseCreationResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CaseCreationResponse> submit(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("Divorce Session") Map<String, Object> payload) throws WorkflowException {
 
         ResponseEntity<CaseCreationResponse> endpointResponse;
@@ -112,7 +112,7 @@ public class OrchestrationController {
             response = CaseResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CaseResponse> update(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @PathVariable String caseId,
         @RequestBody @ApiParam("Divorce Session") Map<String, Object> payload) throws WorkflowException {
 
@@ -130,7 +130,7 @@ public class OrchestrationController {
         @ApiResponse(code = 404, message = "Draft does not exist")})
     public ResponseEntity<Map<String, Object>> retrieveDraft(
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true)
-        @RequestHeader(AUTHORIZATION_HEADER) final String authorizationToken)
+        @RequestHeader(AUTHORIZATION) final String authorizationToken)
         throws WorkflowException {
 
         Map<String, Object> response = orchestrationService.getDraft(authorizationToken);
@@ -163,7 +163,7 @@ public class OrchestrationController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "The Divorce draft case has been deleted successfully")})
     public ResponseEntity<Map<String, Object>> deleteDraft(
-        @RequestHeader(AUTHORIZATION_HEADER)
+        @RequestHeader(AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken) throws WorkflowException {
 
         return ResponseEntity.ok(orchestrationService.deleteDraft(authorizationToken));
@@ -248,7 +248,7 @@ public class OrchestrationController {
             response = CaseResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<Map<String, Object>> submitRespondentAos(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @PathVariable String caseId,
         @RequestBody @ApiParam("Complete Divorce Session / partial AoS data ") Map<String, Object> payload)
         throws WorkflowException {
@@ -264,7 +264,7 @@ public class OrchestrationController {
             response = CaseResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<Map<String, Object>> submitCoRespondentAos(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("Co-Respondent AOS data") Map<String, Object> payload)
         throws WorkflowException {
 
@@ -278,7 +278,7 @@ public class OrchestrationController {
             response = CaseResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<Map<String, Object>> submitDn(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @PathVariable String caseId,
         @RequestBody @ApiParam("Complete Divorce Session / partial DN data ") Map<String, Object> divorceSession)
         throws WorkflowException {
@@ -294,7 +294,7 @@ public class OrchestrationController {
                     response = CaseResponse.class),
             @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<Map<String, Object>> submitDa(
-            @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+            @RequestHeader(value = AUTHORIZATION) String authorizationToken,
             @PathVariable String caseId,
             @RequestBody @ApiParam("Decree Absolute Data as required") Map<String, Object> divorceSession)
             throws WorkflowException {
@@ -312,7 +312,7 @@ public class OrchestrationController {
         @ApiResponse(code = 404,
             message = "No draft was created as no existing case found.")})
     public ResponseEntity<Map<String, Object>> amendPetition(
-            @RequestHeader(AUTHORIZATION_HEADER)
+            @RequestHeader(AUTHORIZATION)
             @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
             @PathVariable String caseId)
             throws WorkflowException {
@@ -329,7 +329,7 @@ public class OrchestrationController {
         @ApiResponse(code = 404,
             message = "No draft was created as no existing case found.")})
     public ResponseEntity<Map<String, Object>> amendPetitionForRefusal(
-            @RequestHeader(AUTHORIZATION_HEADER)
+            @RequestHeader(AUTHORIZATION)
             @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String authorizationToken,
             @PathVariable String caseId)
             throws WorkflowException {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/SolicitorCallbackController.java
@@ -25,8 +25,8 @@ import javax.ws.rs.core.MediaType;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PBA_NUMBERS;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils.isSolicitorPaymentMethodPba;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.ControllerUtils.responseWithData;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.ControllerUtils.responseWithErrors;
@@ -46,7 +46,7 @@ public class SolicitorCallbackController {
             response = CaseResponse.class),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<CcdCallbackResponse> issuePersonalServicePack(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) {
 
         Map<String, Object> response;
@@ -112,7 +112,7 @@ public class SolicitorCallbackController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Callback processed")})
     public ResponseEntity<CcdCallbackResponse> retrievePbaNumbers(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken,
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CcdCallbackRequest ccdCallbackRequest) throws WorkflowException {
 
         CaseDetails caseDetails = ccdCallbackRequest.getCaseDetails();

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/internal/DecreeAbsoluteCaseInternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/internal/DecreeAbsoluteCaseInternalController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.WorkflowException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.DecreeAbsoluteService;
 
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @RestController
 @Slf4j
@@ -27,7 +27,7 @@ public class DecreeAbsoluteCaseInternalController {
         @ApiResponse(code = 200, message = "Cases are made eligible for Decree Absolute"),
         @ApiResponse(code = 400, message = "Bad Request")})
     public ResponseEntity<String> makeCasesEligibleForDA(
-        @RequestHeader(value = AUTHORIZATION_HEADER) String authorizationToken) throws WorkflowException {
+        @RequestHeader(value = AUTHORIZATION) String authorizationToken) throws WorkflowException {
         int casesProcessed = decreeAbsoluteService.enableCaseEligibleForDecreeAbsolute(authorizationToken);
         return ResponseEntity.ok("Cases made eligible for DA: " + casesProcessed);
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -17,8 +17,6 @@ public class OrchestrationConstants {
     public static final String GRANT_TYPE = "authorization_code";
     public static final String BASIC = "Basic ";
     public static final String LOCATION_HEADER = "Location";
-    public static final String SERVICE_AUTHORIZATION_HEADER = "ServiceAuthorization";
-    public static final String AUTHORIZATION_HEADER = "Authorization";
 
     //Issue Petition
     public static final String GENERATE_AOS_INVITATION = "generateAosInvitation";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/DocumentContentFetcherService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/DocumentContentFetcherService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.divorce.model.documentupdate.GeneratedDocumentInfo;
-import uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants;
+import uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders;
 import uk.gov.hmcts.reform.divorce.orchestration.exception.FetchingDocumentFromDmStoreException;
 
 @Slf4j
@@ -25,7 +25,7 @@ public class DocumentContentFetcherService {
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Headers {
-        public static final String SERVICE_AUTHORIZATION = OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+        public static final String SERVICE_AUTHORIZATION = SpecificHttpHeaders.SERVICE_AUTHORIZATION;
         public static final String USER_ROLES = "user-roles";
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FetchPrintDocsFromDmStoreTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FetchPrintDocsFromDmStoreTask.java
@@ -27,10 +27,10 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_DETAILS_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8DOCUMENTS_GENERATED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DOCUMENTS_GENERATED;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 
 @Component
 @Slf4j
@@ -83,7 +83,7 @@ public class FetchPrintDocsFromDmStoreTask implements Task<Map<String, Object>> 
         CaseDetails caseDetails = context.getTransientObject(CASE_DETAILS_JSON_KEY);
         for (GeneratedDocumentInfo generatedDocumentInfo : generatedDocumentsInfo.values()) {
             HttpHeaders headers = new HttpHeaders();
-            headers.set(SERVICE_AUTHORIZATION_HEADER, authTokenGenerator.generate());
+            headers.set(SERVICE_AUTHORIZATION, authTokenGenerator.generate());
             headers.set(USER_ROLES, CASEWORKER_DIVORCE);
             HttpEntity<RestRequest> httpEntity = new HttpEntity<>(headers);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MockedFunctionalTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/MockedFunctionalTest.java
@@ -38,7 +38,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_ORGANISATION_POLICY_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SERVICE_AUTH_TOKEN;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.elasticsearch.CMSElasticSearchSupport.buildCMSBooleanSearchSource;
 
@@ -147,7 +147,7 @@ public abstract class MockedFunctionalTest {
 
     public void stubDMStore(String documentId, byte[] fileBytes) {
         documentStore.stubFor(WireMock.get("/documents/" + documentId + "/binary")
-            .withHeader(SERVICE_AUTHORIZATION_HEADER, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
             .withHeader("user-roles", new EqualToPattern("caseworker-divorce"))
             .willReturn(aResponse()
                 .withStatus(HttpStatus.OK.value())
@@ -157,7 +157,7 @@ public abstract class MockedFunctionalTest {
 
     public void stubRemoveCaseRoleServerEndpoint(String authToken, String s2sAuthToken, HttpStatus status) {
         caseRoleServer.stubFor(WireMock.delete("/case-users")
-            .withHeader(SERVICE_AUTHORIZATION_HEADER, new EqualToPattern("Bearer " + s2sAuthToken))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern("Bearer " + s2sAuthToken))
             .withHeader(AUTHORIZATION, new EqualToPattern(authToken))
             .willReturn(aResponse()
                 .withStatus(status.value())
@@ -166,7 +166,7 @@ public abstract class MockedFunctionalTest {
 
     public void stubAssignCaseAccessServerEndpoint(String authToken, String s2sAuthToken, HttpStatus status) {
         assignCaseAccessServer.stubFor(WireMock.post("/case-assignments")
-            .withHeader(SERVICE_AUTHORIZATION_HEADER, new EqualToPattern("Bearer " + s2sAuthToken))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern("Bearer " + s2sAuthToken))
             .withHeader(AUTHORIZATION, new EqualToPattern(authToken))
             .willReturn(aResponse()
                 .withStatus(status.value())
@@ -176,7 +176,7 @@ public abstract class MockedFunctionalTest {
     public void stubGetMyOrganisationServerEndpoint(String authToken, String s2sToken) {
         prdServer.stubFor(WireMock.get("/refdata/external/v1/organisations")
             .withHeader(AUTHORIZATION, new EqualToPattern(authToken))
-            .withHeader(SERVICE_AUTHORIZATION_HEADER, new EqualToPattern("Bearer " + s2sToken))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern("Bearer " + s2sToken))
             .willReturn(aResponse()
                 .withStatus(HttpStatus.OK.value())
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PaymentUpdateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/PaymentUpdateITest.java
@@ -29,8 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.BEARER_AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.BEARER_AUTH_TOKEN_1;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.ID;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
 public class PaymentUpdateITest extends IdamTestSupport {
@@ -100,7 +100,7 @@ public class PaymentUpdateITest extends IdamTestSupport {
     @Test
     public void givenEventDataAndAuth_whenEventDataIsSubmitted_thenReturnSuccess() throws Exception {
         webClient.perform(put(API_URL)
-                    .header(SERVICE_AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN_1)
+                    .header(SERVICE_AUTHORIZATION, BEARER_AUTH_TOKEN_1)
                     .content(convertObjectToJsonString(paymentUpdate))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -111,7 +111,7 @@ public class PaymentUpdateITest extends IdamTestSupport {
     @Test
     public void givenEventDataAndForbiddenAuth_whenEventDataIsSubmitted_thenReturnError() throws Exception {
         webClient.perform(put(API_URL)
-            .header(SERVICE_AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN)
+            .header(SERVICE_AUTHORIZATION, BEARER_AUTH_TOKEN)
             .content(convertObjectToJsonString(paymentUpdate))
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
@@ -122,7 +122,7 @@ public class PaymentUpdateITest extends IdamTestSupport {
     @Test
     public void givenEventDataAndNoAuth_whenEventDataIsSubmitted_thenReturnError() throws Exception {
         webClient.perform(put(API_URL)
-            .header(SERVICE_AUTHORIZATION_HEADER, "")
+            .header(SERVICE_AUTHORIZATION, "")
             .content(convertObjectToJsonString(paymentUpdate))
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentAbstractITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentAbstractITest.java
@@ -73,6 +73,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLIC
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PETITIONER_SOLICITOR_FIRM;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CASE_ID_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CURRENCY;
@@ -97,7 +98,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_FIRST_NAME_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_LAST_NAME_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_HOW_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_REFERENCE_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_STATEMENT_OF_TRUTH;
@@ -586,7 +586,7 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
     private void stubCreditAccountPayment(HttpStatus status, CreditAccountPaymentResponse response) {
         paymentServiceServer.stubFor(WireMock.post(PAYMENTS_CREDIT_ACCOUNT_CONTEXT_PATH)
             .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-            .withHeader(SERVICE_AUTHORIZATION_HEADER, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
             .withRequestBody(equalToJson(convertObjectToJsonString(request)))
             .willReturn(aResponse()
                 .withStatus(status.value())

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentRepRespJourneyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentRepRespJourneyTest.java
@@ -52,6 +52,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLIC
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PETITIONER_SOLICITOR_FIRM;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RESPONDENT_SOLICITOR_DIGITAL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.RESPONDENT_SOLICITOR_ORGANISATION_POLICY;
@@ -71,7 +72,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_LAST_NAME_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESP_SOL_REPRESENTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_FEE_ACCOUNT_NUMBER_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_HOW_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_REFERENCE_JSON_KEY;
@@ -220,7 +220,7 @@ public class ProcessPbaPaymentRepRespJourneyTest extends MockedFunctionalTest {
     private void stubCreditAccountPayment(HttpStatus status, CreditAccountPaymentResponse response) {
         paymentServiceServer.stubFor(WireMock.post(PAYMENTS_CREDIT_ACCOUNT_CONTEXT_PATH)
             .withHeader(AUTHORIZATION, new EqualToPattern(AUTH_TOKEN))
-            .withHeader(SERVICE_AUTHORIZATION_HEADER, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
             .withRequestBody(equalToJson(convertObjectToJsonString(request)))
             .willReturn(aResponse()
                 .withStatus(status.value())

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrievePbaNumbersITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/RetrievePbaNumbersITest.java
@@ -40,9 +40,9 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESP_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SERVICE_AUTH_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_STATE;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.PBA_NUMBERS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.FEE_PAY_BY_ACCOUNT;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SOLICITOR_HOW_TO_PAY_JSON_KEY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.DynamicList.asDynamicList;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
@@ -133,7 +133,7 @@ public class RetrievePbaNumbersITest extends IdamTestSupport {
     private void stubRetrievePbaNumbersEndpoint(HttpStatus status, PBAOrganisationResponse response) {
         pbaValidationServer.stubFor(WireMock.get(urlEqualTo(RETRIEVE_PBA_NUMBERS_URL))
             .withHeader(AUTHORIZATION, new EqualToPattern(BEARER_AUTH_TOKEN))
-            .withHeader(SERVICE_AUTHORIZATION_HEADER, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern("Bearer " + TEST_SERVICE_AUTH_TOKEN))
             .willReturn(aResponse()
                 .withStatus(status.value())
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/TransformationBulkScanITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/TransformationBulkScanITest.java
@@ -35,12 +35,12 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE_SEPARATION_DAY;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE_SEPARATION_MONTH;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_REASON_FOR_DIVORCE_SEPARATION_YEAR;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.divorce.orchestration.functionaltest.bulk.scan.S2SAuthTokens.ALLOWED_SERVICE_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.functionaltest.bulk.scan.S2SAuthTokens.I_AM_NOT_ALLOWED_SERVICE_TOKEN;
@@ -82,7 +82,7 @@ public class TransformationBulkScanITest {
             post(TRANSFORMATION_URL)
                 .contentType(APPLICATION_JSON)
                 .content(jsonPayload)
-                .header(SERVICE_AUTHORIZATION_HEADER, I_AM_NOT_ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, I_AM_NOT_ALLOWED_SERVICE_TOKEN)
         ).andExpect(status().isForbidden());
     }
 
@@ -92,7 +92,7 @@ public class TransformationBulkScanITest {
             post(TRANSFORMATION_URL)
                 .contentType(APPLICATION_JSON)
                 .content(jsonPayload)
-                .header(SERVICE_AUTHORIZATION_HEADER, "")
+                .header(SERVICE_AUTHORIZATION, "")
         ).andExpect(status().isUnauthorized());
     }
 
@@ -104,7 +104,7 @@ public class TransformationBulkScanITest {
             post(TRANSFORMATION_URL)
                 .contentType(APPLICATION_JSON)
                 .content(jsonPayload)
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         )
             .andExpect(status().isOk())
             .andExpect(content().string(
@@ -229,7 +229,7 @@ public class TransformationBulkScanITest {
             post(TRANSFORMATION_URL)
                 .contentType(APPLICATION_JSON)
                 .content(formToTransform)
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         )
             .andExpect(status().isOk())
             .andExpect(content().string(
@@ -269,7 +269,7 @@ public class TransformationBulkScanITest {
             post(TRANSFORMATION_URL)
                 .contentType(APPLICATION_JSON)
                 .content(jsonToTransform)
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(status().isUnprocessableEntity());
     }
 
@@ -284,7 +284,7 @@ public class TransformationBulkScanITest {
             post(TRANSFORMATION_URL)
                 .contentType(APPLICATION_JSON)
                 .content(formToTransform)
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         )
             .andExpect(status().isUnprocessableEntity())
             .andExpect(content().string(hasErrorWithMessageCopiedFromWarning(warningMsg)));

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/UpdateBulkScanITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/bulk/scan/UpdateBulkScanITest.java
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.ResultMatcher.matchAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.SERVICE_AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.divorce.orchestration.config.SpecificHttpHeaders.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.functionaltest.bulk.scan.S2SAuthTokens.ALLOWED_SERVICE_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.functionaltest.bulk.scan.S2SAuthTokens.I_AM_NOT_ALLOWED_SERVICE_TOKEN;
 import static uk.gov.hmcts.reform.divorce.orchestration.testutil.ResourceLoader.loadResourceAsString;
@@ -86,7 +86,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_2_YEAR_SEP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, I_AM_NOT_ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, I_AM_NOT_ALLOWED_SERVICE_TOKEN)
         ).andExpect(status().isForbidden());
     }
 
@@ -96,7 +96,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_2_YEAR_SEP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, "")
+                .header(SERVICE_AUTHORIZATION, "")
         ).andExpect(status().isUnauthorized());
     }
 
@@ -106,7 +106,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_2_YEAR_SEP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isOk(),
@@ -122,7 +122,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(INVALID_AOS_OFFLINE_2_YEAR_SEP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isUnprocessableEntity(),
@@ -142,7 +142,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_5_YEAR_SEP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isOk(),
@@ -158,7 +158,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(INVALID_AOS_OFFLINE_5_YEAR_SEP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isUnprocessableEntity(),
@@ -179,7 +179,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_BEHAVIOUR_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isOk(),
@@ -195,7 +195,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(INVALID_AOS_OFFLINE_BEHAVIOUR_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(matchAll(
             status().isUnprocessableEntity(),
             content().string(allOf(
@@ -212,7 +212,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_DESERTION_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isOk(),
@@ -228,7 +228,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(INVALID_AOS_OFFLINE_DESERTION_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(matchAll(
             status().isUnprocessableEntity(),
             content().string(allOf(
@@ -245,7 +245,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_ADULTERY_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isOk(),
@@ -261,7 +261,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(INVALID_AOS_OFFLINE_ADULTERY_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(matchAll(
             status().isUnprocessableEntity(),
             content().string(allOf(
@@ -278,7 +278,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(AOS_OFFLINE_ADULTERY_CO_RESP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isOk(),
@@ -294,7 +294,7 @@ public class UpdateBulkScanITest {
             post(UPDATE_URL)
                 .contentType(APPLICATION_JSON)
                 .content(loadResourceAsString(INVALID_AOS_OFFLINE_ADULTERY_CO_RESP_JSON_PATH))
-                .header(SERVICE_AUTHORIZATION_HEADER, ALLOWED_SERVICE_TOKEN)
+                .header(SERVICE_AUTHORIZATION, ALLOWED_SERVICE_TOKEN)
         ).andExpect(
             matchAll(
                 status().isUnprocessableEntity(),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/callback/AosPackIssuedCallbackTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/callback/AosPackIssuedCallbackTest.java
@@ -42,7 +42,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETIT
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RELATIONSHIP;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_WELSH_FEMALE_GENDER_IN_RELATION;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdEvents.ISSUE_AOS_OFFLINE_RESPONDENT_FROM_AOS_AWAITING;
-import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_DIVORCED_WHO;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_EMAIL;
@@ -103,7 +102,7 @@ public class AosPackIssuedCallbackTest extends MockedFunctionalTest {
 
         webClient.perform(post("/aos-pack-issued")
             .contentType(APPLICATION_JSON)
-            .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
+            .header(AUTHORIZATION, AUTH_TOKEN)
             .content(ObjectMapperTestUtil.convertObjectToJsonString(payload))
         ).andExpect(status().isOk());
 


### PR DESCRIPTION
Before I update the headers in `AssignCaseAccessClient` I want to clean up a bit.

Story:
https://tools.hmcts.net/jira/browse/RPET-984

Documentation:
https://tools.hmcts.net/confluence/display/ACA/API+Operation%3A+Assign+Access+within+Organisation