### PR TITLE
DFR-706 - rmv confidential petitioner details from AosOverdueCoverLetter

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/domain/model/OrchestrationConstants.java
@@ -144,6 +144,7 @@ public class OrchestrationConstants {
     public static final String CASE_LIST_FOR_PRONOUNCEMENT_DOCUMENT_TYPE = "caseListForPronouncement";
     public static final String CASE_LIST_FOR_PRONOUNCEMENT_FILE_NAME = "caseListForPronouncement";
     public static final String DN_DECISION_DATE_FIELD = "DNApprovalDate";
+    public static final String D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL = "D8PetitionerContactDetailsConfidential";
 
     // Divorce Session
     public static final String DIVORCE_SESSION_EXISTING_PAYMENTS = "existingPayments";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractor.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getCoRespondentFullName;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getCoRespondentSolicitorFullName;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getPetitionerFullName;
+import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getPetitionerSolicitorFullName;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getRespondentFullName;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.FullNamesDataExtractor.getRespondentSolicitorFullName;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.helper.ExtractorHelper.getMandatoryStringValue;
@@ -26,6 +27,7 @@ public class AddresseeDataExtractor {
         public static final String RESPONDENT_SOLICITOR_ADDRESS = "D8DerivedRespondentSolicitorAddr";
         public static final String CO_RESPONDENT_ADDRESS = "D8DerivedReasonForDivorceAdultery3rdAddr";
         public static final String CO_RESPONDENT_SOLICITOR_ADDRESS = "DerivedCoRespondentSolicitorAddr";
+        public static final String PETITIONER_SOLICITOR_ADDRESS = "DerivedPetitionerSolicitorAddr";
     }
 
     public static Addressee getRespondent(Map<String, Object> caseData) {
@@ -46,6 +48,13 @@ public class AddresseeDataExtractor {
         return Addressee.builder()
             .name(getCoRespondentFullName(caseData))
             .formattedAddress(getCoRespondentFormattedAddress(caseData))
+            .build();
+    }
+
+    public static Addressee getPetitionerSolicitor(Map<String, Object> caseData) {
+        return Addressee.builder()
+            .name(getPetitionerSolicitorFullName(caseData))
+            .formattedAddress(getPetitionerSolicitorFormattedAddress(caseData))
             .build();
     }
 
@@ -76,6 +85,10 @@ public class AddresseeDataExtractor {
 
     private static String getCoRespondentFormattedAddress(Map<String, Object> caseData) {
         return getMandatoryStringValue(caseData, CaseDataKeys.CO_RESPONDENT_ADDRESS);
+    }
+
+    private static String getPetitionerSolicitorFormattedAddress(Map<String, Object> caseData) {
+        return getMandatoryStringValue(caseData, CaseDataKeys.PETITIONER_SOLICITOR_ADDRESS);
     }
 
     private static String getRespondentSolicitorFormattedAddress(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
@@ -20,6 +20,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.AOS_OVERDUE_COVER_LETTER;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor.getPetitioner;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor.getPetitionerSolicitor;
+import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getMandatoryPropertyValueAsString;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getOptionalPropertyValueAsString;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils.formatCaseIdToReferenceNumber;
 
@@ -55,9 +56,9 @@ public class AosOverdueCoverLetterGenerationTask extends BasePayloadSpecificDocu
         return AOS_OVERDUE_COVER_LETTER_DOCUMENT_TYPE;
     }
 
-    private Addressee getAddressee(Map<String, Object> caseData) {
+    public Addressee getAddressee(Map<String, Object> caseData) {
 
-        String confidentialField = getOptionalPropertyValueAsString(caseData, D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, "empty");
+        String confidentialField = getMandatoryPropertyValueAsString(caseData, D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL);
 
         if (confidentialField.equals(KEEP)
             && !PartyRepresentationChecker.isPetitionerRepresented(caseData)) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
@@ -57,7 +57,7 @@ public class AosOverdueCoverLetterGenerationTask extends BasePayloadSpecificDocu
     }
 
     private Addressee getAddressee(Map<String, Object> caseData) {
-        if(getMandatoryPropertyValueAsString(caseData, D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL).equals(KEEP)
+        if (getMandatoryPropertyValueAsString(caseData, D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL).equals(KEEP)
             && !PartyRepresentationChecker.isPetitionerRepresented(caseData)) {
             return Addressee.builder()
                 .name("")
@@ -65,8 +65,8 @@ public class AosOverdueCoverLetterGenerationTask extends BasePayloadSpecificDocu
                 .build();
         }
 
-        return PartyRepresentationChecker.isPetitionerRepresented(caseData) ?
-            getPetitionerSolicitor(caseData) : getPetitioner(caseData);
+        return PartyRepresentationChecker.isPetitionerRepresented(caseData)
+            ? getPetitionerSolicitor(caseData) : getPetitioner(caseData);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
@@ -20,7 +20,6 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.document.template.DocumentType.AOS_OVERDUE_COVER_LETTER;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor.getPetitioner;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractor.getPetitionerSolicitor;
-import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getMandatoryPropertyValueAsString;
 import static uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils.getOptionalPropertyValueAsString;
 import static uk.gov.hmcts.reform.divorce.orchestration.util.CaseDataUtils.formatCaseIdToReferenceNumber;
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTask.java
@@ -57,7 +57,10 @@ public class AosOverdueCoverLetterGenerationTask extends BasePayloadSpecificDocu
     }
 
     private Addressee getAddressee(Map<String, Object> caseData) {
-        if (getMandatoryPropertyValueAsString(caseData, D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL).equals(KEEP)
+
+        String confidentialField = getOptionalPropertyValueAsString(caseData, D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, "empty");
+
+        if (confidentialField.equals(KEEP)
             && !PartyRepresentationChecker.isPetitionerRepresented(caseData)) {
             return Addressee.builder()
                 .name("")

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/TestConstants.java
@@ -117,6 +117,7 @@ public class TestConstants {
     public static final String TEST_CO_RESPONDENT_FIRST_NAME = "Bruce";
     public static final String TEST_CO_RESPONDENT_LAST_NAME = "Wayne";
     public static final String TEST_CO_RESPONDENT_FULL_NAME = TEST_CO_RESPONDENT_FIRST_NAME + " " + TEST_CO_RESPONDENT_LAST_NAME;
+    public static final String TEST_D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL = "keep";
 
     public static final String TEST_RECEIVED_DATE = "2020-05-05";
     public static final String TEST_DECISION_DATE = "2030-10-10";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/TestConstants.java
@@ -117,7 +117,6 @@ public class TestConstants {
     public static final String TEST_CO_RESPONDENT_FIRST_NAME = "Bruce";
     public static final String TEST_CO_RESPONDENT_LAST_NAME = "Wayne";
     public static final String TEST_CO_RESPONDENT_FULL_NAME = TEST_CO_RESPONDENT_FIRST_NAME + " " + TEST_CO_RESPONDENT_LAST_NAME;
-    public static final String TEST_D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL = "keep";
 
     public static final String TEST_RECEIVED_DATE = "2020-05-05";
     public static final String TEST_DECISION_DATE = "2030-10-10";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
@@ -67,8 +67,9 @@ public class AddresseeDataExtractorTest {
     public static final String D8_CASE_REFERENCE = "LV17D80102";
     public static final String CO_RESPONDENT_SOLICITOR_REF = "SolRef1234";
     public static final String VALID_HEARING_DATE = "2020-10-20";
-    public static final String CONFIDENTIAL_KEEP = "keep";
-    public static final String CONFIDENTIAL_SHARE = "share";
+    public static final String CONFIDENTIAL_TRUE = "keep";
+    public static final String CONFIDENTIAL_FALSE = "share";
+
 
     @Test
     public void getRespondentShouldReturnValidValues() {
@@ -176,7 +177,7 @@ public class AddresseeDataExtractorTest {
         Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_CORRESPONDENCE_ADDRESS, PETITIONERS_CORRESPONDENCE_ADDRESS);
-        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_SHARE);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_FALSE);
 
         return caseData;
     }
@@ -185,7 +186,7 @@ public class AddresseeDataExtractorTest {
         Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
-        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_SHARE);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_FALSE);
 
         return caseData;
     }
@@ -194,7 +195,7 @@ public class AddresseeDataExtractorTest {
         Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
-        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_KEEP);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_TRUE);
 
         return caseData;
     }
@@ -203,7 +204,7 @@ public class AddresseeDataExtractorTest {
         Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
-        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_SHARE);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_FALSE);
         caseData.put(PETITIONER_SOLICITOR_NAME, TEST_SOLICITOR_NAME);
         caseData.put(PETITIONER_SOLICITOR_DERIVED_ADDRESS, TEST_SOLICITOR_ADDRESS);
         caseData.put(PETITIONER_SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL);
@@ -215,7 +216,7 @@ public class AddresseeDataExtractorTest {
         Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
-        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_KEEP);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_TRUE);
         caseData.put(PETITIONER_SOLICITOR_NAME, TEST_SOLICITOR_NAME);
         caseData.put(PETITIONER_SOLICITOR_DERIVED_ADDRESS, TEST_SOLICITOR_ADDRESS);
         caseData.put(PETITIONER_SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
@@ -64,6 +64,9 @@ public class AddresseeDataExtractorTest {
     public static final String D8_CASE_REFERENCE = "LV17D80102";
     public static final String CO_RESPONDENT_SOLICITOR_REF = "SolRef1234";
     public static final String VALID_HEARING_DATE = "2020-10-20";
+    public static final String D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL = "D8PetitionerContactDetailsConfidential";
+    public static final String CONFIDENTIAL_KEEP = "keep";
+    public static final String CONFIDENTIAL_SHARE = "share";
 
     @Test
     public void getRespondentShouldReturnValidValues() {
@@ -171,6 +174,7 @@ public class AddresseeDataExtractorTest {
         Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_CORRESPONDENCE_ADDRESS, PETITIONERS_CORRESPONDENCE_ADDRESS);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_SHARE);
 
         return caseData;
     }
@@ -179,6 +183,16 @@ public class AddresseeDataExtractorTest {
         Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_SHARE);
+
+        return caseData;
+    }
+
+    public static Map<String, Object> buildCaseDataWithConfidentialKeepPetitioner() {
+        Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
+        caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
+        caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_KEEP);
 
         return caseData;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
@@ -27,6 +27,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.G
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_IS_USING_DIGITAL_CHANNEL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.CO_RESPONDENT_REPRESENTED;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_DERIVED_REASON_FOR_DIVORCE_ADULTERY_3RD_PARTY_ADDRESS;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D8_RESPONDENT_SOLICITOR_REFERENCE;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.DATETIME_OF_HEARING_CCD_FIELD;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_CASE_REFERENCE;
@@ -66,7 +67,6 @@ public class AddresseeDataExtractorTest {
     public static final String D8_CASE_REFERENCE = "LV17D80102";
     public static final String CO_RESPONDENT_SOLICITOR_REF = "SolRef1234";
     public static final String VALID_HEARING_DATE = "2020-10-20";
-    public static final String D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL = "D8PetitionerContactDetailsConfidential";
     public static final String CONFIDENTIAL_KEEP = "keep";
     public static final String CONFIDENTIAL_SHARE = "share";
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/service/bulk/print/dataextractor/AddresseeDataExtractorTest.java
@@ -18,6 +18,7 @@ import static uk.gov.hmcts.reform.divorce.model.parties.DivorceParty.PETITIONER;
 import static uk.gov.hmcts.reform.divorce.model.parties.DivorceParty.RESPONDENT;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_OTHER_PARTY_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_RESPONDENT_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.CcdFields.GENERAL_EMAIL_OTHER_RECIPIENT_EMAIL;
@@ -32,6 +33,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.D_8_PETITIONER_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.LANGUAGE_PREFERENCE_WELSH;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.NO_VALUE;
+import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITIONER_SOLICITOR_DERIVED_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITIONER_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.PETITIONER_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.OrchestrationConstants.RESPONDENT_SOLICITOR_EMAIL_ADDRESS;
@@ -193,6 +195,30 @@ public class AddresseeDataExtractorTest {
         caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
         caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
         caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_KEEP);
+
+        return caseData;
+    }
+
+    public static Map<String, Object> buildCaseDataWithPetitionerSolicitorNotConfidential() {
+        Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
+        caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
+        caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_SHARE);
+        caseData.put(PETITIONER_SOLICITOR_NAME, TEST_SOLICITOR_NAME);
+        caseData.put(PETITIONER_SOLICITOR_DERIVED_ADDRESS, TEST_SOLICITOR_ADDRESS);
+        caseData.put(PETITIONER_SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL);
+
+        return caseData;
+    }
+
+    public static Map<String, Object> buildCaseDataWithPetitionerSolicitorIsConfidential() {
+        Map<String, Object> caseData = buildCaseDataWithPetitionerNames();
+        caseData.put(GENERAL_EMAIL_PARTIES, PETITIONER.getDescription());
+        caseData.put(PETITIONER_HOME_ADDRESS, PETITIONERS_HOME_ADDRESS);
+        caseData.put(D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL, CONFIDENTIAL_KEEP);
+        caseData.put(PETITIONER_SOLICITOR_NAME, TEST_SOLICITOR_NAME);
+        caseData.put(PETITIONER_SOLICITOR_DERIVED_ADDRESS, TEST_SOLICITOR_ADDRESS);
+        caseData.put(PETITIONER_SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL);
 
         return caseData;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTaskTest.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskCon
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskException;
 import uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest;
 import uk.gov.hmcts.reform.divorce.orchestration.tasks.bulk.printing.BasePayloadSpecificDocumentGenerationTaskTest;
-import uk.gov.hmcts.reform.divorce.orchestration.tasks.util.TaskUtils;
 
 import java.util.Map;
 
@@ -19,8 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FULL_NAME;
-import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.CONFIDENTIAL_KEEP;
-import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.D8_PETITIONER_CONTACT_DETAILS_CONFIDENTIAL;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.PETITIONERS_CORRESPONDENCE_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.PETITIONERS_HOME_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.buildCaseDataWithPetitionerHomeAddressButNoCorrespondenceAddress;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTaskTest.java
@@ -113,7 +113,6 @@ public class AosOverdueCoverLetterGenerationTaskTest extends BasePayloadSpecific
 
     private Map<String, Object> buildCaseDataWithHelpWithFeesWithNoCorrespondenceAddress() {
         Map<String, Object> caseData = buildCaseDataWithPetitionerHomeAddressButNoCorrespondenceAddress();
-
         caseData.put("D8HelpWithFeesReferenceNumber", TEST_HELP_WITH_FEES_NUMBER);
 
         return caseData;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/aos/AosOverdueCoverLetterGenerationTaskTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_PETITIONER_FULL_NAME;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_ADDRESS;
+import static uk.gov.hmcts.reform.divorce.orchestration.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.PETITIONERS_CORRESPONDENCE_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.PETITIONERS_HOME_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.orchestration.service.bulk.print.dataextractor.AddresseeDataExtractorTest.buildCaseDataWithPetitionerHomeAddressButNoCorrespondenceAddress;
@@ -108,11 +110,65 @@ public class AosOverdueCoverLetterGenerationTaskTest extends BasePayloadSpecific
         );
     }
 
+    @Test
+    public void shouldGenerateDocumentWithSolicitorAddressNotConfidential() {
+        Map<String, Object> caseData = buildCaseDataWithHWFAndPetSolNotConfidential();
+
+        Map<String, Object> returnedCaseData = classUnderTest.execute(context, caseData);
+
+        verify(ctscContactDetailsDataProviderService).getCtscContactDetails();
+        final AosOverdueCoverLetter expectedDocmosisTemplateVars = AosOverdueCoverLetter.aosOverdueCoverLetterBuilder()
+            .caseReference(formatCaseIdToReferenceNumber(TEST_CASE_ID))
+            .addressee(classUnderTest.getAddressee(caseData))
+            .ctscContactDetails(CTSC_CONTACT)
+            .helpWithFeesNumber(TEST_HELP_WITH_FEES_NUMBER)
+            .build();
+        assertThat(expectedDocmosisTemplateVars.getAddressee(), is(Addressee.builder()
+            .name(TEST_SOLICITOR_NAME)
+            .formattedAddress(TEST_SOLICITOR_ADDRESS)
+            .build()));
+        runCommonVerifications(caseData,
+            returnedCaseData,
+            "aosOverdueCoverLetter",
+            "FL-DIV-LET-ENG-00537.odt",
+            expectedDocmosisTemplateVars
+        );
+    }
+
+    @Test
+    public void shouldGenerateDocumentWithSolicitorAddressIsConfidentialPetitioner() {
+        Map<String, Object> caseData = buildCaseDataWithHWFAndPetSolIsConfidential();
+
+        Map<String, Object> returnedCaseData = classUnderTest.execute(context, caseData);
+
+        verify(ctscContactDetailsDataProviderService).getCtscContactDetails();
+        final AosOverdueCoverLetter expectedDocmosisTemplateVars = AosOverdueCoverLetter.aosOverdueCoverLetterBuilder()
+            .caseReference(formatCaseIdToReferenceNumber(TEST_CASE_ID))
+            .addressee(classUnderTest.getAddressee(caseData))
+            .ctscContactDetails(CTSC_CONTACT)
+            .helpWithFeesNumber(TEST_HELP_WITH_FEES_NUMBER)
+            .build();
+        assertThat(expectedDocmosisTemplateVars.getAddressee(), is(Addressee.builder()
+            .name(TEST_SOLICITOR_NAME)
+            .formattedAddress(TEST_SOLICITOR_ADDRESS)
+            .build()));
+        runCommonVerifications(caseData,
+            returnedCaseData,
+            "aosOverdueCoverLetter",
+            "FL-DIV-LET-ENG-00537.odt",
+            expectedDocmosisTemplateVars
+        );
+    }
+
     private Map<String, Object> buildCaseDataWithHelpWithFeesWithNoCorrespondenceAddress() {
         Map<String, Object> caseData = buildCaseDataWithPetitionerHomeAddressButNoCorrespondenceAddress();
         caseData.put("D8HelpWithFeesReferenceNumber", TEST_HELP_WITH_FEES_NUMBER);
 
         return caseData;
+    }
+
+    private Map<String, Object> buildCaseDataWithNoHelpWithFeesWithCorrespondenceAddress() {
+        return AddresseeDataExtractorTest.buildCaseDataWithPetitionerCorrespondenceAddressButNoHomeAddress();
     }
 
     private Map<String, Object> buildCaseDataWithHWFAndConfidentialPetitioner() {
@@ -122,8 +178,18 @@ public class AosOverdueCoverLetterGenerationTaskTest extends BasePayloadSpecific
         return caseData;
     }
 
-    private Map<String, Object> buildCaseDataWithNoHelpWithFeesWithCorrespondenceAddress() {
-        return AddresseeDataExtractorTest.buildCaseDataWithPetitionerCorrespondenceAddressButNoHomeAddress();
+    private Map<String, Object> buildCaseDataWithHWFAndPetSolNotConfidential() {
+        Map<String, Object> caseData = AddresseeDataExtractorTest.buildCaseDataWithPetitionerSolicitorNotConfidential();
+        caseData.put("D8HelpWithFeesReferenceNumber", TEST_HELP_WITH_FEES_NUMBER);
+
+        return caseData;
+    }
+
+    private Map<String, Object> buildCaseDataWithHWFAndPetSolIsConfidential() {
+        Map<String, Object> caseData = AddresseeDataExtractorTest.buildCaseDataWithPetitionerSolicitorIsConfidential();
+        caseData.put("D8HelpWithFeesReferenceNumber", TEST_HELP_WITH_FEES_NUMBER);
+
+        return caseData;
     }
 
 }

--- a/src/test/resources/jsonExamples/payloads/genericPetitionerData.json
+++ b/src/test/resources/jsonExamples/payloads/genericPetitionerData.json
@@ -6,7 +6,8 @@
       "D8PetitionerEmail": "petitioner@divorce.co.uk",
       "D8PetitionerFirstName": "Ted",
       "D8PetitionerLastName": "Jones",
-      "D8DerivedPetitionerCorrespondenceAddr": "10 Jones's Close\nLondon"
+      "D8DerivedPetitionerCorrespondenceAddr": "10 Jones's Close\nLondon",
+      "D8PetitionerContactDetailsConfidential": "share"
     }
   }
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fix for issue where confidential petitioner's address details were still appearing on AOS overdue cover letters. Also fixes issue where, if a petitioner had legal representation, their own details were on the cover letter instead of their solicitor's.  

Fixes # (issue)

https://tools.hmcts.net/jira/browse/DFR-706

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests to check that the address to appear on the cover letter matches what is expected, all unit tests passing. 

Manual test in preview, generated aosOverdue documents for confidential petitioner, and petitioner with solicitor scenarios, correct address is now displaying on document

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
