### PR TITLE
Bumping netty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ allprojects {
             }
 
             // solves CVE-2014-3488, CVE-2015-2156, CVE-2019-16869, CVE-2021-21409
-            dependencySet(group: 'io.netty', version: '4.1.71.Final') {
+            dependencySet(group: 'io.netty', version: '4.1.77.Final') {
                 entry 'netty-buffer'
                 entry 'netty-codec'
                 entry 'netty-codec-http'


### PR DESCRIPTION
# Description

Bumping netty to 4.1.77

Fixes netty dependency fail

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
