### PR TITLE
Fix functional tests

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -3,7 +3,7 @@
 properties([
         pipelineTriggers([cron('15 01 * * *')]),
         parameters([
-                string(name: 'URL_TO_TEST', defaultValue: 'http://div-cos-aat.service.core-compute-aat.internal', description: 'The URL you want to run these tests against')
+                string(name: 'URL_TO_TEST', defaultValue: 'https://div-cos-aat.service.core-compute-aat.internal', description: 'The URL you want to run these tests against')
         ])
 ])
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -80,4 +80,9 @@
       <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
       <cve>CVE-2022-34305</cve>
     </suppress>
-</suppressions>    
+    <suppress>
+        <notes><![CDATA[file name: postgresql-42.2.25.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
+        <cve>CVE-2022-31197</cve>
+    </suppress>
+</suppressions>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.context;
 
+import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.runners.SerenityRunner;
@@ -78,6 +79,7 @@ public abstract class IntegrationTest {
 
     @PostConstruct
     public void init() {
+        RestAssured.useRelaxedHTTPSValidation();
         if (!Strings.isNullOrEmpty(httpProxy)) {
             try {
                 URL proxy = new URL(httpProxy);

--- a/src/integrationTest/resources/application-aat.properties
+++ b/src/integrationTest/resources/application-aat.properties
@@ -1,6 +1,6 @@
 # Add any test specific environment variables here
 idam.client.redirectUri=https://div-pfe-aat.service.core-compute-aat.internal/authenticated
-core_case_data.api.url=https://ccd-data-store-api-aat.service.core-compute-aat.internal
+core_case_data.api.url=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
 # Hardcoded for Kubernetes7
 idam.client.baseUrl=https://idam-api.aat.platform.hmcts.net

--- a/src/integrationTest/resources/application-aat.properties
+++ b/src/integrationTest/resources/application-aat.properties
@@ -1,8 +1,8 @@
 # Add any test specific environment variables here
 idam.client.redirectUri=https://div-pfe-aat.service.core-compute-aat.internal/authenticated
-core_case_data.api.url=http://ccd-data-store-api-aat.service.core-compute-aat.internal
+core_case_data.api.url=https://ccd-data-store-api-aat.service.core-compute-aat.internal
 
 # Hardcoded for Kubernetes7
 idam.client.baseUrl=https://idam-api.aat.platform.hmcts.net
 idam.s2s-auth.url=http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
-case_maintenance.api.url=http://div-cms-aat.service.core-compute-aat.internal
+case_maintenance.api.url=https://div-cms-aat.service.core-compute-aat.internal

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -32,7 +32,7 @@ auth.provider.payment-update.microservice=payment_app
 ###############################################
 #  Routes                                     #
 ###############################################
-case.orchestration.service.base.uri=#{environment["TEST_URL"].replaceFirst("https://", "http://")}
+case.orchestration.service.base.uri=#{environment["TEST_URL"]}
 case.orchestration.petition-issued.context-path=/petition-issued
 case.orchestration.maintenance.submit.context-path=/submit
 case.orchestration.maintenance.update.context-path=/updateCase

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -8,7 +8,7 @@ logging.level.uk.gov.hmcts.reform.divorce:DEBUG
 #  Setup                                      #
 ###############################################
 env=${test_environment:local}
-TEST_URL=https://localhost:4012
+TEST_URL=http://localhost:4012
 ###############################################
 #  IDAM Auth                                  #
 ###############################################

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -8,7 +8,7 @@ logging.level.uk.gov.hmcts.reform.divorce:DEBUG
 #  Setup                                      #
 ###############################################
 env=${test_environment:local}
-TEST_URL=http://localhost:4012
+TEST_URL=https://localhost:4012
 ###############################################
 #  IDAM Auth                                  #
 ###############################################


### PR DESCRIPTION
Fix functional test because of cluster switch.

Some key points to note regarding Preview changes:
1. service.core-compute-preview.internal like it has always been the case, and preview has always used HTTPS. Traefik V2 is more strict than V1 and only allows either HTTP or HTTPS, this is why HTTPS is now being forced in URLs.
2. All AAT URLs accessed from preview should still be used with http.
3. AAT-Staging URLs, used only with jenkins builds, will all be https.
4. All internal communication from service to service with in preview cluster should be done using svc URLs, see [CCD product chart](https://github.com/hmcts/chart-ccd/blob/master/ccd/values.yaml#L48-L56) for example.
4. Ingress should be needed only for URLs which are accessed by tests(Jenkins) /QA from browser.
6. SSL validation need to be disabled only on tests, no application code should do that.
7. Further comms regarding Preview Ingress (https) - https://hmcts-reform.slack.com/archives/CA4F2MAFR/p1659959158752859
Additional regarding the upgrade to traefik v2
As you are aware, we had to upgrade traefik v2 along with AKS as the current versions are not supported by Azure and we are running under a major risk of DR.